### PR TITLE
Add configurable endpoint URL and model for AI Assist

### DIFF
--- a/cmd/ai.go
+++ b/cmd/ai.go
@@ -11,8 +11,10 @@ type aiCompletionReq struct {
 }
 
 type providerUpdateReq struct {
-	Provider string `json:"provider"`
-	APIKey   string `json:"api_key"`
+	Provider    string `json:"provider"`
+	APIKey      string `json:"api_key"`
+	EndpointURL string `json:"endpoint_url"`
+	Model       string `json:"model"`
 }
 
 // handleAICompletion handles AI completion requests
@@ -45,6 +47,18 @@ func handleGetAIPrompts(r *fastglue.Request) error {
 	return r.SendEnvelope(resp)
 }
 
+// handleGetAIProvider returns the current AI provider config (sanitized).
+func handleGetAIProvider(r *fastglue.Request) error {
+	var (
+		app = r.Context.(*App)
+	)
+	resp, err := app.ai.GetProvider()
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	return r.SendEnvelope(resp)
+}
+
 // handleUpdateAIProvider updates the AI provider
 func handleUpdateAIProvider(r *fastglue.Request) error {
 	var (
@@ -54,7 +68,7 @@ func handleUpdateAIProvider(r *fastglue.Request) error {
 	if err := r.Decode(&req, "json"); err != nil {
 		return sendErrorEnvelope(r, envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.errorParsing", "name", "{globals.terms.request}"), nil))
 	}
-	if err := app.ai.UpdateProvider(req.Provider, req.APIKey); err != nil {
+	if err := app.ai.UpdateProvider(req.Provider, req.APIKey, req.EndpointURL, req.Model); err != nil {
 		return sendErrorEnvelope(r, err)
 	}
 	return r.SendEnvelope("Provider updated successfully")

--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -223,6 +223,7 @@ func initHandlers(g *fastglue.Fastglue, hub *ws.Hub) {
 	// AI completions.
 	g.GET("/api/v1/ai/prompts", auth(handleGetAIPrompts))
 	g.POST("/api/v1/ai/completion", auth(handleAICompletion))
+	g.GET("/api/v1/ai/provider", perm(handleGetAIProvider, "ai:manage"))
 	g.PUT("/api/v1/ai/provider", perm(handleUpdateAIProvider, "ai:manage"))
 
 	// Custom attributes.

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -437,6 +437,7 @@ const updateAIProvider = (data) => http.put('/api/v1/ai/provider', data, {
     'Content-Type': 'application/json'
   }
 })
+const getAIProvider = () => http.get('/api/v1/ai/provider')
 const getContactNotes = (id) => http.get(`/api/v1/contacts/${id}/notes`)
 const createContactNote = (id, data) => http.post(`/api/v1/contacts/${id}/notes`, data, {
   headers: {
@@ -560,6 +561,7 @@ export default {
   updateAutomationRuleWeights,
   updateAutomationRulesExecutionMode,
   updateAIProvider,
+  getAIProvider,
   createAutomationRule,
   toggleAutomationRule,
   deleteAutomationRule,

--- a/frontend/src/constants/navigation.js
+++ b/frontend/src/constants/navigation.js
@@ -166,6 +166,11 @@ export const adminNavItems = [
         href: '/admin/webhooks',
         permission: 'webhooks:manage',
         isTitleKeyPlural: true
+      },
+      {
+        titleKey: 'admin.ai.title',
+        href: '/admin/ai',
+        permission: 'ai:manage'
       }
     ]
   }

--- a/frontend/src/features/admin/ai/AISettingsForm.vue
+++ b/frontend/src/features/admin/ai/AISettingsForm.vue
@@ -1,0 +1,112 @@
+<template>
+  <form @submit="onSubmit" class="space-y-6">
+    <!-- Endpoint URL -->
+    <FormField v-slot="{ componentField }" name="endpoint_url">
+      <FormItem>
+        <FormLabel>{{ $t('admin.ai.endpointUrl') }}</FormLabel>
+        <FormControl>
+          <Input
+            type="text"
+            placeholder="https://api.openai.com/v1/chat/completions"
+            v-bind="componentField"
+          />
+        </FormControl>
+        <FormDescription>{{ $t('admin.ai.endpointUrl.description') }}</FormDescription>
+        <FormMessage />
+      </FormItem>
+    </FormField>
+
+    <!-- Model -->
+    <FormField v-slot="{ componentField }" name="model">
+      <FormItem>
+        <FormLabel>{{ $t('admin.ai.model') }}</FormLabel>
+        <FormControl>
+          <Input type="text" placeholder="gpt-4o-mini" v-bind="componentField" />
+        </FormControl>
+        <FormDescription>{{ $t('admin.ai.model.description') }}</FormDescription>
+        <FormMessage />
+      </FormItem>
+    </FormField>
+
+    <!-- API Key -->
+    <FormField v-slot="{ componentField }" name="api_key">
+      <FormItem>
+        <FormLabel>{{ $t('globals.terms.apiKey') }}</FormLabel>
+        <FormControl>
+          <Input type="password" placeholder="" v-bind="componentField" />
+        </FormControl>
+        <FormDescription>
+          <span v-if="hasAPIKey" class="flex items-center gap-1.5 mb-1">
+            <span class="inline-block w-2 h-2 rounded-full bg-green-500"></span>
+            {{ $t('admin.ai.apiKeyConfigured') }}
+          </span>
+          {{ $t('admin.ai.apiKey.settingsDescription') }}
+        </FormDescription>
+        <FormMessage />
+      </FormItem>
+    </FormField>
+
+    <Button type="submit" :isLoading="isLoading">
+      {{ $t('globals.messages.save') }}
+    </Button>
+  </form>
+</template>
+
+<script setup>
+import { watch, ref, computed } from 'vue'
+import { Button } from '@/components/ui/button'
+import { useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { formSchema } from './formSchema.js'
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  FormDescription
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+
+const isLoading = ref(false)
+const props = defineProps({
+  initialValues: {
+    type: Object,
+    required: false
+  },
+  submitForm: {
+    type: Function,
+    required: true
+  }
+})
+
+const hasAPIKey = computed(() => props.initialValues?.has_api_key || false)
+
+const form = useForm({
+  validationSchema: toTypedSchema(formSchema)
+})
+
+const onSubmit = form.handleSubmit(async (values) => {
+  isLoading.value = true
+  try {
+    await props.submitForm(values)
+  } finally {
+    isLoading.value = false
+  }
+})
+
+// Watch for changes in initialValues and update the form.
+watch(
+  () => props.initialValues,
+  (newValues) => {
+    if (newValues) {
+      form.setValues({
+        endpoint_url: newValues.endpoint_url || '',
+        model: newValues.model || '',
+        api_key: ''
+      })
+    }
+  },
+  { deep: true, immediate: true }
+)
+</script>

--- a/frontend/src/features/admin/ai/formSchema.js
+++ b/frontend/src/features/admin/ai/formSchema.js
@@ -1,0 +1,13 @@
+import * as z from 'zod'
+
+export const formSchema = z.object({
+  endpoint_url: z
+    .string()
+    .refine((val) => val === '' || /^https?:\/\/.+/.test(val), {
+      message: 'Must be a valid URL (http:// or https://)'
+    })
+    .optional()
+    .default(''),
+  model: z.string().optional().default(''),
+  api_key: z.string().optional().default('')
+})

--- a/frontend/src/features/conversation/ReplyBox.vue
+++ b/frontend/src/features/conversation/ReplyBox.vue
@@ -10,6 +10,10 @@
             })
           }}
         </DialogDescription>
+        <p class="text-sm text-muted-foreground mt-2">
+          {{ $t('admin.ai.advancedSetup') }}
+          <router-link to="/admin/ai" class="text-primary underline">{{ $t('admin.ai.title') }}</router-link>
+        </p>
       </DialogHeader>
       <Form v-slot="{ handleSubmit }" as="" keep-values :validation-schema="formSchema">
         <form id="apiKeyForm" @submit="handleSubmit($event, updateProvider)">

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -454,6 +454,12 @@ const routes = [
             ]
           },
           {
+            path: 'ai',
+            name: 'ai-settings',
+            component: () => import('@/views/admin/ai/AISettings.vue'),
+            meta: { title: 'AI Assist' }
+          },
+          {
             path: 'conversations',
             meta: { title: 'Conversations' },
             children: [

--- a/frontend/src/views/admin/ai/AISettings.vue
+++ b/frontend/src/views/admin/ai/AISettings.vue
@@ -1,0 +1,78 @@
+<template>
+  <AdminPageWithHelp>
+    <template #content>
+      <div :class="{ 'opacity-50 transition-opacity duration-300': isLoading }">
+        <Spinner v-if="isLoading" />
+        <AISettingsForm :initial-values="initialValues" :submit-form="submitForm" />
+      </div>
+    </template>
+
+    <template #help>
+      <p>{{ $t('admin.ai.help') }}</p>
+    </template>
+  </AdminPageWithHelp>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '@/api'
+import AdminPageWithHelp from '@/layouts/admin/AdminPageWithHelp.vue'
+import { useI18n } from 'vue-i18n'
+import AISettingsForm from '@/features/admin/ai/AISettingsForm.vue'
+import { EMITTER_EVENTS } from '@/constants/emitterEvents.js'
+import { useEmitter } from '@/composables/useEmitter'
+import { handleHTTPError } from '@/utils/http'
+import { Spinner } from '@/components/ui/spinner'
+
+const initialValues = ref({})
+const { t } = useI18n()
+const isLoading = ref(false)
+const emitter = useEmitter()
+
+onMounted(() => {
+  fetchProvider()
+})
+
+const fetchProvider = async () => {
+  try {
+    isLoading.value = true
+    const resp = await api.getAIProvider()
+    const data = resp.data.data
+    initialValues.value = {
+      endpoint_url: data.endpoint_url || '',
+      model: data.model || '',
+      api_key: '',
+      has_api_key: data.has_api_key || false
+    }
+  } catch (error) {
+    emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
+      variant: 'destructive',
+      description: handleHTTPError(error).message
+    })
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const submitForm = async (values) => {
+  try {
+    await api.updateAIProvider({
+      provider: 'openai',
+      endpoint_url: values.endpoint_url || '',
+      model: values.model || '',
+      api_key: values.api_key || ''
+    })
+    emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
+      description: t('globals.messages.savedSuccessfully', {
+        name: t('globals.terms.provider')
+      })
+    })
+    await fetchProvider()
+  } catch (error) {
+    emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
+      variant: 'destructive',
+      description: handleHTTPError(error).message
+    })
+  }
+}
+</script>

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -731,5 +731,15 @@
   "importer.importCompleted": "Import completed: {success} of {total} successful, {errors} failed",
   "importer.csvMustContainHeadersAndData": "CSV must contain headers and at least one data row",
   "importer.importAlreadyInProgress": "Import already in progress",
-  "importer.agentCaseSensitiveNote": "Roles and teams must match exactly (case-sensitive)"
+  "importer.agentCaseSensitiveNote": "Roles and teams must match exactly (case-sensitive)",
+
+  "admin.ai.title": "AI Assist",
+  "admin.ai.help": "Configure the AI provider for AI Assist features like text completion and rewriting in the reply editor. Any OpenAI-compatible endpoint can be used, including self-hosted models.",
+  "admin.ai.endpointUrl": "Endpoint URL",
+  "admin.ai.endpointUrl.description": "The chat completions endpoint URL. Leave empty to use the default OpenAI endpoint.",
+  "admin.ai.model": "Model",
+  "admin.ai.model.description": "The model name to use for completions. Leave empty to use the default (gpt-4o-mini).",
+  "admin.ai.apiKeyConfigured": "API key is configured",
+  "admin.ai.apiKey.settingsDescription": "Enter a new key to update, or leave empty to keep the current key.",
+  "admin.ai.advancedSetup": "For advanced setup (custom endpoint, model)"
 }

--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"encoding/json"
 	"errors"
+	"strings"
 
 	"github.com/abhinavxd/libredesk/internal/ai/models"
 	"github.com/abhinavxd/libredesk/internal/crypto"
@@ -41,10 +42,25 @@ type Opts struct {
 
 // queries contains prepared SQL queries.
 type queries struct {
-	GetDefaultProvider *sqlx.Stmt `query:"get-default-provider"`
-	GetPrompt          *sqlx.Stmt `query:"get-prompt"`
-	GetPrompts         *sqlx.Stmt `query:"get-prompts"`
-	SetOpenAIKey       *sqlx.Stmt `query:"set-openai-key"`
+	GetDefaultProvider   *sqlx.Stmt `query:"get-default-provider"`
+	GetPrompt            *sqlx.Stmt `query:"get-prompt"`
+	GetPrompts           *sqlx.Stmt `query:"get-prompts"`
+	UpdateProviderConfig *sqlx.Stmt `query:"update-provider-config"`
+}
+
+// providerConfig represents the JSONB config stored in ai_providers.
+type providerConfig struct {
+	APIKey      string `json:"api_key"`
+	EndpointURL string `json:"endpoint_url"`
+	Model       string `json:"model"`
+}
+
+// ProviderInfo is the sanitized response for GET /ai/provider (no decrypted key).
+type ProviderInfo struct {
+	Provider    string `json:"provider"`
+	EndpointURL string `json:"endpoint_url"`
+	Model       string `json:"model"`
+	HasAPIKey   bool   `json:"has_api_key"`
 }
 
 // New creates and returns a new instance of the Manager.
@@ -106,29 +122,87 @@ func (m *Manager) GetPrompts() ([]models.Prompt, error) {
 	return prompts, nil
 }
 
-// UpdateProvider updates a provider.
-func (m *Manager) UpdateProvider(provider, apiKey string) error {
+// GetProvider returns the default provider's config (sanitized, no decrypted key).
+func (m *Manager) GetProvider() (ProviderInfo, error) {
+	var p models.Provider
+	if err := m.q.GetDefaultProvider.Get(&p); err != nil {
+		m.lo.Error("error fetching provider details", "error", err)
+		return ProviderInfo{}, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorFetching", "name", m.i18n.Ts("globals.terms.provider")), nil)
+	}
+
+	var cfg providerConfig
+	if p.Config != "" {
+		if err := json.Unmarshal([]byte(p.Config), &cfg); err != nil {
+			m.lo.Error("error parsing provider config", "error", err)
+			return ProviderInfo{}, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorParsing", "name", m.i18n.Ts("globals.terms.provider")), nil)
+		}
+	}
+
+	return ProviderInfo{
+		Provider:    p.Provider,
+		EndpointURL: cfg.EndpointURL,
+		Model:       cfg.Model,
+		HasAPIKey:   cfg.APIKey != "",
+	}, nil
+}
+
+// UpdateProvider updates a provider's config.
+func (m *Manager) UpdateProvider(provider, apiKey, endpointURL, model string) error {
+	// Validate endpoint URL if provided.
+	if endpointURL != "" && !strings.HasPrefix(endpointURL, "http://") && !strings.HasPrefix(endpointURL, "https://") {
+		return envelope.NewError(envelope.InputError, m.i18n.Ts("globals.messages.invalid", "name", "endpoint URL"), nil)
+	}
+
 	switch ProviderType(provider) {
 	case ProviderOpenAI:
-		return m.setOpenAIAPIKey(apiKey)
+		return m.updateOpenAIProvider(apiKey, endpointURL, model)
 	default:
 		m.lo.Error("unsupported provider type", "provider", provider)
 		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.invalid", "name", m.i18n.Ts("globals.terms.provider")), nil)
 	}
 }
 
-// setOpenAIAPIKey sets the OpenAI API key in the database.
-func (m *Manager) setOpenAIAPIKey(apiKey string) error {
-	// Encrypt API key before storing.
-	encryptedKey, err := crypto.Encrypt(apiKey, m.encryptionKey)
-	if err != nil {
-		m.lo.Error("error encrypting API key", "error", err)
-		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorUpdating", "name", "OpenAI API Key"), nil)
+// updateOpenAIProvider updates the OpenAI provider config in the database.
+// If apiKey is empty, the existing key is preserved.
+func (m *Manager) updateOpenAIProvider(apiKey, endpointURL, model string) error {
+	// Read current config to preserve fields not being updated.
+	var p models.Provider
+	if err := m.q.GetDefaultProvider.Get(&p); err != nil {
+		m.lo.Error("error fetching provider for update", "error", err)
+		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorFetching", "name", m.i18n.Ts("globals.terms.provider")), nil)
 	}
 
-	if _, err := m.q.SetOpenAIKey.Exec(encryptedKey); err != nil {
-		m.lo.Error("error setting OpenAI API key", "error", err)
-		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorUpdating", "name", "OpenAI API Key"), nil)
+	var current providerConfig
+	if p.Config != "" {
+		if err := json.Unmarshal([]byte(p.Config), &current); err != nil {
+			m.lo.Error("error parsing provider config for update", "error", err)
+			return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorParsing", "name", m.i18n.Ts("globals.terms.provider")), nil)
+		}
+	}
+
+	// Only overwrite api_key if a new one is provided.
+	if apiKey != "" {
+		encryptedKey, err := crypto.Encrypt(apiKey, m.encryptionKey)
+		if err != nil {
+			m.lo.Error("error encrypting API key", "error", err)
+			return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorUpdating", "name", "OpenAI API Key"), nil)
+		}
+		current.APIKey = encryptedKey
+	}
+
+	// Update endpoint_url and model (empty string means use defaults at runtime).
+	current.EndpointURL = endpointURL
+	current.Model = model
+
+	configJSON, err := json.Marshal(current)
+	if err != nil {
+		m.lo.Error("error marshalling provider config", "error", err)
+		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorUpdating", "name", m.i18n.Ts("globals.terms.provider")), nil)
+	}
+
+	if _, err := m.q.UpdateProviderConfig.Exec(string(configJSON)); err != nil {
+		m.lo.Error("error updating provider config", "error", err)
+		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorUpdating", "name", m.i18n.Ts("globals.terms.provider")), nil)
 	}
 	return nil
 }
@@ -158,20 +232,18 @@ func (m *Manager) getDefaultProviderClient() (ProviderClient, error) {
 
 	switch ProviderType(p.Provider) {
 	case ProviderOpenAI:
-		config := struct {
-			APIKey string `json:"api_key"`
-		}{}
-		if err := json.Unmarshal([]byte(p.Config), &config); err != nil {
+		var cfg providerConfig
+		if err := json.Unmarshal([]byte(p.Config), &cfg); err != nil {
 			m.lo.Error("error parsing provider config", "error", err)
 			return nil, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorParsing", "name", m.i18n.Ts("globals.terms.provider")), nil)
 		}
 		// Decrypt API key.
-		decryptedKey, err := crypto.Decrypt(config.APIKey, m.encryptionKey)
+		decryptedKey, err := crypto.Decrypt(cfg.APIKey, m.encryptionKey)
 		if err != nil {
 			m.lo.Error("error decrypting API key", "error", err)
 			return nil, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorFetching", "name", m.i18n.Ts("globals.terms.provider")), nil)
 		}
-		return NewOpenAIClient(decryptedKey, m.lo), nil
+		return NewOpenAIClient(decryptedKey, cfg.EndpointURL, cfg.Model, m.lo), nil
 	default:
 		m.lo.Error("unsupported provider type", "provider", p.Provider)
 		return nil, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.invalid", "name", m.i18n.Ts("globals.terms.provider")), nil)

--- a/internal/ai/openai.go
+++ b/internal/ai/openai.go
@@ -12,29 +12,43 @@ import (
 	"github.com/zerodha/logf"
 )
 
+const (
+	defaultEndpointURL = "https://api.openai.com/v1/chat/completions"
+	defaultModel       = "gpt-4o-mini"
+)
+
 type OpenAIClient struct {
-	apikey string
-	lo     *logf.Logger
-	client *http.Client
+	apikey      string
+	endpointURL string
+	model       string
+	lo          *logf.Logger
+	client      *http.Client
 }
 
-func NewOpenAIClient(apiKey string, lo *logf.Logger) *OpenAIClient {
+func NewOpenAIClient(apiKey, endpointURL, model string, lo *logf.Logger) *OpenAIClient {
+	if endpointURL == "" {
+		endpointURL = defaultEndpointURL
+	}
+	if model == "" {
+		model = defaultModel
+	}
 	return &OpenAIClient{
-		apikey: apiKey,
-		lo:     lo,
-		client: &http.Client{Timeout: 10 * time.Second},
+		apikey:      apiKey,
+		endpointURL: endpointURL,
+		model:       model,
+		lo:          lo,
+		client:      &http.Client{Timeout: 30 * time.Second},
 	}
 }
 
-// SendPrompt sends a prompt to the OpenAI API and returns the response text.
+// SendPrompt sends a prompt to the OpenAI-compatible API and returns the response text.
 func (o *OpenAIClient) SendPrompt(payload PromptPayload) (string, error) {
 	if o.apikey == "" {
 		return "", ErrApiKeyNotSet
 	}
 
-	apiURL := "https://api.openai.com/v1/chat/completions"
 	requestBody := map[string]interface{}{
-		"model": "gpt-4o-mini",
+		"model": o.model,
 		"messages": []map[string]string{
 			{"role": "system", "content": payload.SystemPrompt},
 			{"role": "user", "content": payload.UserPrompt},
@@ -49,7 +63,7 @@ func (o *OpenAIClient) SendPrompt(payload PromptPayload) (string, error) {
 		return "", fmt.Errorf("marshalling request body: %w", err)
 	}
 
-	req, err := http.NewRequest(fasthttp.MethodPost, apiURL, bytes.NewBuffer(bodyBytes))
+	req, err := http.NewRequest(fasthttp.MethodPost, o.endpointURL, bytes.NewBuffer(bodyBytes))
 	if err != nil {
 		o.lo.Error("error creating request", "error", err)
 		return "", fmt.Errorf("error creating request: %w", err)

--- a/internal/ai/queries.sql
+++ b/internal/ai/queries.sql
@@ -7,11 +7,5 @@ SELECT id, created_at, updated_at, key, title, content FROM ai_prompts where key
 -- name: get-prompts
 SELECT id, created_at, updated_at, key, title FROM ai_prompts order by title;
 
--- name: set-openai-key
-UPDATE ai_providers 
-SET config = jsonb_set(
-    COALESCE(config, '{}'::jsonb),
-    '{api_key}', 
-    to_jsonb($1::text)
-) 
-WHERE provider = 'openai';
+-- name: update-provider-config
+UPDATE ai_providers SET config = $1::jsonb, updated_at = now() WHERE is_default = true;


### PR DESCRIPTION
## Summary

The AI Assist feature currently hardcodes `api.openai.com` and `gpt-4o-mini`, with only the API key editable via an inline popup. This makes it unusable with alternative providers or self-hosted models.

This PR adds admin-configurable **endpoint URL** and **model** fields alongside the existing API key, so any OpenAI-compatible API can be used — including self-hosted models (vLLM, Ollama, llama.cpp), alternative providers (Groq, Together AI, Mistral), or proxied endpoints.

## Changes

**Backend** (4 files):
- `internal/ai/openai.go` — Configurable `endpointURL` and `model` fields with sensible defaults (`api.openai.com`, `gpt-4o-mini`). HTTP timeout increased from 10s to 30s (self-hosted models and some providers can exceed 10s for completions).
- `internal/ai/ai.go` — New `GetProvider()` method for reading config (sanitized, no decrypted key). `UpdateProvider()` extended with `endpointURL`/`model` params and server-side URL validation. Read-modify-write pattern preserves existing encrypted API key when only changing endpoint or model.
- `internal/ai/queries.sql` — Replace `set-openai-key` with `update-provider-config` (full JSONB write with `updated_at`).
- `cmd/ai.go` + `cmd/handlers.go` — New `GET /api/v1/ai/provider` endpoint (requires `ai:manage`), extended PUT payload with optional `endpoint_url` and `model` fields.

**Frontend** (6 files):
- New admin settings page at **Admin → Integrations → AI Assist** (`AISettings.vue`, `AISettingsForm.vue`, `formSchema.js`).
- Endpoint URL, model, and API key fields with Zod validation (URL format when non-empty).
- Green "API key is configured" indicator when a key exists.
- Link from the existing inline API key dialog in `ReplyBox.vue` to the new settings page ("For advanced setup").
- `navigation.js` — AI Assist item added under Integrations.
- `router/index.js` — `/admin/ai` route.

**i18n** (1 file):
- 9 new keys in `en.json` for the settings UI.

## Backwards compatibility

- **No database migration needed.** The existing JSONB `config` column on `ai_providers` absorbs the new fields (`endpoint_url`, `model`) naturally. Go code defaults handle missing fields on existing installs — behaviour is identical to current upstream when fields are empty.
- **No breaking API change.** The PUT endpoint accepts `endpoint_url` and `model` as optional fields. Existing API callers sending only `{provider, api_key}` continue to work unchanged.
- **Existing inline API key dialog still works.** The new admin page is an addition, not a replacement.

## Screenshots

The new admin settings page follows the existing LibreDesk admin page patterns (AdminPageWithHelp layout, vee-validate + Zod, same component library).

## Test plan

- [ ] Fresh install: verify AI Assist works with default OpenAI endpoint after entering only an API key
- [ ] Existing install: verify upgrade with no migration, existing API key preserved
- [ ] Set custom endpoint URL and model, verify completions use the configured endpoint
- [ ] Leave endpoint/model empty, verify defaults (api.openai.com, gpt-4o-mini) are used
- [ ] Update only endpoint/model without re-entering API key, verify key is preserved
- [ ] Enter invalid URL (no http/https prefix), verify server-side validation rejects it
- [ ] Verify "advanced setup" link appears in ReplyBox inline dialog
- [ ] Verify AI Assist navigation item appears under Admin → Integrations