### PR TITLE
feat: Enhanced search and ticket number display

### DIFF
--- a/frontend/src/features/conversation/list/ConversationListItem.vue
+++ b/frontend/src/features/conversation/list/ConversationListItem.vue
@@ -21,11 +21,16 @@
 
       <!-- Content container -->
       <div class="flex-1 min-w-0 space-y-2">
-        <!-- Contact name and last message time -->
+        <!-- Contact name, reference number, and last message time -->
         <div class="flex items-center justify-between gap-2">
-          <h3 class="text-sm font-semibold truncate">
-            {{ contactFullName }}
-          </h3>
+          <div class="flex items-center gap-2 min-w-0">
+            <h3 class="text-sm font-semibold truncate">
+              {{ contactFullName }}
+            </h3>
+            <span v-if="conversation.reference_number" class="text-xs font-mono text-muted-foreground whitespace-nowrap">
+              #{{ conversation.reference_number }}
+            </span>
+          </div>
           <span class="text-xs text-gray-400 whitespace-nowrap" v-if="conversation.last_message_at">
             {{ relativeLastMessageTime }}
           </span>

--- a/internal/conversation/models/models.go
+++ b/internal/conversation/models/models.go
@@ -59,6 +59,7 @@ type ConversationListItem struct {
 	CreatedAt          time.Time               `db:"created_at" json:"created_at"`
 	UpdatedAt          time.Time               `db:"updated_at" json:"updated_at"`
 	UUID               string                  `db:"uuid" json:"uuid"`
+	ReferenceNumber    string                  `db:"reference_number" json:"reference_number"`
 	WaitingSince       null.Time               `db:"waiting_since" json:"waiting_since"`
 	Contact            ConversationListContact `db:"contact" json:"contact"`
 	InboxChannel       string                  `db:"inbox_channel" json:"inbox_channel"`

--- a/internal/conversation/queries.sql
+++ b/internal/conversation/queries.sql
@@ -36,6 +36,7 @@ SELECT
     conversations.created_at,
     conversations.updated_at,
     conversations.uuid,
+    conversations.reference_number,
     conversations.waiting_since,
     users.created_at as "contact.created_at",
     users.updated_at as "contact.updated_at",


### PR DESCRIPTION
## Summary

- **Merge Conversations**: Allows agents to merge duplicate or related conversations into one, preserving all messages and history
- **Enhanced Search**: Search now works with partial matching for names, emails, subjects, and reference numbers
- **Ticket # in List**: Reference numbers are now visible in the conversation list view

## Features

### Conversation Merge
- New merge button in conversation sidebar
- Search modal to find conversations to merge into
- Moves all messages from source to target conversation
- Marks source as merged with timestamp
- New `conversations:merge` permission for role-based access

### Search Improvements
- Partial name search (first name, last name, full name)
- Partial email search
- Subject/title search
- Partial reference number search

### UI Improvements
- Ticket reference number (#123) now displayed in conversation list next to contact name

## Migration
The v0.9.0 migration automatically:
- Adds `merged_into_id` and `merged_at` columns to conversations
- Adds `conversations:merge` permission to Admin role

## Test Plan
- [ ] Test merging two conversations
- [ ] Verify merged conversation shows all messages
- [ ] Verify source conversation is marked as merged
- [ ] Test search with partial name (e.g., "Matt" for Matthew)
- [ ] Test search with partial email
- [ ] Test search with subject keywords
- [ ] Verify reference numbers display in list view