### PR TITLE
Allow to disable cookies secure flag when needed

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -606,7 +606,8 @@ func initAuth(o *oidc.Manager, rd *redis.Client) *auth_.Auth {
 		log.Fatalf("error initializing auth: %v", err)
 	}
 
-	auth, err := auth_.New(auth_.Config{Providers: providers}, rd, lo)
+	secure := !ko.Bool("app.server.disable_secure_cookies")
+	auth, err := auth_.New(auth_.Config{Providers: providers, SecureCookies: secure}, rd, lo)
 	if err != nil {
 		log.Fatalf("error initializing auth: %v", err)
 	}

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -8,6 +8,9 @@ check_updates = true
 [app.server]
 address = "0.0.0.0:9000"
 socket = ""
+# Do NOT disable secure cookies in production environment if you don't know
+# exactly what you're doing!
+disable_secure_cookies = false
 read_timeout = "5s"
 write_timeout = "5s"
 max_body_size = 500000000

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -46,7 +46,8 @@ type Provider struct {
 
 // Config stores multiple OIDC provider configurations
 type Config struct {
-	Providers []Provider
+	Providers     []Provider
+	SecureCookies bool
 }
 
 // Auth is the auth service it manages OIDC authentication and sessions
@@ -92,7 +93,7 @@ func New(cfg Config, rd *redis.Client, logger *logf.Logger) (*Auth, error) {
 		Cookie: simplesessions.CookieOptions{
 			Name:       "libredesk_session",
 			IsHTTPOnly: true,
-			IsSecure:   true,
+			IsSecure:   cfg.SecureCookies,
 			MaxAge:     time.Hour * 9,
 		},
 	})
@@ -282,7 +283,7 @@ func (a *Auth) SetCSRFCookie(r *fastglue.Request) error {
 		csrfCookie.SetKey("csrf_token")
 		csrfCookie.SetValue(token)
 		csrfCookie.SetPath("/")
-		csrfCookie.SetSecure(true)
+		csrfCookie.SetSecure(a.cfg.SecureCookies)
 		csrfCookie.SetHTTPOnly(false)
 		r.RequestCtx.Response.Header.SetCookie(&csrfCookie)
 		return nil

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -44,7 +44,7 @@ type Provider struct {
 	ClientSecret string
 }
 
-// Config stores multiple OIDC provider configurations
+// Config holds OIDC providers and cookies security settings
 type Config struct {
 	Providers     []Provider
 	SecureCookies bool


### PR DESCRIPTION
When Libredesk is accessed through non-HTTPS connections (typically on development environments), both CSRF and session cookies are still sent with a `Secure` flag, which means they're ignored by the browser, resulting in `Invalid CSRF token`and `Invalid or expired session` errors in the app.

This PR add an new `disable_secure_cookies` option which allow to disable the secure flag being set on both CSRF an session cookies when enabled.

Please note that:
 - I’m not a Go specialist and Libredesk auth code is a bit complex, so maybe there’s a better way to do that than using Auth.cfg?
 - I haven’t modified `simpleSessGetCookieCB()` and `simpleSessSetCookieCB()` as I don’t think this is necessary? 

Fixes #13.