### PR TITLE
Enable setting redis config via url

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -723,6 +723,16 @@ func initI18n(fs stuffbin.FileSystem) *i18n.I18n {
 
 // initRedis inits redis DB.
 func initRedis() *redis.Client {
+	// Load options from redis URL if set.
+	redisURL := ko.String("redis.url")
+	if redisURL != "" {
+		options, err := redis.ParseURL(redisURL)
+		if err != nil {
+			log.Fatalf("error parsing redis url: %v", err)
+		}
+		return redis.NewClient(options)
+	}
+	// Load from individual config options.
 	return redis.NewClient(&redis.Options{
 		Addr:     ko.MustString("redis.address"),
 		Username: ko.String("redis.user"),

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -76,6 +76,8 @@ max_lifetime = "300s"
 
 # Redis.
 [redis]
+# url parameter overrides other redis config options
+# url = "redis://user:password@host:port/db"
 # If running locally, use `localhost:6379`.
 address = "redis:6379"
 user = ""


### PR DESCRIPTION
Adds option to set redis connection details with a single `url` parameter instead of configuring each separately. Current implementation makes `url` override individual variables.

Main motivations:

- Enables easily enabling TLS by having `rediss://` prefix in url. Implementation with separate `redis.tls` config option got crowded and difficult to read
- Cloud providers often expose the redis connection string as a single variable. Makes the container configuration cleaner by having a single variable for redis configuration instead of four.