### PR TITLE
stop crowdin workflow on forks

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   crowdin:
     runs-on: ubuntu-latest
+    # Only run on the original repository, not forks
+    if: github.event.repository.fork == false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Crowdin should run only on the original repository.
It fixes annoying emails for failing pipelines on forks.