### PR TITLE
Add month support to getRelativeTime

### DIFF
--- a/frontend/src/utils/datetime.js
+++ b/frontend/src/utils/datetime.js
@@ -1,17 +1,17 @@
-import { format, differenceInMinutes, differenceInHours, differenceInDays,differenceInMonths, differenceInYears } from 'date-fns'
+import { format, differenceInMinutes, differenceInHours, differenceInDays, differenceInMonths, differenceInYears } from 'date-fns'
 
 export function getRelativeTime (timestamp, now = new Date()) {
   try {
     const mins = differenceInMinutes(now, timestamp)
     const hours = differenceInHours(now, timestamp)
     const days = differenceInDays(now, timestamp)
-    const months=differenceInMonths(now, timestamp)
+    const months = differenceInMonths(now, timestamp)
     const years = differenceInYears(now, timestamp)
 
     if (mins === 0) return 'now'
     if (mins < 60) return `${mins}m`
     if (hours < 24) return `${hours}h`
-    if (days < 30) return `${days}d`
+    if (days < 31) return `${days}d`
     if (months < 12) return `${months}mo`
     return `${years}y`
   } catch (error) {

--- a/frontend/src/utils/datetime.js
+++ b/frontend/src/utils/datetime.js
@@ -1,16 +1,18 @@
-import { format, differenceInMinutes, differenceInHours, differenceInDays, differenceInYears } from 'date-fns'
+import { format, differenceInMinutes, differenceInHours, differenceInDays,differenceInMonths, differenceInYears } from 'date-fns'
 
 export function getRelativeTime (timestamp, now = new Date()) {
   try {
     const mins = differenceInMinutes(now, timestamp)
     const hours = differenceInHours(now, timestamp)
     const days = differenceInDays(now, timestamp)
+    const months=differenceInMonths(now, timestamp)
     const years = differenceInYears(now, timestamp)
 
     if (mins === 0) return 'now'
     if (mins < 60) return `${mins}m`
     if (hours < 24) return `${hours}h`
-    if (days < 365) return `${days}d`
+    if (days < 30) return `${days}d`
+    if (months < 12) return `${months}mo`
     return `${years}y`
   } catch (error) {
     console.error('Error parsing time', error, 'timestamp', timestamp)


### PR DESCRIPTION
This PR updates the getRelativeTime function in datetime.js to add month support. Previously, the function displayed days up to 365 and then jumped directly to years. Now, it correctly shows months (Xmo) for timestamps older than 30 days but less than a year.