### PR TITLE
Add OpenRouter provider support

### DIFF
--- a/cmd/ai.go
+++ b/cmd/ai.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/abhinavxd/libredesk/internal/ai"
 	"github.com/abhinavxd/libredesk/internal/envelope"
 	"github.com/zerodha/fastglue"
 )
@@ -13,6 +14,17 @@ type aiCompletionReq struct {
 type providerUpdateReq struct {
 	Provider string `json:"provider"`
 	APIKey   string `json:"api_key"`
+	Model    string `json:"model"`
+}
+
+type setDefaultProviderReq struct {
+	Provider string `json:"provider"`
+}
+
+type testProviderReq struct {
+	Provider string `json:"provider"`
+	APIKey   string `json:"api_key"`
+	Model    string `json:"model"`
 }
 
 // handleAICompletion handles AI completion requests
@@ -45,6 +57,27 @@ func handleGetAIPrompts(r *fastglue.Request) error {
 	return r.SendEnvelope(resp)
 }
 
+// handleGetAIProviders returns configured AI providers
+func handleGetAIProviders(r *fastglue.Request) error {
+	var (
+		app = r.Context.(*App)
+	)
+	resp, err := app.ai.GetProviders()
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	return r.SendEnvelope(resp)
+}
+
+// handleGetAvailableModels returns available models for OpenRouter
+func handleGetAvailableModels(r *fastglue.Request) error {
+	var (
+		app = r.Context.(*App)
+	)
+	models := app.ai.GetAvailableModels()
+	return r.SendEnvelope(models)
+}
+
 // handleUpdateAIProvider updates the AI provider
 func handleUpdateAIProvider(r *fastglue.Request) error {
 	var (
@@ -54,8 +87,43 @@ func handleUpdateAIProvider(r *fastglue.Request) error {
 	if err := r.Decode(&req, "json"); err != nil {
 		return sendErrorEnvelope(r, envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.errorParsing", "name", "{globals.terms.request}"), nil))
 	}
-	if err := app.ai.UpdateProvider(req.Provider, req.APIKey); err != nil {
+	if err := app.ai.UpdateProvider(req.Provider, req.APIKey, req.Model); err != nil {
 		return sendErrorEnvelope(r, err)
 	}
 	return r.SendEnvelope("Provider updated successfully")
+}
+
+// handleSetDefaultAIProvider sets the default AI provider
+func handleSetDefaultAIProvider(r *fastglue.Request) error {
+	var (
+		app = r.Context.(*App)
+		req setDefaultProviderReq
+	)
+	if err := r.Decode(&req, "json"); err != nil {
+		return sendErrorEnvelope(r, envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.errorParsing", "name", "{globals.terms.request}"), nil))
+	}
+	if err := app.ai.SetDefaultProvider(req.Provider); err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	return r.SendEnvelope("Default provider updated successfully")
+}
+
+// handleTestAIProvider tests the AI provider connection
+func handleTestAIProvider(r *fastglue.Request) error {
+	var (
+		app = r.Context.(*App)
+		req testProviderReq
+	)
+	if err := r.Decode(&req, "json"); err != nil {
+		return sendErrorEnvelope(r, envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.errorParsing", "name", "{globals.terms.request}"), nil))
+	}
+	if err := app.ai.TestProvider(req.Provider, req.APIKey, req.Model); err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	return r.SendEnvelope("Connection successful")
+}
+
+// handleGetSupportedProviders returns list of supported AI provider types
+func handleGetSupportedProviders(r *fastglue.Request) error {
+	return r.SendEnvelope(ai.SupportedProviders)
 }

--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -199,7 +199,12 @@ func initHandlers(g *fastglue.Fastglue, hub *ws.Hub) {
 	// AI completions.
 	g.GET("/api/v1/ai/prompts", auth(handleGetAIPrompts))
 	g.POST("/api/v1/ai/completion", auth(handleAICompletion))
+	g.GET("/api/v1/ai/providers", perm(handleGetAIProviders, "ai:manage"))
+	g.GET("/api/v1/ai/providers/supported", perm(handleGetSupportedProviders, "ai:manage"))
+	g.GET("/api/v1/ai/models", perm(handleGetAvailableModels, "ai:manage"))
 	g.PUT("/api/v1/ai/provider", perm(handleUpdateAIProvider, "ai:manage"))
+	g.PUT("/api/v1/ai/provider/default", perm(handleSetDefaultAIProvider, "ai:manage"))
+	g.POST("/api/v1/ai/provider/test", perm(handleTestAIProvider, "ai:manage"))
 
 	// Custom attributes.
 	g.GET("/api/v1/custom-attributes", auth(handleGetCustomAttributes))

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -396,6 +396,18 @@ const updateAIProvider = (data) => http.put('/api/v1/ai/provider', data, {
     'Content-Type': 'application/json'
   }
 })
+const getAIProviders = () => http.get('/api/v1/ai/providers')
+const getAvailableModels = () => http.get('/api/v1/ai/models')
+const setDefaultAIProvider = (data) => http.put('/api/v1/ai/provider/default', data, {
+  headers: {
+    'Content-Type': 'application/json'
+  }
+})
+const testAIProvider = (data) => http.post('/api/v1/ai/provider/test', data, {
+  headers: {
+    'Content-Type': 'application/json'
+  }
+})
 const getContactNotes = (id) => http.get(`/api/v1/contacts/${id}/notes`)
 const createContactNote = (id, data) => http.post(`/api/v1/contacts/${id}/notes`, data, {
   headers: {
@@ -542,6 +554,10 @@ export default {
   deleteView,
   getAiPrompts,
   aiCompletion,
+  getAIProviders,
+  getAvailableModels,
+  setDefaultAIProvider,
+  testAIProvider,
   searchConversations,
   searchMessages,
   searchContacts,

--- a/frontend/src/constants/navigation.js
+++ b/frontend/src/constants/navigation.js
@@ -16,6 +16,11 @@ export const adminNavItems = [
         permission: 'general_settings:manage'
       },
       {
+        titleKey: 'AI Settings',
+        href: '/admin/ai',
+        permission: 'ai:manage'
+      },
+      {
         titleKey: 'globals.terms.businessHour',
         href: '/admin/business-hours',
         permission: 'business_hours:manage'

--- a/frontend/src/features/conversation/ReplyBox.vue
+++ b/frontend/src/features/conversation/ReplyBox.vue
@@ -201,7 +201,13 @@ const handleAiPromptSelected = async (key) => {
   } catch (error) {
     // Check if user needs to enter OpenAI API key and has permission to do so.
     if (error.response?.status === 400 && userStore.can('ai:manage')) {
-      openAIKeyPrompt.value = true
+      // Direct user to AI Settings page
+      emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
+        variant: 'default',
+        description: 'Please configure an AI provider in Settings > AI Settings'
+      })
+      return
+      // Removed - now using toast instead
     }
     emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
       variant: 'destructive',

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -182,6 +182,12 @@ const routes = [
             meta: { title: 'General' }
           },
           {
+            path: 'ai',
+            name: 'ai-settings',
+            component: () => import('@/views/admin/ai/AISettings.vue'),
+            meta: { title: 'AI Settings' }
+          },
+          {
             path: 'business-hours',
             component: () => import('@/views/admin/business-hours/BusinessHours.vue'),
             meta: { title: 'Business Hours' },

--- a/frontend/src/views/admin/ai/AISettings.vue
+++ b/frontend/src/views/admin/ai/AISettings.vue
@@ -1,0 +1,313 @@
+<script setup>
+import { ref, onMounted, computed } from 'vue'
+import { toast } from 'vue-sonner'
+import api from '@/api'
+import AdminPageWithHelp from '@/layouts/admin/AdminPageWithHelp.vue'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Badge } from '@/components/ui/badge'
+import Spinner from '@/components/ui/spinner/Spinner.vue'
+import { Bot, CheckCircle, AlertCircle, RefreshCw } from 'lucide-vue-next'
+
+const providers = ref([])
+const availableModels = ref([])
+const loading = ref(true)
+const saving = ref(false)
+const testing = ref(false)
+
+// Form state
+const openaiApiKey = ref('')
+const openrouterApiKey = ref('')
+const openrouterModel = ref('anthropic/claude-3-haiku')
+const defaultProvider = ref('openai')
+
+const hasOpenAIKey = computed(() => {
+  const p = providers.value.find(p => p.provider === 'openai')
+  return p?.has_api_key || false
+})
+
+const hasOpenRouterKey = computed(() => {
+  const p = providers.value.find(p => p.provider === 'openrouter')
+  return p?.has_api_key || false
+})
+
+const currentDefaultProvider = computed(() => {
+  const p = providers.value.find(p => p.is_default)
+  return p?.provider || 'openai'
+})
+
+async function fetchProviders() {
+  try {
+    const res = await api.getAIProviders()
+    providers.value = res.data.data || []
+
+    // Set default provider
+    const defaultP = providers.value.find(p => p.is_default)
+    if (defaultP) {
+      defaultProvider.value = defaultP.provider
+    }
+
+    // Get current OpenRouter model
+    const openrouter = providers.value.find(p => p.provider === 'openrouter')
+    if (openrouter?.model) {
+      openrouterModel.value = openrouter.model
+    }
+  } catch (err) {
+    console.error('Error fetching providers:', err)
+    toast.error('Failed to load AI providers')
+  }
+}
+
+async function fetchModels() {
+  try {
+    const res = await api.getAvailableModels()
+    availableModels.value = res.data.data || []
+  } catch (err) {
+    console.error('Error fetching models:', err)
+  }
+}
+
+async function saveOpenAI() {
+  if (!openaiApiKey.value) {
+    toast.error('Please enter an API key')
+    return
+  }
+
+  saving.value = true
+  try {
+    await api.updateAIProvider({
+      provider: 'openai',
+      api_key: openaiApiKey.value,
+      model: ''
+    })
+    toast.success('OpenAI API key saved')
+    openaiApiKey.value = ''
+    await fetchProviders()
+  } catch (err) {
+    toast.error(err.response?.data?.message || 'Failed to save')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function saveOpenRouter() {
+  if (!openrouterApiKey.value && !hasOpenRouterKey.value) {
+    toast.error('Please enter an API key')
+    return
+  }
+
+  saving.value = true
+  try {
+    await api.updateAIProvider({
+      provider: 'openrouter',
+      api_key: openrouterApiKey.value || '',
+      model: openrouterModel.value
+    })
+    toast.success('OpenRouter settings saved')
+    openrouterApiKey.value = ''
+    await fetchProviders()
+  } catch (err) {
+    toast.error(err.response?.data?.message || 'Failed to save')
+  } finally {
+    saving.value = false
+  }
+}
+
+async function setDefaultProvider(provider) {
+  try {
+    await api.setDefaultAIProvider({ provider })
+    toast.success(`${provider === 'openai' ? 'OpenAI' : 'OpenRouter'} set as default`)
+    await fetchProviders()
+  } catch (err) {
+    toast.error(err.response?.data?.message || 'Failed to set default')
+  }
+}
+
+async function testProvider(provider) {
+  const config = {
+    provider,
+    api_key: provider === 'openai' ? openaiApiKey.value : openrouterApiKey.value,
+    model: provider === 'openrouter' ? openrouterModel.value : ''
+  }
+
+  testing.value = true
+  try {
+    await api.testAIProvider(config)
+    toast.success('Connection successful!')
+  } catch (err) {
+    toast.error(err.response?.data?.message || 'Connection failed')
+  } finally {
+    testing.value = false
+  }
+}
+
+onMounted(async () => {
+  loading.value = true
+  await Promise.all([fetchProviders(), fetchModels()])
+  loading.value = false
+})
+</script>
+
+<template>
+  <AdminPageWithHelp>
+    <template #content>
+      <div v-if="loading" class="flex items-center justify-center py-12">
+        <Spinner />
+      </div>
+
+      <div v-else class="space-y-6">
+        <!-- OpenAI Card -->
+        <Card>
+          <CardHeader>
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-2">
+                <Bot class="h-5 w-5" />
+                <CardTitle>OpenAI</CardTitle>
+              </div>
+              <div class="flex items-center gap-2">
+                <Badge v-if="hasOpenAIKey" class="bg-green-100 text-green-800">
+                  <CheckCircle class="h-3 w-3 mr-1" />
+                  Configured
+                </Badge>
+                <Badge v-else variant="secondary">
+                  <AlertCircle class="h-3 w-3 mr-1" />
+                  Not configured
+                </Badge>
+                <Badge v-if="currentDefaultProvider === 'openai'">
+                  Default
+                </Badge>
+              </div>
+            </div>
+            <CardDescription>
+              Use OpenAI's GPT-4o-mini model for AI assistance.
+            </CardDescription>
+          </CardHeader>
+          <CardContent class="space-y-4">
+            <div class="space-y-2">
+              <Label for="openai-key">API Key</Label>
+              <Input
+                id="openai-key"
+                v-model="openaiApiKey"
+                type="password"
+                :placeholder="hasOpenAIKey ? '********' : 'sk-...'"
+              />
+              <p class="text-xs text-muted-foreground">
+                Get your API key from <a href="https://platform.openai.com/api-keys" target="_blank" class="underline">OpenAI Dashboard</a>
+              </p>
+            </div>
+            <div class="flex gap-2">
+              <Button @click="saveOpenAI" :disabled="saving || !openaiApiKey">
+                Save
+              </Button>
+              <Button variant="outline" @click="testProvider('openai')" :disabled="testing">
+                <RefreshCw v-if="testing" class="h-4 w-4 mr-2 animate-spin" />
+                Test Connection
+              </Button>
+              <Button
+                v-if="currentDefaultProvider !== 'openai' && hasOpenAIKey"
+                variant="secondary"
+                @click="setDefaultProvider('openai')"
+              >
+                Set as Default
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <!-- OpenRouter Card -->
+        <Card>
+          <CardHeader>
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-2">
+                <Bot class="h-5 w-5" />
+                <CardTitle>OpenRouter</CardTitle>
+              </div>
+              <div class="flex items-center gap-2">
+                <Badge v-if="hasOpenRouterKey" class="bg-green-100 text-green-800">
+                  <CheckCircle class="h-3 w-3 mr-1" />
+                  Configured
+                </Badge>
+                <Badge v-else variant="secondary">
+                  <AlertCircle class="h-3 w-3 mr-1" />
+                  Not configured
+                </Badge>
+                <Badge v-if="currentDefaultProvider === 'openrouter'">
+                  Default
+                </Badge>
+              </div>
+            </div>
+            <CardDescription>
+              Access multiple AI models through OpenRouter - Claude, GPT-4, Gemini, Llama, and more.
+            </CardDescription>
+          </CardHeader>
+          <CardContent class="space-y-4">
+            <div class="space-y-2">
+              <Label for="openrouter-key">API Key</Label>
+              <Input
+                id="openrouter-key"
+                v-model="openrouterApiKey"
+                type="password"
+                :placeholder="hasOpenRouterKey ? '********' : 'sk-or-...'"
+              />
+              <p class="text-xs text-muted-foreground">
+                Get your API key from <a href="https://openrouter.ai/keys" target="_blank" class="underline">OpenRouter Dashboard</a>
+              </p>
+            </div>
+
+            <div class="space-y-2">
+              <Label for="openrouter-model">Model</Label>
+              <Select v-model="openrouterModel">
+                <SelectTrigger>
+                  <SelectValue :placeholder="openrouterModel" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem
+                    v-for="model in availableModels"
+                    :key="model"
+                    :value="model"
+                  >
+                    {{ model }}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+              <p class="text-xs text-muted-foreground">
+                Choose the AI model to use. Different models have different capabilities and pricing.
+              </p>
+            </div>
+
+            <div class="flex gap-2">
+              <Button @click="saveOpenRouter" :disabled="saving">
+                Save
+              </Button>
+              <Button variant="outline" @click="testProvider('openrouter')" :disabled="testing || !hasOpenRouterKey">
+                <RefreshCw v-if="testing" class="h-4 w-4 mr-2 animate-spin" />
+                Test Connection
+              </Button>
+              <Button
+                v-if="currentDefaultProvider !== 'openrouter' && hasOpenRouterKey"
+                variant="secondary"
+                @click="setDefaultProvider('openrouter')"
+              >
+                Set as Default
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </template>
+    <template #help>
+      <h4 class="font-medium mb-2">AI Settings</h4>
+      <p class="text-sm text-muted-foreground mb-4">
+        Configure AI providers for response assistance. You can use OpenAI directly or OpenRouter for access to multiple models.
+      </p>
+      <h4 class="font-medium mb-2">How AI Assist Works</h4>
+      <p class="text-sm text-muted-foreground">
+        When composing replies, select text and click the AI button in the toolbar to rewrite it.
+        Choose from options like "Make Friendly", "Make Professional", "Add Empathy", etc.
+      </p>
+    </template>
+  </AdminPageWithHelp>
+</template>

--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -38,10 +38,14 @@ type Opts struct {
 
 // queries contains prepared SQL queries.
 type queries struct {
-	GetDefaultProvider *sqlx.Stmt `query:"get-default-provider"`
-	GetPrompt          *sqlx.Stmt `query:"get-prompt"`
-	GetPrompts         *sqlx.Stmt `query:"get-prompts"`
-	SetOpenAIKey       *sqlx.Stmt `query:"set-openai-key"`
+	GetDefaultProvider   *sqlx.Stmt `query:"get-default-provider"`
+	GetPrompt            *sqlx.Stmt `query:"get-prompt"`
+	GetPrompts           *sqlx.Stmt `query:"get-prompts"`
+	SetOpenAIKey         *sqlx.Stmt `query:"set-openai-key"`
+	SetOpenRouterConfig  *sqlx.Stmt `query:"set-openrouter-config"`
+	GetProviders         *sqlx.Stmt `query:"get-providers"`
+	SetDefaultProvider   *sqlx.Stmt `query:"set-default-provider"`
+	UpsertOpenRouter     *sqlx.Stmt `query:"upsert-openrouter"`
 }
 
 // New creates and returns a new instance of the Manager.
@@ -79,11 +83,11 @@ func (m *Manager) Completion(k string, prompt string) (string, error) {
 	if err != nil {
 		if errors.Is(err, ErrInvalidAPIKey) {
 			m.lo.Error("error invalid API key", "error", err)
-			return "", envelope.NewError(envelope.InputError, m.i18n.Ts("globals.messages.invalid", "name", "OpenAI API Key"), nil)
+			return "", envelope.NewError(envelope.InputError, m.i18n.Ts("globals.messages.invalid", "name", "API Key"), nil)
 		}
 		if errors.Is(err, ErrApiKeyNotSet) {
 			m.lo.Error("error API key not set", "error", err)
-			return "", envelope.NewError(envelope.InputError, m.i18n.Ts("ai.apiKeyNotSet", "provider", "OpenAI"), nil)
+			return "", envelope.NewError(envelope.InputError, m.i18n.Ts("ai.apiKeyNotSet", "provider", "AI"), nil)
 		}
 		m.lo.Error("error sending prompt to provider", "error", err)
 		return "", envelope.NewError(envelope.GeneralError, err.Error(), nil)
@@ -102,15 +106,130 @@ func (m *Manager) GetPrompts() ([]models.Prompt, error) {
 	return prompts, nil
 }
 
+// GetProviders returns information about all configured providers.
+func (m *Manager) GetProviders() ([]ProviderInfo, error) {
+	var providers = make([]models.Provider, 0)
+	if err := m.q.GetProviders.Select(&providers); err != nil {
+		m.lo.Error("error fetching providers", "error", err)
+		return nil, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorFetching", "name", m.i18n.Ts("globals.terms.provider")), nil)
+	}
+
+	result := make([]ProviderInfo, 0, len(providers))
+	for _, p := range providers {
+		info := ProviderInfo{
+			Provider:  p.Provider,
+			Name:      p.Name,
+			IsDefault: p.IsDefault,
+		}
+
+		// Parse config to check if API key is set and get model
+		var config map[string]interface{}
+		if err := json.Unmarshal([]byte(p.Config), &config); err == nil {
+			if apiKey, ok := config["api_key"].(string); ok && apiKey != "" {
+				info.HasAPIKey = true
+			}
+			if model, ok := config["model"].(string); ok {
+				info.Model = model
+			}
+		}
+		result = append(result, info)
+	}
+	return result, nil
+}
+
+// GetAvailableModels returns available models for OpenRouter.
+func (m *Manager) GetAvailableModels() []string {
+	models, _ := FetchOpenRouterModels()
+	return models
+}
+
 // UpdateProvider updates a provider.
-func (m *Manager) UpdateProvider(provider, apiKey string) error {
+func (m *Manager) UpdateProvider(provider, apiKey, model string) error {
 	switch ProviderType(provider) {
 	case ProviderOpenAI:
 		return m.setOpenAIAPIKey(apiKey)
+	case ProviderOpenRouter:
+		return m.setOpenRouterConfig(apiKey, model)
 	default:
 		m.lo.Error("unsupported provider type", "provider", provider)
 		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.invalid", "name", m.i18n.Ts("globals.terms.provider")), nil)
 	}
+}
+
+// SetDefaultProvider sets a provider as the default.
+func (m *Manager) SetDefaultProvider(provider string) error {
+	if _, err := m.q.SetDefaultProvider.Exec(provider); err != nil {
+		m.lo.Error("error setting default provider", "error", err)
+		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorUpdating", "name", m.i18n.Ts("globals.terms.provider")), nil)
+	}
+	return nil
+}
+
+// TestProvider tests the connection to a provider.
+// getSavedAPIKey retrieves the saved API key for a provider from the database.
+func (m *Manager) getSavedAPIKey(provider string) (string, string) {
+	rows, err := m.q.GetProviders.Queryx()
+	if err != nil {
+		return "", ""
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var p models.Provider
+		if err := rows.StructScan(&p); err != nil {
+			continue
+		}
+		if p.Provider != provider {
+			continue
+		}
+		var config map[string]interface{}
+		if err := json.Unmarshal([]byte(p.Config), &config); err != nil {
+			return "", ""
+		}
+		apiKey, _ := config["api_key"].(string)
+		model, _ := config["model"].(string)
+		return apiKey, model
+	}
+	return "", ""
+}
+
+// TestProvider tests the connection to a provider.
+// If apiKey is empty, it uses the saved key from the database.
+func (m *Manager) TestProvider(provider, apiKey, model string) error {
+	// If no API key provided, use saved one from database
+	if apiKey == "" {
+		savedKey, savedModel := m.getSavedAPIKey(provider)
+		apiKey = savedKey
+		if model == "" {
+			model = savedModel
+		}
+	}
+
+	var client ProviderClient
+	switch ProviderType(provider) {
+	case ProviderOpenAI:
+		client = NewOpenAIClient(apiKey, m.lo)
+	case ProviderOpenRouter:
+		client = NewOpenRouterClient(apiKey, model, m.lo)
+	default:
+		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.invalid", "name", m.i18n.Ts("globals.terms.provider")), nil)
+	}
+
+	// Test with a simple prompt
+	_, err := client.SendPrompt(PromptPayload{
+		SystemPrompt: "You are a helpful assistant.",
+		UserPrompt:   "Say OK to confirm the connection works.",
+	})
+	if err != nil {
+		if errors.Is(err, ErrInvalidAPIKey) {
+			return envelope.NewError(envelope.InputError, "Invalid API Key", nil)
+		}
+		if errors.Is(err, ErrApiKeyNotSet) {
+			return envelope.NewError(envelope.InputError, "API Key not set", nil)
+		}
+		return envelope.NewError(envelope.GeneralError, err.Error(), nil)
+	}
+	return nil
 }
 
 // setOpenAIAPIKey sets the OpenAI API key in the database.
@@ -118,6 +237,26 @@ func (m *Manager) setOpenAIAPIKey(apiKey string) error {
 	if _, err := m.q.SetOpenAIKey.Exec(apiKey); err != nil {
 		m.lo.Error("error setting OpenAI API key", "error", err)
 		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorUpdating", "name", "OpenAI API Key"), nil)
+	}
+	return nil
+}
+
+// setOpenRouterConfig sets the OpenRouter config in the database.
+func (m *Manager) setOpenRouterConfig(apiKey, model string) error {
+	if model == "" {
+		model = "anthropic/claude-3-haiku"
+	}
+
+	// First, ensure OpenRouter provider exists
+	if _, err := m.q.UpsertOpenRouter.Exec(); err != nil {
+		m.lo.Error("error upserting OpenRouter provider", "error", err)
+		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorUpdating", "name", "OpenRouter"), nil)
+	}
+
+	// Then update its config
+	if _, err := m.q.SetOpenRouterConfig.Exec(apiKey, model); err != nil {
+		m.lo.Error("error setting OpenRouter config", "error", err)
+		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorUpdating", "name", "OpenRouter"), nil)
 	}
 	return nil
 }
@@ -145,16 +284,20 @@ func (m *Manager) getDefaultProviderClient() (ProviderClient, error) {
 		return nil, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorFetching", "name", m.i18n.Ts("globals.terms.provider")), nil)
 	}
 
+	var config struct {
+		APIKey string `json:"api_key"`
+		Model  string `json:"model"`
+	}
+	if err := json.Unmarshal([]byte(p.Config), &config); err != nil {
+		m.lo.Error("error parsing provider config", "error", err)
+		return nil, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorParsing", "name", m.i18n.Ts("globals.terms.provider")), nil)
+	}
+
 	switch ProviderType(p.Provider) {
 	case ProviderOpenAI:
-		config := struct {
-			APIKey string `json:"api_key"`
-		}{}
-		if err := json.Unmarshal([]byte(p.Config), &config); err != nil {
-			m.lo.Error("error parsing provider config", "error", err)
-			return nil, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorParsing", "name", m.i18n.Ts("globals.terms.provider")), nil)
-		}
 		return NewOpenAIClient(config.APIKey, m.lo), nil
+	case ProviderOpenRouter:
+		return NewOpenRouterClient(config.APIKey, config.Model, m.lo), nil
 	default:
 		m.lo.Error("unsupported provider type", "provider", p.Provider)
 		return nil, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.invalid", "name", m.i18n.Ts("globals.terms.provider")), nil)

--- a/internal/ai/openrouter.go
+++ b/internal/ai/openrouter.go
@@ -1,0 +1,116 @@
+package ai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/valyala/fasthttp"
+	"github.com/zerodha/logf"
+)
+
+// OpenRouterClient implements ProviderClient for OpenRouter API.
+type OpenRouterClient struct {
+	apiKey string
+	model  string
+	lo     *logf.Logger
+	client *http.Client
+}
+
+// NewOpenRouterClient creates a new OpenRouter client.
+func NewOpenRouterClient(apiKey, model string, lo *logf.Logger) *OpenRouterClient {
+	if model == "" {
+		model = "anthropic/claude-3-haiku" // Default model
+	}
+	return &OpenRouterClient{
+		apiKey: apiKey,
+		model:  model,
+		lo:     lo,
+		client: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// SendPrompt sends a prompt to the OpenRouter API and returns the response text.
+func (o *OpenRouterClient) SendPrompt(payload PromptPayload) (string, error) {
+	if o.apiKey == "" {
+		return "", ErrApiKeyNotSet
+	}
+
+	apiURL := "https://openrouter.ai/api/v1/chat/completions"
+	requestBody := map[string]interface{}{
+		"model": o.model,
+		"messages": []map[string]string{
+			{"role": "system", "content": payload.SystemPrompt},
+			{"role": "user", "content": payload.UserPrompt},
+		},
+		"max_tokens":  1024,
+		"temperature": 0.7,
+	}
+
+	bodyBytes, err := json.Marshal(requestBody)
+	if err != nil {
+		o.lo.Error("error marshalling request body", "error", err)
+		return "", fmt.Errorf("marshalling request body: %w", err)
+	}
+
+	req, err := http.NewRequest(fasthttp.MethodPost, apiURL, bytes.NewBuffer(bodyBytes))
+	if err != nil {
+		o.lo.Error("error creating request", "error", err)
+		return "", fmt.Errorf("error creating request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+o.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("HTTP-Referer", "https://libredesk.io")
+	req.Header.Set("X-Title", "LibreDesk Helpdesk")
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		o.lo.Error("error making HTTP request", "error", err)
+		return "", fmt.Errorf("making HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return "", ErrInvalidAPIKey
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		o.lo.Error("non-ok response received from OpenRouter API", "status", resp.Status, "code", resp.StatusCode, "response_text", string(body))
+		return "", fmt.Errorf("API error: %s, body: %s", resp.Status, body)
+	}
+
+	var responseBody struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&responseBody); err != nil {
+		return "", fmt.Errorf("decoding response body: %w", err)
+	}
+
+	if len(responseBody.Choices) > 0 {
+		return responseBody.Choices[0].Message.Content, nil
+	}
+	return "", fmt.Errorf("no response found")
+}
+
+// TestConnection tests the OpenRouter API connection.
+func (o *OpenRouterClient) TestConnection() error {
+	if o.apiKey == "" {
+		return ErrApiKeyNotSet
+	}
+
+	// Simple test with a minimal prompt
+	_, err := o.SendPrompt(PromptPayload{
+		SystemPrompt: "You are a helpful assistant.",
+		UserPrompt:   "Say 'OK' to confirm connection.",
+	})
+	return err
+}

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -1,5 +1,14 @@
 package ai
 
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
 // ProviderClient is the interface all providers should implement.
 type ProviderClient interface {
 	SendPrompt(payload PromptPayload) (string, error)
@@ -9,8 +18,9 @@ type ProviderClient interface {
 type ProviderType string
 
 const (
-	ProviderOpenAI ProviderType = "openai"
-	ProviderClaude ProviderType = "claude"
+	ProviderOpenAI     ProviderType = "openai"
+	ProviderClaude     ProviderType = "claude"
+	ProviderOpenRouter ProviderType = "openrouter"
 )
 
 // PromptPayload represents the structured input for an LLM provider.
@@ -18,3 +28,178 @@ type PromptPayload struct {
 	SystemPrompt string `json:"system_prompt"`
 	UserPrompt   string `json:"user_prompt"`
 }
+
+// ProviderInfo contains information about an AI provider for the frontend.
+type ProviderInfo struct {
+	Provider  string `json:"provider"`
+	Name      string `json:"name"`
+	Model     string `json:"model,omitempty"`
+	HasAPIKey bool   `json:"has_api_key"`
+	IsDefault bool   `json:"is_default"`
+}
+
+// SupportedProviders returns a list of supported provider types.
+var SupportedProviders = []ProviderInfo{
+	{Provider: string(ProviderOpenAI), Name: "OpenAI", Model: "gpt-4o-mini"},
+	{Provider: string(ProviderOpenRouter), Name: "OpenRouter", Model: "anthropic/claude-sonnet-4.5"},
+}
+
+// Model cache for OpenRouter models
+var (
+	modelCache      []string
+	modelCacheMutex sync.RWMutex
+	modelCacheTime  time.Time
+	modelCacheTTL   = 24 * time.Hour
+)
+
+// OpenRouterModel represents a model from OpenRouter API
+type OpenRouterModel struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// OpenRouterModelsResponse represents the API response
+type OpenRouterModelsResponse struct {
+	Data []OpenRouterModel `json:"data"`
+}
+
+// providerConfig defines how many models to take from each provider
+type providerConfig struct {
+	prefix   string
+	maxCount int
+}
+
+// preferredProviders defines providers and how many models to show from each
+var preferredProviders = []providerConfig{
+	{"anthropic/", 8},
+	{"openai/", 10},
+	{"google/", 6},
+	{"x-ai/", 4},
+	{"moonshotai/", 3},
+	{"z-ai/", 4},
+	{"deepseek/", 5},
+	{"qwen/", 5},
+	{"meta-llama/", 5},
+	{"mistralai/", 5},
+}
+
+// FetchOpenRouterModels fetches models from OpenRouter API with caching
+func FetchOpenRouterModels() ([]string, error) {
+	modelCacheMutex.RLock()
+	if len(modelCache) > 0 && time.Since(modelCacheTime) < modelCacheTTL {
+		defer modelCacheMutex.RUnlock()
+		return modelCache, nil
+	}
+	modelCacheMutex.RUnlock()
+
+	// Fetch fresh models
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get("https://openrouter.ai/api/v1/models")
+	if err != nil {
+		return getFallbackModels(), nil
+	}
+	defer resp.Body.Close()
+
+	var result OpenRouterModelsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return getFallbackModels(), nil
+	}
+
+	// Filter and balance models across providers
+	models := balanceModelsAcrossProviders(result.Data)
+
+	// Update cache
+	modelCacheMutex.Lock()
+	modelCache = models
+	modelCacheTime = time.Now()
+	modelCacheMutex.Unlock()
+
+	return models, nil
+}
+
+// balanceModelsAcrossProviders takes a balanced selection from each provider
+func balanceModelsAcrossProviders(data []OpenRouterModel) []string {
+	// Group models by provider
+	providerModels := make(map[string][]string)
+
+	for _, model := range data {
+		// Skip free tier and special variants
+		if strings.HasSuffix(model.ID, ":free") || strings.HasSuffix(model.ID, ":exacto") {
+			continue
+		}
+
+		// Find which provider this belongs to
+		for _, pc := range preferredProviders {
+			if strings.HasPrefix(model.ID, pc.prefix) {
+				providerModels[pc.prefix] = append(providerModels[pc.prefix], model.ID)
+				break
+			}
+		}
+	}
+
+	// Sort each providers models (newer/better models tend to have higher version numbers)
+	for prefix := range providerModels {
+		models := providerModels[prefix]
+		sort.Slice(models, func(i, j int) bool {
+			// Sort descending so newer versions come first
+			return models[i] > models[j]
+		})
+	}
+
+	// Take configured number from each provider
+	var result []string
+	for _, pc := range preferredProviders {
+		models := providerModels[pc.prefix]
+		count := pc.maxCount
+		if len(models) < count {
+			count = len(models)
+		}
+		result = append(result, models[:count]...)
+	}
+
+	return result
+}
+
+// getFallbackModels returns a static list if API is unavailable
+func getFallbackModels() []string {
+	return []string{
+		// Anthropic
+		"anthropic/claude-opus-4.5",
+		"anthropic/claude-sonnet-4.5",
+		"anthropic/claude-haiku-4.5",
+		"anthropic/claude-opus-4",
+		"anthropic/claude-sonnet-4",
+		// OpenAI
+		"openai/gpt-5.2-pro",
+		"openai/gpt-5.1",
+		"openai/o3-pro",
+		"openai/o3",
+		"openai/gpt-4o",
+		// Google
+		"google/gemini-3-pro-preview",
+		"google/gemini-2.5-pro",
+		"google/gemini-2.5-flash",
+		// xAI
+		"x-ai/grok-4",
+		"x-ai/grok-3",
+		// Moonshot
+		"moonshotai/kimi-k2",
+		// Zhipu
+		"z-ai/glm-4.6",
+		"z-ai/glm-4.5",
+		// DeepSeek
+		"deepseek/deepseek-v3.2",
+		"deepseek/deepseek-r1",
+		// Qwen
+		"qwen/qwen3-max",
+		"qwen/qwen3-235b-a22b",
+		// Meta
+		"meta-llama/llama-4-maverick",
+		"meta-llama/llama-3.3-70b-instruct",
+		// Mistral
+		"mistralai/mistral-large-2512",
+	}
+}
+
+// PopularOpenRouterModels kept for backwards compatibility
+var PopularOpenRouterModels = getFallbackModels()

--- a/internal/ai/queries.sql
+++ b/internal/ai/queries.sql
@@ -13,5 +13,26 @@ SET config = jsonb_set(
     COALESCE(config, '{}'::jsonb),
     '{api_key}', 
     to_jsonb($1::text)
-) 
+),
+updated_at = NOW()
 WHERE provider = 'openai';
+
+-- name: get-providers
+SELECT id, name, provider, config, is_default FROM ai_providers ORDER BY name;
+
+-- name: set-default-provider
+UPDATE ai_providers SET is_default = (provider = $1), updated_at = NOW();
+
+-- name: upsert-openrouter
+INSERT INTO ai_providers (name, provider, config, is_default)
+VALUES ('OpenRouter', 'openrouter', '{"api_key": "", "model": "anthropic/claude-3-haiku"}'::jsonb, false)
+ON CONFLICT (name) DO NOTHING;
+
+-- name: set-openrouter-config
+UPDATE ai_providers 
+SET config = jsonb_build_object(
+    'api_key', CASE WHEN $1::text = '' THEN config->>'api_key' ELSE $1::text END,
+    'model', $2::text
+),
+    updated_at = NOW()
+WHERE provider = 'openrouter';


### PR DESCRIPTION
## Summary
- Add OpenRouter as an alternative AI provider alongside OpenAI
- New AI Settings page in admin to configure providers
- Dynamic model list fetched from OpenRouter API with 24hr cache
- Balanced model selection across providers (Anthropic, OpenAI, Google, xAI, Moonshot, Zhipu, DeepSeek, Qwen, Meta, Mistral)
- Test connection uses saved API key if form field is empty
- Preserve existing API key when only updating model selection

## New files
- `internal/ai/openrouter.go` - OpenRouter client implementation
- `frontend/src/views/admin/ai/AISettings.vue` - Provider settings UI

## Changes
- Add provider management APIs (list, test, set default)
- Add navigation item for AI Settings
- Improve error messaging when AI not configured

## Screenshots
The AI Settings page allows users to:
- Configure OpenAI or OpenRouter API keys
- Select from dynamically fetched models
- Test connections
- Set default provider