### PR TITLE
feat: display conversation subject in list view

### DIFF
--- a/frontend/src/features/conversation/list/ConversationListItem.vue
+++ b/frontend/src/features/conversation/list/ConversationListItem.vue
@@ -42,6 +42,11 @@
               </span>
             </div>
 
+            <!-- Subject -->
+            <p v-if="conversation.subject" class="text-xs font-medium text-muted-foreground truncate">
+              {{ conversation.subject }}
+            </p>
+
             <!-- Inbox name -->
             <p class="text-xs text-gray-400 flex items-center gap-1.5">
               <Mail class="w-3.5 h-3.5 text-gray-400/80" />


### PR DESCRIPTION
## Summary

Shows the conversation subject in the conversation list, between the contact name and inbox name rows. This helps agents triage tickets without opening each conversation and navigating to the Information panel.

- Subject is conditionally rendered (`v-if`) so conversations without subjects don't show an empty line
- Styled consistently with existing list item elements (`text-xs`, `truncate`, `text-muted-foreground`)
- No backend changes needed — the `subject` field is already included in the conversation list API response

Closes #239

## Changes

Before: conversation list shows contact name, inbox, and last message preview — no subject visible.

After: subject line appears below the contact name, making it easy to identify tickets at a glance.