### PR TITLE
Fix and Improve Email Recipients Handling in Conversations

### DIFF
--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -707,8 +707,8 @@ func handleCreateConversation(r *fastglue.Request) error {
 	}
 
 	// Send reply to the created conversation.
-	if err := app.conversation.SendReply(nil /**media**/, inboxID, auser.ID, conversationUUID, content, to, nil /**cc**/, nil /**bcc**/, map[string]any{} /**meta**/); err != nil {
-		// Delete the conversation if sending the reply fails.
+	if err := app.conversation.SendReply(nil /**media**/, inboxID, auser.ID /**sender_id**/, conversationUUID, content, to, nil /**cc**/, nil /**bcc**/, map[string]any{} /**meta**/); err != nil {
+		// Delete the conversation if reply fails.
 		if err := app.conversation.DeleteConversation(conversationUUID); err != nil {
 			app.lo.Error("error deleting conversation", "error", err)
 		}

--- a/frontend/src/assets/styles/main.scss
+++ b/frontend/src/assets/styles/main.scss
@@ -183,15 +183,7 @@
 }
 
 .message-bubble {
-  @apply flex
-  flex-col
-  px-4
-  pt-2
-  pb-3
-  min-w-[30%] max-w-[70%]
-  border
-  overflow-x-auto
-  rounded-xl;
+  @apply flex flex-col px-4 pt-2 pb-3 w-fit min-w-[30%] max-w-full border overflow-x-auto rounded-xl;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   table {
     width: 100% !important;

--- a/frontend/src/features/admin/notification/NotificationSettingForm.vue
+++ b/frontend/src/features/admin/notification/NotificationSettingForm.vue
@@ -97,6 +97,18 @@
       </FormItem>
     </FormField>
 
+    <!-- Max Message Retries Field -->
+    <FormField v-slot="{ componentField }" name="max_msg_retries">
+      <FormItem>
+        <FormLabel>{{ $t('admin.inbox.maxRetries') }}</FormLabel>
+        <FormControl>
+          <Input type="number" placeholder="3" v-bind="componentField" />
+        </FormControl>
+        <FormMessage />
+        <FormDescription> {{ $t('admin.inbox.maxRetries.description') }} </FormDescription>
+      </FormItem>
+    </FormField>
+
     <!-- Authentication Protocol Field -->
     <FormField v-slot="{ componentField }" name="auth_protocol">
       <FormItem>
@@ -133,18 +145,6 @@
         </FormControl>
         <FormMessage />
         <FormDescription> {{ $t('admin.inbox.fromEmailAddress.description') }}</FormDescription>
-      </FormItem>
-    </FormField>
-
-    <!-- Max Message Retries Field -->
-    <FormField v-slot="{ componentField }" name="max_msg_retries">
-      <FormItem>
-        <FormLabel>{{ $t('admin.inbox.maxRetries') }}</FormLabel>
-        <FormControl>
-          <Input type="number" placeholder="3" v-bind="componentField" />
-        </FormControl>
-        <FormMessage />
-        <FormDescription> {{ $t('admin.inbox.maxRetries.description') }} </FormDescription>
       </FormItem>
     </FormField>
 

--- a/frontend/src/features/conversation/ReplyBoxContent.vue
+++ b/frontend/src/features/conversation/ReplyBoxContent.vue
@@ -259,7 +259,6 @@ const enableSend = computed(() => {
  * @param {string} field - 'to', 'cc', or 'bcc'
  */
 const validateEmails = (field) => {
-  console.log('Validating emails for field:', field)
   const emails = field === 'to' ? to.value : field === 'cc' ? cc.value : bcc.value
   const emailList = emails
     .split(',')
@@ -267,8 +266,6 @@ const validateEmails = (field) => {
     .filter((e) => e !== '')
 
   const invalidEmails = emailList.filter((email) => !validateEmail(email))
-
-  console.log('Invalid emails:', invalidEmails)
 
   // Clear existing errors
   emailErrors.value = []

--- a/frontend/src/features/conversation/ReplyBoxContent.vue
+++ b/frontend/src/features/conversation/ReplyBoxContent.vue
@@ -37,11 +37,21 @@
       </span>
     </div>
 
-    <!-- CC and BCC fields -->
+    <!-- To, CC, and BCC fields -->
     <div
       :class="['space-y-3', isFullscreen ? 'p-4 border-b border-border' : 'mb-4']"
       v-if="messageType === 'reply'"
     >
+      <div class="flex items-center space-x-2">
+        <label class="w-12 text-sm font-medium text-muted-foreground">To:</label>
+        <Input
+          type="text"
+          :placeholder="t('replyBox.emailAddresess')"
+          v-model="to"
+          class="flex-grow px-3 py-2 text-sm border rounded-md focus:ring-2 focus:ring-ring"
+          @blur="validateEmails('to')"
+        />
+      </div>
       <div class="flex items-center space-x-2">
         <label class="w-12 text-sm font-medium text-muted-foreground">CC:</label>
         <Input
@@ -71,7 +81,7 @@
       </div>
     </div>
 
-    <!-- CC and BCC field validation errors -->
+    <!-- email errors -->
     <div
       v-if="emailErrors.length > 0"
       class="mb-4 px-2 py-1 bg-destructive/10 border border-destructive text-destructive rounded"
@@ -148,9 +158,11 @@ import AttachmentsPreview from '@/features/conversation/message/attachment/Attac
 import MacroActionsPreview from '@/features/conversation/MacroActionsPreview.vue'
 import ReplyBoxMenuBar from '@/features/conversation/ReplyBoxMenuBar.vue'
 import { useI18n } from 'vue-i18n'
+import { validateEmail } from '@/utils/strings'
 
 // Define models for two-way binding
 const messageType = defineModel('messageType', { default: 'reply' })
+const to = defineModel('to', { default: '' })
 const cc = defineModel('cc', { default: '' })
 const bcc = defineModel('bcc', { default: '' })
 const showBcc = defineModel('showBcc', { default: false })
@@ -243,28 +255,30 @@ const enableSend = computed(() => {
 })
 
 /**
- * Validate email addresses in the CC and BCC fields
- * @param {string} field - 'cc' or 'bcc'
+ * Validate email addresses in the To, CC, and BCC fields
+ * @param {string} field - 'to', 'cc', or 'bcc'
  */
 const validateEmails = (field) => {
-  const emails = field === 'cc' ? cc.value : bcc.value
+  console.log('Validating emails for field:', field)
+  const emails = field === 'to' ? to.value : field === 'cc' ? cc.value : bcc.value
   const emailList = emails
     .split(',')
     .map((e) => e.trim())
     .filter((e) => e !== '')
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-  const invalidEmails = emailList.filter((email) => !emailRegex.test(email))
 
-  // Remove any existing errors for this field
-  emailErrors.value = emailErrors.value.filter(
-    (error) => !error.startsWith(`${t('replyBox.invalidEmailsIn')} ${field.toUpperCase()}`)
-  )
+  const invalidEmails = emailList.filter((email) => !validateEmail(email))
+
+  console.log('Invalid emails:', invalidEmails)
+
+  // Clear existing errors
+  emailErrors.value = []
 
   // Add new error if there are invalid emails
   if (invalidEmails.length > 0) {
-    emailErrors.value.push(
-      `${t('replyBox.invalidEmailsIn')} ${field.toUpperCase()}: ${invalidEmails.join(', ')}`
-    )
+    emailErrors.value = [
+      ...emailErrors.value,
+      `${t('replyBox.invalidEmailsIn')} '${field}': ${invalidEmails.join(', ')}`
+    ]
   }
 }
 
@@ -272,6 +286,7 @@ const validateEmails = (field) => {
  * Send the reply or private note
  */
 const handleSend = async () => {
+  validateEmails('to')
   validateEmails('cc')
   validateEmails('bcc')
   if (emailErrors.value.length > 0) {

--- a/frontend/src/features/conversation/message/AgentMessageBubble.vue
+++ b/frontend/src/features/conversation/message/AgentMessageBubble.vue
@@ -21,9 +21,9 @@
           }"
         >
           <!-- Message Envelope -->
-          <MessageEnvelope :message="message" />
+          <MessageEnvelope :message="message" v-if="showEnvelope" />
 
-          <hr class="mb-2" />
+          <hr class="mb-2" v-if="showEnvelope" />
 
           <!-- Message -->
           <div
@@ -137,6 +137,16 @@ const avatarFallback = computed(() => {
 const retryMessage = (msg) => {
   api.retryMessage(convStore.current.uuid, msg.uuid)
 }
+
+const showEnvelope = computed(() => {
+  return (
+    props.message.meta?.from?.length ||
+    props.message.meta?.to?.length ||
+    props.message.meta?.cc?.length ||
+    props.message.meta?.bcc?.length ||
+    props.message.meta?.subject
+  )
+})
 </script>
 
 <style scoped>

--- a/frontend/src/features/conversation/message/AgentMessageBubble.vue
+++ b/frontend/src/features/conversation/message/AgentMessageBubble.vue
@@ -9,38 +9,46 @@
 
     <!-- Message Bubble -->
     <div class="flex flex-row gap-2 justify-end">
-      <div
-        class="flex flex-col message-bubble justify-end items-end relative rounded-lg p-3 max-w-[80%]"
-        :class="{
-          '!bg-[#FEF1E1]': message.private,
-          'bg-white border border-border': !message.private,
-          'opacity-50 animate-pulse': message.status === 'pending',
-          'bg-red-50 border-red-200': message.status === 'failed'
-        }"
-      >
-        <!-- Message Content -->
+      <!-- Bubble Wrapper with max 80% width -->
+      <div class="w-4/5 flex justify-end">
         <div
-          v-dompurify-html="messageContent"
-          class="whitespace-pre-wrap break-words overflow-wrap-anywhere native-html" 
-          :class="{ 'mb-3': message.attachments.length > 0 }"
-        />
+          class="flex flex-col justify-end message-bubble relative"
+          :class="{
+            '!bg-[#FEF1E1]': message.private,
+            'bg-white border border-border': !message.private,
+            'opacity-50 animate-pulse': message.status === 'pending',
+            'bg-red-50 border-red-200': message.status === 'failed'
+          }"
+        >
+          <!-- Message Envelope -->
+          <MessageEnvelope :message="message" />
 
-        <!-- Attachments -->
-        <MessageAttachmentPreview :attachments="nonInlineAttachments" />
+          <hr class="mb-2" />
 
-        <!-- Spinner for Pending Messages -->
-        <Spinner v-if="message.status === 'pending'" size="w-4 h-4" />
-
-        <!-- Icons -->
-        <div class="flex items-center space-x-2 mt-2">
-          <Lock :size="10" v-if="isPrivateMessage" class="text-muted-foreground" />
-          <Check :size="14" v-if="showCheckCheck" class="text-green-500" />
-          <RotateCcw
-            size="10"
-            @click="retryMessage(message)"
-            class="cursor-pointer text-muted-foreground hover:text-foreground transition-colors duration-200"
-            v-if="showRetry"
+          <!-- Message -->
+          <div
+            v-dompurify-html="messageContent"
+            class="whitespace-pre-wrap break-words overflow-wrap-anywhere native-html"
+            :class="{ 'mb-3': message.attachments.length > 0 }"
           />
+
+          <!-- Attachments -->
+          <MessageAttachmentPreview :attachments="nonInlineAttachments" />
+
+          <!-- Spinner for Pending Messages -->
+          <Spinner v-if="message.status === 'pending'" size="w-4 h-4" />
+
+          <!-- Icons -->
+          <div class="flex items-center space-x-2 mt-2 self-end">
+            <Lock :size="10" v-if="isPrivateMessage" class="text-muted-foreground" />
+            <Check :size="14" v-if="showCheckCheck" class="text-green-500" />
+            <RotateCcw
+              size="10"
+              @click="retryMessage(message)"
+              class="cursor-pointer text-muted-foreground hover:text-foreground transition-colors duration-200"
+              v-if="showRetry"
+            />
+          </div>
         </div>
       </div>
 
@@ -53,7 +61,7 @@
       </Avatar>
     </div>
 
-    <!-- Timestamp -->
+    <!-- Timestamp tooltip -->
     <div class="pr-[47px]">
       <Tooltip>
         <TooltipTrigger>
@@ -79,6 +87,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Spinner } from '@/components/ui/spinner'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import MessageAttachmentPreview from '@/features/conversation/message/attachment/MessageAttachmentPreview.vue'
+import MessageEnvelope from './MessageEnvelope.vue'
 import api from '@/api'
 
 const props = defineProps({

--- a/frontend/src/features/conversation/message/ContactMessageBubble.vue
+++ b/frontend/src/features/conversation/message/ContactMessageBubble.vue
@@ -8,7 +8,7 @@
     </div>
 
     <!-- Message Bubble -->
-    <div class="flex flex-row gap-2">
+    <div class="flex flex-row gap-2 w-full">
       <!-- Avatar -->
       <Avatar class="cursor-pointer w-8 h-8">
         <AvatarImage :src="getAvatar" />
@@ -18,32 +18,40 @@
       </Avatar>
 
       <!-- Message Content -->
-      <div
-        class="flex flex-col justify-end message-bubble bg-white border border-border rounded-lg p-3 max-w-[80%]"
-        :class="{
-          'show-quoted-text': showQuotedText,
-          'hide-quoted-text': !showQuotedText
-        }"
-      >
-        <!-- Message Text -->
-        <Letter
-          :html="sanitizedMessageContent"
-          :allowedSchemas="['cid', 'https', 'http', 'mailto']"
-          class="mb-1 native-html"
-          :class="{ 'mb-3': message.attachments.length > 0 }"
-        />
-
-        <!-- Quoted Text Toggle -->
+      <div class="w-4/5">
         <div
-          v-if="hasQuotedContent"
-          @click="toggleQuote"
-          class="text-xs cursor-pointer text-muted-foreground px-2 py-1 w-max hover:bg-muted hover:text-primary rounded-md transition-all"
+          class="flex flex-col justify-end message-bubble"
+          :class="{
+            'show-quoted-text': showQuotedText,
+            'hide-quoted-text': !showQuotedText
+          }"
         >
-          {{ showQuotedText ? t('conversation.hideQuotedText') : t('conversation.showQuotedText') }}
-        </div>
+          <MessageEnvelope :message="message" />
 
-        <!-- Attachments -->
-        <MessageAttachmentPreview :attachments="nonInlineAttachments" />
+          <hr class="mb-2" />
+
+          <!-- Message Text -->
+          <Letter
+            :html="sanitizedMessageContent"
+            :allowedSchemas="['cid', 'https', 'http', 'mailto']"
+            class="mb-1 native-html"
+            :class="{ 'mb-3': message.attachments.length > 0 }"
+          />
+
+          <!-- Quoted Text Toggle -->
+          <div
+            v-if="hasQuotedContent"
+            @click="toggleQuote"
+            class="text-xs cursor-pointer text-muted-foreground px-2 py-1 w-max hover:bg-muted hover:text-primary rounded-md transition-all"
+          >
+            {{
+              showQuotedText ? t('conversation.hideQuotedText') : t('conversation.showQuotedText')
+            }}
+          </div>
+
+          <!-- Attachments -->
+          <MessageAttachmentPreview :attachments="nonInlineAttachments" />
+        </div>
       </div>
     </div>
 
@@ -75,6 +83,7 @@ import { Letter } from 'vue-letter'
 import { useAppSettingsStore } from '@/stores/appSettings'
 import { useI18n } from 'vue-i18n'
 import MessageAttachmentPreview from '@/features/conversation/message/attachment/MessageAttachmentPreview.vue'
+import MessageEnvelope from './MessageEnvelope.vue'
 
 const props = defineProps({
   message: Object

--- a/frontend/src/features/conversation/message/ContactMessageBubble.vue
+++ b/frontend/src/features/conversation/message/ContactMessageBubble.vue
@@ -26,9 +26,9 @@
             'hide-quoted-text': !showQuotedText
           }"
         >
-          <MessageEnvelope :message="message" />
+          <MessageEnvelope :message="message" v-if="showEnvelope" />
 
-          <hr class="mb-2" />
+          <hr class="mb-2" v-if="showEnvelope" />
 
           <!-- Message Text -->
           <Letter
@@ -131,5 +131,15 @@ const getFullName = computed(() => {
 const avatarFallback = computed(() => {
   const contact = convStore.current?.contact || {}
   return (contact.first_name || '').toUpperCase().substring(0, 2)
+})
+
+const showEnvelope = computed(() => {
+  return (
+    props.message.meta?.from?.length ||
+    props.message.meta?.to?.length ||
+    props.message.meta?.cc?.length ||
+    props.message.meta?.bcc?.length ||
+    props.message.meta?.subject
+  )
 })
 </script>

--- a/frontend/src/features/conversation/message/MessageEnvelope.vue
+++ b/frontend/src/features/conversation/message/MessageEnvelope.vue
@@ -1,0 +1,37 @@
+<template>
+  <div
+    class="mb-1 space-y-0.5 text-xs text-muted-foreground"
+    v-if="
+      message.meta.from?.length ||
+      message.meta.to?.length ||
+      message.meta.cc?.length ||
+      message.meta.bcc?.length ||
+      message.meta.subject
+    "
+  >
+    <p v-if="message.meta.from?.length">
+      <span class="font-medium text-foreground">From:</span> {{ message.meta.from.join(', ') }}
+    </p>
+    <p v-if="message.meta.to?.length">
+      <span class="font-medium text-foreground">To:</span> {{ message.meta.to.join(', ') }}
+    </p>
+    <p v-if="message.meta.cc?.length">
+      <span class="font-medium text-foreground">CC:</span> {{ message.meta.cc.join(', ') }}
+    </p>
+    <p v-if="message.meta.bcc?.length">
+      <span class="font-medium text-foreground">BCC:</span> {{ message.meta.bcc.join(', ') }}
+    </p>
+    <p v-if="message.meta.subject">
+      <span class="font-medium text-foreground">Subject:</span> {{ message.meta.subject }}
+    </p>
+  </div>
+</template>
+
+<script setup>
+defineProps({
+  message: {
+    type: Object,
+    required: true
+  }
+})
+</script>

--- a/frontend/src/features/conversation/message/MessageEnvelope.vue
+++ b/frontend/src/features/conversation/message/MessageEnvelope.vue
@@ -1,14 +1,5 @@
 <template>
-  <div
-    class="mb-1 space-y-0.5 text-xs text-muted-foreground"
-    v-if="
-      message.meta.from?.length ||
-      message.meta.to?.length ||
-      message.meta.cc?.length ||
-      message.meta.bcc?.length ||
-      message.meta.subject
-    "
-  >
+  <div class="mb-1 space-y-0.5 text-xs text-muted-foreground">
     <p v-if="message.meta.from?.length">
       <span class="font-medium text-foreground">From:</span> {{ message.meta.from.join(', ') }}
     </p>

--- a/frontend/src/features/conversation/sidebar/ConversationInfo.vue
+++ b/frontend/src/features/conversation/sidebar/ConversationInfo.vue
@@ -1,10 +1,14 @@
 <template>
   <div class="space-y-4">
-    <div class="flex flex-col">
+    <!-- Hide subject for email channel as each message shows the envelope -->
+    <div
+      class="flex flex-col"
+      v-if="conversation.subject && conversation.inbox_channel !== 'email'"
+    >
       <p class="font-medium">{{ $t('form.field.subject') }}</p>
       <Skeleton v-if="conversationStore.conversation.loading" class="w-32 h-4" />
       <p v-else>
-        {{ conversation.subject || '-' }}
+        {{ conversation.subject }}
       </p>
     </div>
 

--- a/frontend/src/features/conversation/sidebar/CustomAttributes.vue
+++ b/frontend/src/features/conversation/sidebar/CustomAttributes.vue
@@ -180,7 +180,6 @@ const getValidationSchema = (attribute) => {
       // If regex is provided and valid, add it to the schema validation along with the hint
       if (attribute.regex) {
         try {
-          console.log('Creating regex:', attribute.regex)
           const regex = new RegExp(attribute.regex)
           schema = schema.regex(regex, {
             message: attribute.regex_hint

--- a/frontend/src/stores/conversation.js
+++ b/frontend/src/stores/conversation.js
@@ -262,12 +262,11 @@ export const useConversationStore = defineStore('conversation', () => {
     if (!conv || !msgData || !inboxEmail) return
 
     const latestMessage = msgData.getLatestMessage(conv.uuid, ['incoming', 'outgoing'], true)
+    if (!latestMessage) return
 
     if (!["received", "sent"].includes(latestMessage.status)) {
       return
     }
-
-    if (!latestMessage) return
 
     const { to, cc, bcc } = computeRecipientsFromMessage(
       latestMessage,

--- a/frontend/src/utils/conversation-message-cache.js
+++ b/frontend/src/utils/conversation-message-cache.js
@@ -1,7 +1,7 @@
 export default class MessageCache {
     /**
-     * Cache for conversation messages with LRU eviction
-     * @param {number} maxConvs - Max conversations to store
+     * Cache for conversation messages with eviction of old conversations
+     * @param {number} maxConvs - Max conversations to store before eviction
      */
     constructor(maxConvs = 100) {
         this.cache = new Map()
@@ -80,18 +80,23 @@ export default class MessageCache {
     getLatestMessage (convId, type = [], excludePrivate = false) {
         const conv = this.cache.get(convId)
         if (!conv) return null
+
+        // Get all messages from all pages
         let allMessages = Array.from(conv.pages.values()).flat()
-        // If type is provided, filter messages by type
+
+        // Apply filters
         if (type.length > 0) {
             allMessages = allMessages.filter(msg => type.includes(msg.type))
         }
-        // If excludePrivate is true, filter out private messages
         if (excludePrivate) {
             allMessages = allMessages.filter(msg => !msg.private)
         }
+
+        // Sort messages by created_at in descending order (newest first)
+        allMessages.sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+
         return allMessages.length ? allMessages[0] : null
     }
-
     /**
      * Updates message fields by applying update object
      */

--- a/frontend/src/utils/conversation-message-cache.js
+++ b/frontend/src/utils/conversation-message-cache.js
@@ -70,6 +70,29 @@ export default class MessageCache {
     }
 
     /**
+     * Returns latest message for a conversation
+     * @param {string} convId - Conversation ID
+     * @param {string[]} type - Array of message types to filter - outgoing, incoming, etc.
+     * @param {boolean} excludePrivate - Exclude private messages
+     * 
+     * @returns {object} - Latest message object or null if not found
+     */
+    getLatestMessage (convId, type = [], excludePrivate = false) {
+        const conv = this.cache.get(convId)
+        if (!conv) return null
+        let allMessages = Array.from(conv.pages.values()).flat()
+        // If type is provided, filter messages by type
+        if (type.length > 0) {
+            allMessages = allMessages.filter(msg => type.includes(msg.type))
+        }
+        // If excludePrivate is true, filter out private messages
+        if (excludePrivate) {
+            allMessages = allMessages.filter(msg => !msg.private)
+        }
+        return allMessages.length ? allMessages[0] : null
+    }
+
+    /**
      * Updates message fields by applying update object
      */
     updateMessage (convId, msgId, updates) {

--- a/frontend/src/utils/email-recipients.js
+++ b/frontend/src/utils/email-recipients.js
@@ -1,0 +1,44 @@
+export function computeRecipientsFromMessage (message, contactEmail, inboxEmail) {
+    const meta = message?.meta || {}
+    const isIncoming = message.type === 'incoming'
+
+    // Build TO field
+    const toList = isIncoming
+        ? meta.from || []
+        : meta.to && meta.to.length
+            ? meta.to
+            : contactEmail
+                ? [contactEmail]
+                : []
+
+    // Build CC field
+    let ccList = meta.cc || []
+
+    if (isIncoming) {
+        // Include original 'to' recipients in CC to preserve full thread context (e.g. other participants)
+        if (Array.isArray(meta.to))
+            ccList = ccList.concat(meta.to)
+
+        // If someone else replies (not the original contact), re-add original contact to CC to keep them in the loop.
+        if (
+            contactEmail &&
+            !toList.includes(contactEmail) &&
+            !ccList.includes(contactEmail)
+        ) {
+            ccList.push(contactEmail)
+        }
+    }
+
+    // BCC field
+    let bccList = meta.bcc || []
+
+    // Dedup + remove inbox email
+    const clean = list =>
+        Array.from(new Set(list.filter(email => email && email !== inboxEmail)))
+
+    return {
+        to: clean(toList),
+        cc: clean(ccList),
+        bcc: clean(bccList)
+    }
+}

--- a/frontend/src/utils/email-recipients.js
+++ b/frontend/src/utils/email-recipients.js
@@ -33,9 +33,6 @@ export function computeRecipientsFromMessage (message, contactEmail, inboxEmail)
         }
     }
 
-    // BCC field
-    let bccList = meta.bcc || []
-
     // Dedup + remove inbox email
     const clean = list =>
         Array.from(new Set(list.filter(email => email && email !== inboxEmail)))
@@ -43,6 +40,7 @@ export function computeRecipientsFromMessage (message, contactEmail, inboxEmail)
     return {
         to: clean(toList),
         cc: clean(ccList),
-        bcc: clean(bccList)
+        // BCC stays empty user is supposed to add it manually.
+        bcc: [],
     }
 }

--- a/frontend/src/utils/email-recipients.js
+++ b/frontend/src/utils/email-recipients.js
@@ -4,7 +4,11 @@ export function computeRecipientsFromMessage (message, contactEmail, inboxEmail)
 
     // Build TO field
     const toList = isIncoming
-        ? meta.from || []
+        ? meta.from && meta.from.length
+            ? meta.from
+            : contactEmail
+                ? [contactEmail]
+                : []
         : meta.to && meta.to.length
             ? meta.to
             : contactEmail

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -185,7 +185,6 @@ func New(
 
 type queries struct {
 	// Conversation queries.
-	GetToAddress                       *sqlx.Stmt `query:"get-to-address"`
 	GetConversationUUID                *sqlx.Stmt `query:"get-conversation-uuid"`
 	GetConversation                    *sqlx.Stmt `query:"get-conversation"`
 	GetConversationsCreatedAfter       *sqlx.Stmt `query:"get-conversations-created-after"`
@@ -745,16 +744,6 @@ func (c *Manager) SetConversationTags(uuid string, action string, tagNames []str
 	}
 
 	return nil
-}
-
-// GetToAddress retrieves the recipient addresses for a conversation and channel.
-func (m *Manager) GetToAddress(conversationID int) ([]string, error) {
-	var addr []string
-	if err := m.q.GetToAddress.Select(&addr, conversationID); err != nil {
-		m.lo.Error("error fetching `to` address for message", "error", err, "conversation_id", conversationID)
-		return addr, err
-	}
-	return addr, nil
 }
 
 // GetMessageSourceIDs retrieves source IDs for messages in a conversation in descending order.

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -28,6 +28,7 @@ import (
 	mmodels "github.com/abhinavxd/libredesk/internal/media/models"
 	notifier "github.com/abhinavxd/libredesk/internal/notification"
 	slaModels "github.com/abhinavxd/libredesk/internal/sla/models"
+	"github.com/abhinavxd/libredesk/internal/stringutil"
 	tmodels "github.com/abhinavxd/libredesk/internal/team/models"
 	"github.com/abhinavxd/libredesk/internal/template"
 	umodels "github.com/abhinavxd/libredesk/internal/user/models"
@@ -254,6 +255,14 @@ func (c *Manager) GetConversation(id int, uuid string) (models.Conversation, err
 		c.lo.Error("error fetching conversation", "error", err)
 		return conversation, envelope.NewError(envelope.GeneralError, c.i18n.Ts("globals.messages.errorFetching", "name", "{globals.terms.conversation}"), nil)
 	}
+
+	// Strip name and extract plain email from "Name <email>"
+	var err error
+	conversation.InboxMail, err = stringutil.ExtractEmail(conversation.InboxMail)
+	if err != nil {
+		c.lo.Error("error extracting email from inbox mail", "inbox_mail", conversation.InboxMail, "error", err)
+	}
+
 	return conversation, nil
 }
 

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -41,11 +41,11 @@ import (
 
 var (
 	//go:embed queries.sql
-	efs                                  embed.FS
-	errConversationNotFound              = errors.New("conversation not found")
-	conversationsAllowedFields = []string{"status_id", "priority_id", "assigned_team_id", "assigned_user_id", "inbox_id", "last_message_at", "created_at", "waiting_since", "next_sla_deadline_at", "priority_id"}
-	conversationStatusAllowedFields     = []string{"id", "name"}
-	csatReplyMessage                     = "Please rate your experience with us: <a href=\"%s\">Rate now</a>"
+	efs                             embed.FS
+	errConversationNotFound         = errors.New("conversation not found")
+	conversationsAllowedFields      = []string{"status_id", "priority_id", "assigned_team_id", "assigned_user_id", "inbox_id", "last_message_at", "created_at", "waiting_since", "next_sla_deadline_at", "priority_id"}
+	conversationStatusAllowedFields = []string{"id", "name"}
+	csatReplyMessage                = "Please rate your experience with us: <a href=\"%s\">Rate now</a>"
 )
 
 const (
@@ -886,7 +886,7 @@ func (m *Manager) ApplyAction(action amodels.RuleAction, conv models.Conversatio
 	case amodels.ActionSendPrivateNote:
 		return m.SendPrivateNote([]mmodels.Media{}, user.ID, conv.UUID, action.Value[0])
 	case amodels.ActionReply:
-		return m.SendReply([]mmodels.Media{}, conv.InboxID, user.ID, conv.UUID, action.Value[0], nil, nil, nil)
+		return m.SendReply([]mmodels.Media{}, conv.InboxID, user.ID, conv.UUID, action.Value[0], nil, nil, nil, nil)
 	case amodels.ActionSetSLA:
 		slaID, _ := strconv.Atoi(action.Value[0])
 		return m.ApplySLA(conv, slaID, user)
@@ -924,7 +924,7 @@ func (m *Manager) SendCSATReply(actorUserID int, conversation models.Conversatio
 	meta := map[string]interface{}{
 		"is_csat": true,
 	}
-	return m.SendReply([]mmodels.Media{}, conversation.InboxID, actorUserID, conversation.UUID, message, nil, nil, meta)
+	return m.SendReply([]mmodels.Media{}, conversation.InboxID, actorUserID, conversation.UUID, message, nil, nil, nil, meta)
 }
 
 // DeleteConversation deletes a conversation.

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -142,7 +142,7 @@ func (m *Manager) sendOutgoingMessage(message models.Message) {
 		return
 	}
 
-	// Render content  template
+	// Render content in template
 	if err := m.RenderContentInTemplate(inbox.Channel(), &message); err != nil {
 		handleError(err, "error rendering content in template")
 		return
@@ -154,12 +154,8 @@ func (m *Manager) sendOutgoingMessage(message models.Message) {
 		return
 	}
 
-	// Set from and to addresses
+	// Set from address of the inbox
 	message.From = inbox.FromAddress()
-	message.To, err = m.GetToAddress(message.ConversationID)
-	if handleError(err, "error fetching `to` address") {
-		return
-	}
 
 	// Set "In-Reply-To" and "References" headers, logging any errors but continuing to send the message.
 	// Include only the last 20 messages as references to avoid exceeding header size limits.
@@ -318,16 +314,24 @@ func (m *Manager) SendPrivateNote(media []mmodels.Media, senderID int, conversat
 }
 
 // SendReply inserts a reply message in a conversation.
-func (m *Manager) SendReply(media []mmodels.Media, inboxID, senderID int, conversationUUID, content string, cc, bcc []string, meta map[string]interface{}) error {
-	// Save cc and bcc as JSON in meta.
+func (m *Manager) SendReply(media []mmodels.Media, inboxID, senderID int, conversationUUID, content string, to, cc, bcc []string, meta map[string]interface{}) error {
+	// Save to, cc and bcc in meta.
+	to = stringutil.RemoveEmpty(to)
 	cc = stringutil.RemoveEmpty(cc)
 	bcc = stringutil.RemoveEmpty(bcc)
+
+	if len(to) == 0 {
+		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.empty", "name", "to"), nil)
+	}
+	meta["to"] = to
+
 	if len(cc) > 0 {
 		meta["cc"] = cc
 	}
 	if len(bcc) > 0 {
 		meta["bcc"] = bcc
 	}
+
 	metaJSON, err := json.Marshal(meta)
 	if err != nil {
 		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorMarshalling", "name", "{globals.terms.meta}"), nil)
@@ -355,7 +359,7 @@ func (m *Manager) SendReply(media []mmodels.Media, inboxID, senderID int, conver
 		ContentType:      models.ContentTypeHTML,
 		Private:          false,
 		Media:            media,
-		Meta:             string(metaJSON),
+		Meta:             metaJSON,
 		SourceID:         null.StringFrom(sourceID),
 	}
 	return m.InsertMessage(&message)
@@ -368,9 +372,8 @@ func (m *Manager) InsertMessage(message *models.Message) error {
 		message.Status = models.MessageStatusSent
 	}
 
-	// Handle empty meta.
-	if message.Meta == "" || message.Meta == "null" {
-		message.Meta = "{}"
+	if len(message.Meta) == 0 || string(message.Meta) == "null" {
+		message.Meta = json.RawMessage(`{}`)
 	}
 
 	// Convert HTML content to text for search.
@@ -566,11 +569,10 @@ func (m *Manager) processIncomingMessage(in models.IncomingMessage) error {
 	systemUser, err := m.userStore.GetSystemUser()
 	if err != nil {
 		m.lo.Error("error fetching system user", "error", err)
-		return fmt.Errorf("error fetching system user for reopening conversation: %w", err)
-	}
-	if err := m.ReOpenConversation(in.Message.ConversationUUID, systemUser); err != nil {
-		m.lo.Error("error reopening conversation", "error", err)
-		return fmt.Errorf("error reopening conversation: %w", err)
+	} else {
+		if err := m.ReOpenConversation(in.Message.ConversationUUID, systemUser); err != nil {
+			m.lo.Error("error reopening conversation", "error", err)
+		}
 	}
 
 	// Trigger automations on incoming message event.

--- a/internal/conversation/models/models.go
+++ b/internal/conversation/models/models.go
@@ -75,8 +75,8 @@ type Conversation struct {
 	Subject               null.String     `db:"subject" json:"subject"`
 	UnreadMessageCount    int             `db:"unread_message_count" json:"unread_message_count"`
 	InboxMail             string          `db:"inbox_mail" json:"inbox_mail"`
-	InboxName             string          `db:"inbox_name" json:"inbox_name,omitempty"`
-	InboxChannel          string          `db:"inbox_channel" json:"inbox_channel,omitempty"`
+	InboxName             string          `db:"inbox_name" json:"inbox_name"`
+	InboxChannel          string          `db:"inbox_channel" json:"inbox_channel"`
 	Tags                  null.JSON       `db:"tags" json:"tags"`
 	Meta                  pq.StringArray  `db:"meta" json:"meta"`
 	CustomAttributes      json.RawMessage `db:"custom_attributes" json:"custom_attributes"`

--- a/internal/conversation/models/models.go
+++ b/internal/conversation/models/models.go
@@ -74,8 +74,8 @@ type Conversation struct {
 	WaitingSince          null.Time       `db:"waiting_since" json:"waiting_since"`
 	Subject               null.String     `db:"subject" json:"subject"`
 	UnreadMessageCount    int             `db:"unread_message_count" json:"unread_message_count"`
-	InboxName             string          `db:"inbox_name" json:"inbox_name"`
-	InboxChannel          string          `db:"inbox_channel" json:"inbox_channel"`
+	InboxName             string          `db:"inbox_name" json:"inbox_name,omitempty"`
+	InboxChannel          string          `db:"inbox_channel" json:"inbox_channel,omitempty"`
 	Tags                  null.JSON       `db:"tags" json:"tags"`
 	Meta                  pq.StringArray  `db:"meta" json:"meta"`
 	CustomAttributes      json.RawMessage `db:"custom_attributes" json:"custom_attributes"`
@@ -89,6 +89,7 @@ type Conversation struct {
 	FirstResponseDueAt    null.Time       `db:"first_response_deadline_at" json:"first_response_deadline_at"`
 	ResolutionDueAt       null.Time       `db:"resolution_deadline_at" json:"resolution_deadline_at"`
 	SLAStatus             null.String     `db:"sla_status" json:"sla_status"`
+	To                    json.RawMessage `db:"to" json:"to"`
 	BCC                   json.RawMessage `db:"bcc" json:"bcc"`
 	CC                    json.RawMessage `db:"cc" json:"cc"`
 	PreviousConversations []Conversation  `db:"-" json:"previous_conversations"`
@@ -131,19 +132,19 @@ type Message struct {
 	SenderID         int                    `db:"sender_id" json:"sender_id"`
 	SenderType       string                 `db:"sender_type" json:"sender_type"`
 	InboxID          int                    `db:"inbox_id" json:"-"`
-	Meta             string                 `db:"meta" json:"meta"`
+	Meta             json.RawMessage        `db:"meta" json:"meta"`
 	Attachments      attachment.Attachments `db:"attachments" json:"attachments"`
 	ConversationUUID string                 `db:"conversation_uuid" json:"-"`
 	From             string                 `db:"from"  json:"-"`
-	To               []string               `db:"from"  json:"-"`
-	AltContent       string                 `db:"alt_content" json:"-"`
 	Subject          string                 `db:"subject" json:"-"`
 	Channel          string                 `db:"channel" json:"-"`
+	To               pq.StringArray         `db:"to"  json:"-"`
 	CC               pq.StringArray         `db:"cc" json:"-"`
 	BCC              pq.StringArray         `db:"bcc" json:"-"`
 	References       []string               `json:"-"`
 	InReplyTo        string                 `json:"-"`
 	Headers          textproto.MIMEHeader   `json:"-"`
+	AltContent       string                 `db:"-" json:"-"`
 	Media            []mmodels.Media        `db:"-" json:"-"`
 	IsCSAT           bool                   `db:"-" json:"-"`
 	Total            int                    `db:"total" json:"-"`

--- a/internal/conversation/models/models.go
+++ b/internal/conversation/models/models.go
@@ -74,6 +74,7 @@ type Conversation struct {
 	WaitingSince          null.Time       `db:"waiting_since" json:"waiting_since"`
 	Subject               null.String     `db:"subject" json:"subject"`
 	UnreadMessageCount    int             `db:"unread_message_count" json:"unread_message_count"`
+	InboxMail             string          `db:"inbox_mail" json:"inbox_mail"`
 	InboxName             string          `db:"inbox_name" json:"inbox_name,omitempty"`
 	InboxChannel          string          `db:"inbox_channel" json:"inbox_channel,omitempty"`
 	Tags                  null.JSON       `db:"tags" json:"tags"`

--- a/internal/conversation/queries.sql
+++ b/internal/conversation/queries.sql
@@ -359,12 +359,6 @@ FROM conversation_tags ct
 JOIN tags t ON ct.tag_id = t.id
 WHERE ct.conversation_id = (SELECT id FROM conversations WHERE uuid = $1);
 
--- name: get-to-address
-SELECT cc.identifier 
-FROM conversations c 
-INNER JOIN contact_channels cc ON cc.id = c.contact_channel_id 
-WHERE c.id = $1;
-
 -- name: get-conversation-uuid-from-message-uuid
 SELECT c.uuid AS conversation_uuid
 FROM conversation_messages m

--- a/internal/conversation/queries.sql
+++ b/internal/conversation/queries.sql
@@ -90,6 +90,7 @@ SELECT
    c.resolved_at,
    c.inbox_id,
    COALESCE(inb.from, '') as inbox_mail,
+   COALESCE(inb.channel::TEXT, '') as inbox_channel,
    c.status_id,
    c.priority_id,
    p.name as priority,
@@ -104,6 +105,7 @@ SELECT
    c.subject,
    c.contact_id,
    c.sla_policy_id,
+   c.meta,
    sla.name as sla_policy_name,
    c.last_message,
    c.custom_attributes,
@@ -129,7 +131,7 @@ SELECT
    as_latest.status as sla_status
 FROM conversations c
 JOIN users ct ON c.contact_id = ct.id
-INNER JOIN inboxes inb ON c.inbox_id = inb.id
+JOIN inboxes inb ON c.inbox_id = inb.id
 LEFT JOIN sla_policies sla ON c.sla_policy_id = sla.id
 LEFT JOIN teams at ON at.id = c.assigned_team_id
 LEFT JOIN conversation_statuses s ON c.status_id = s.id

--- a/internal/conversation/queries.sql
+++ b/internal/conversation/queries.sql
@@ -89,6 +89,7 @@ SELECT
    c.closed_at,
    c.resolved_at,
    c.inbox_id,
+   COALESCE(inb.from, '') as inbox_mail,
    c.status_id,
    c.priority_id,
    p.name as priority,
@@ -128,6 +129,7 @@ SELECT
    as_latest.status as sla_status
 FROM conversations c
 JOIN users ct ON c.contact_id = ct.id
+INNER JOIN inboxes inb ON c.inbox_id = inb.id
 LEFT JOIN sla_policies sla ON c.sla_policy_id = sla.id
 LEFT JOIN teams at ON at.id = c.assigned_team_id
 LEFT JOIN conversation_statuses s ON c.status_id = s.id

--- a/internal/conversation/queries.sql
+++ b/internal/conversation/queries.sql
@@ -558,3 +558,23 @@ WHERE
 
 -- name: delete-conversation
 DELETE FROM conversations WHERE uuid = $1;
+
+-- name: get-latest-message
+SELECT
+    m.created_at,
+    m.updated_at,
+    m.status,
+    m.type, 
+    m.content,
+    m.uuid,
+    m.private,
+    m.sender_id,
+    m.sender_type,
+    m.meta
+FROM conversation_messages m
+WHERE m.conversation_id = $1
+AND m.type = ANY($2)
+AND m.status = ANY($3)
+AND m.private = NOT $4
+ORDER BY m.created_at DESC
+LIMIT 1;

--- a/internal/conversation/recipient.go
+++ b/internal/conversation/recipient.go
@@ -1,0 +1,33 @@
+package conversation
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/abhinavxd/libredesk/internal/conversation/models"
+	"github.com/abhinavxd/libredesk/internal/stringutil"
+)
+
+// makeRecipients computes the recipients for a given conversation ID using the last message in the conversation.
+func (m *Manager) makeRecipients(conversationID int, contactEmail, inboxEmail string) (to, cc, bcc []string, err error) {
+	lastMessage, err := m.getLatestMessage(conversationID, []string{models.MessageIncoming, models.MessageOutgoing}, []string{models.MessageStatusReceived, models.MessageStatusSent}, true)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("fetching message for makeRecipients: %w", err)
+	}
+
+	var meta struct {
+		From []string `json:"from"`
+		To   []string `json:"to"`
+		CC   []string `json:"cc"`
+		BCC  []string `json:"bcc"`
+	}
+	if err = json.Unmarshal(lastMessage.Meta, &meta); err != nil {
+		return nil, nil, nil, err
+	}
+
+	isIncoming := lastMessage.Type == models.MessageIncoming
+	to, cc, bcc = stringutil.ComputeRecipients(
+		meta.From, meta.To, meta.CC, meta.BCC, contactEmail, inboxEmail, isIncoming,
+	)
+	return
+}

--- a/internal/stringutil/stringutil.go
+++ b/internal/stringutil/stringutil.go
@@ -218,8 +218,7 @@ func DedupAndExcludeString(list []string, exclude string) []string {
 	return cleaned
 }
 
-// ComputeRecipients deduplicates and resolves to, cc, and bcc fields.
-// Applies fallback logic using contactEmail and thread rules for incoming messages.
+// ComputeRecipients computes new recipients using last message's recipients and direction.
 func ComputeRecipients(
 	from, to, cc, bcc []string,
 	contactEmail, inboxEmail string,
@@ -250,11 +249,10 @@ func ComputeRecipients(
 		}
 	}
 
-	finalBCC = append([]string{}, bcc...)
-
 	finalTo = DedupAndExcludeString(finalTo, inboxEmail)
 	finalCC = DedupAndExcludeString(finalCC, inboxEmail)
-	finalBCC = DedupAndExcludeString(finalBCC, inboxEmail)
+	// BCC is one-time only, user is supposed to add it manually.
+	finalBCC = []string{}
 
 	return
 }

--- a/internal/stringutil/stringutil.go
+++ b/internal/stringutil/stringutil.go
@@ -191,3 +191,12 @@ func ValidEmail(email string) bool {
 	}
 	return addr.Name == "" && addr.Address == email
 }
+
+// ExtractEmail extracts the email address from a string.
+func ExtractEmail(s string) (string, error) {
+	addr, err := mail.ParseAddress(s)
+	if err != nil {
+		return "", err
+	}
+	return addr.Address, nil
+}


### PR DESCRIPTION
Work in progress

* Adds support for setting the `to` address in the reply box, defaults to contact email address.
* Displays `to`, `from`, `bcc`, and `subject` metadata in each message.
* Uses `message.meta.to` instead of the `get-to-address` query to set addresses before sending the email.
* Fixes incorrect recipients in the reply box when 3rd email is involved. Ref - https://github.com/abhinavxd/libredesk/issues/74#issue-3021419913


![image](https://github.com/user-attachments/assets/e69fd485-c207-4ede-a960-761fcb8bdaaf)
 


Other  changes
* Reorders fields in the notification form for better UX.
* Includes general refactors and ad-hoc fixes


Ref  #74 