### PR TITLE
Fix: update contact names on upsert instead of discarding them

### DIFF
--- a/internal/user/contact.go
+++ b/internal/user/contact.go
@@ -51,20 +51,22 @@ func (u *Manager) CreateContact(user *models.User) error {
 	}
 
 	if user.Email.Valid && user.Email.String != "" {
-		// Reuse any existing contact with this email, preferring one with ext_id if multiple exist.
+		// An ext_id contact owns this email - reuse it; the no-ext-id upsert below can't match it and would insert a duplicate.
 		existing, err := u.GetContactByEmail(user.Email.String)
-		if err == nil {
+		if err == nil && existing.ExternalUserID.String != "" {
 			user.ID = existing.ID
 			return nil
 		}
 
 		// Other error than not found - fail.
-		if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError {
-			return err
+		if err != nil {
+			if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError {
+				return err
+			}
 		}
 	}
 
-	// No ext_id and no existing contact with email - create new.
+	// No ext_id contact for this email - insert new, or update the existing no-ext-id contact's name.
 	if err := u.q.InsertContactNoExtID.QueryRow(user.Email, user.FirstName, user.LastName, password, user.AvatarURL).Scan(&user.ID); err != nil {
 		u.lo.Error("error inserting contact", "error", err)
 		return fmt.Errorf("insert contact: %w", err)

--- a/internal/user/queries.sql
+++ b/internal/user/queries.sql
@@ -176,7 +176,9 @@ RETURNING id;
 INSERT INTO users (email, type, first_name, last_name, "password", avatar_url, external_user_id)
 VALUES ($1, 'contact', $2, $3, $4, $5, NULL)
 ON CONFLICT (email) WHERE type = 'contact' AND deleted_at IS NULL AND external_user_id IS NULL
-DO UPDATE SET updated_at = now()
+DO UPDATE SET first_name = COALESCE(NULLIF(EXCLUDED.first_name, ''), users.first_name),
+              last_name = COALESCE(NULLIF(EXCLUDED.last_name, ''), users.last_name),
+              updated_at = now()
 RETURNING id;
 
 -- name: get-contact-by-email

--- a/internal/user/queries.sql
+++ b/internal/user/queries.sql
@@ -169,7 +169,10 @@ RETURNING user_id;
 INSERT INTO users (email, type, first_name, last_name, "password", avatar_url, external_user_id, custom_attributes)
 VALUES ($1, 'contact', $2, $3, $4, $5, $6, $7)
 ON CONFLICT (external_user_id) WHERE type = 'contact' AND deleted_at IS NULL AND external_user_id IS NOT NULL
-DO UPDATE SET email = EXCLUDED.email, first_name = EXCLUDED.first_name, last_name = EXCLUDED.last_name, updated_at = now()
+DO UPDATE SET email = COALESCE(NULLIF(EXCLUDED.email, ''), users.email),
+              first_name = COALESCE(NULLIF(EXCLUDED.first_name, ''), users.first_name),
+              last_name = COALESCE(NULLIF(EXCLUDED.last_name, ''), users.last_name),
+              updated_at = now()
 RETURNING id;
 
 -- name: insert-contact-without-external-id


### PR DESCRIPTION
## Summary

When a contact already exists, the `insert-contact` query currently only updates `updated_at` on conflict. This means `first_name` and `last_name` values provided via the API (e.g. from form submissions or email workers) are silently discarded for existing contacts.

This one-line change updates the ON CONFLICT clause to set `first_name` and `last_name` from the incoming values, using `COALESCE(NULLIF(EXCLUDED.x, ''), users.x)` so that:
- Non-empty incoming names replace existing ones
- Empty strings are ignored, preserving existing names
- `updated_at` is still touched as before

## Changes

- `internal/user/queries.sql`: Modified `insert-contact` ON CONFLICT clause

## Test plan

- Create a contact via API with a name
- Create the same contact again (same email) with a different name
- Verify the name is updated
- Create the same contact again with an empty name
- Verify the existing name is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact creation workflow by correctly matching and reusing existing contacts via email when enrichment identifiers are unavailable.
  * Enhanced data integrity by preventing empty field values from inadvertently overwriting preserved contact information during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->