### PR TITLE
Add support for setting redis user

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -725,6 +725,7 @@ func initI18n(fs stuffbin.FileSystem) *i18n.I18n {
 func initRedis() *redis.Client {
 	return redis.NewClient(&redis.Options{
 		Addr:     ko.MustString("redis.address"),
+		Username: ko.String("redis.user"),
 		Password: ko.String("redis.password"),
 		DB:       ko.Int("redis.db"),
 	})

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -78,6 +78,7 @@ max_lifetime = "300s"
 [redis]
 # If running locally, use `localhost:6379`.
 address = "redis:6379"
+user = ""
 password = ""
 db = 0
 


### PR DESCRIPTION
Adds a configuration option for setting redis user

`LIBREDESK_REDIS__USER`

```
[redis]
user = ""
```