### PR TITLE
fix: Handle NULL password field for imported contacts

### DIFF
--- a/internal/user/models/models.go
+++ b/internal/user/models/models.go
@@ -57,7 +57,7 @@ type User struct {
 	PhoneNumber            null.String          `db:"phone_number" json:"phone_number"`
 	AvatarURL              null.String          `db:"avatar_url" json:"avatar_url"`
 	Enabled                bool                 `db:"enabled" json:"enabled"`
-	Password               string               `db:"password" json:"-"`
+	Password               null.String          `db:"password" json:"-"`
 	LastActiveAt           null.Time            `db:"last_active_at" json:"last_active_at"`
 	LastLoginAt            null.Time            `db:"last_login_at" json:"last_login_at"`
 	Roles                  pq.StringArray       `db:"roles" json:"roles"`

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -114,7 +114,7 @@ func (u *Manager) VerifyPassword(email string, password []byte) (models.User, er
 		u.lo.Error("error fetching user from db", "error", err)
 		return user, envelope.NewError(envelope.GeneralError, u.i18n.Ts("globals.messages.errorFetching", "name", "{globals.terms.user}"), nil)
 	}
-	if err := u.verifyPassword(password, user.Password); err != nil {
+	if err := u.verifyPassword(password, user.Password.String); err != nil {
 		return user, envelope.NewError(envelope.InputError, u.i18n.T("user.invalidEmailPassword"), nil)
 	}
 	return user, nil


### PR DESCRIPTION
## Summary
- Change `Password` field from `string` to `null.String` in User model
- Update `VerifyPassword` to use `.String` accessor when comparing passwords

## Problem
When fetching contacts imported from external systems (e.g., Magento) that have NULL passwords in the database, the API returns a 500 error:

```
sql: Scan error on column index 4, name "password": converting NULL to string is unsupported
```

## Solution
Use `null.String` type which properly handles NULL database values, consistent with other nullable fields in the User model.

## Test plan
- [x] Verify contacts with NULL passwords can be fetched without error
- [x] Verify login still works for users with passwords set