### PR TITLE
Fix whitespace in HTML emails by removing unnecessary whitespace class

### DIFF
--- a/frontend/src/features/conversation/message/MessageBubble.vue
+++ b/frontend/src/features/conversation/message/MessageBubble.vue
@@ -57,7 +57,7 @@
             v-else
             :html="sanitizedContent"
             :allowedSchemas="['cid', 'https', 'http', 'mailto']"
-            class="mb-1 native-html whitespace-pre-wrap break-words"
+            class="mb-1 native-html break-words"
             :class="{ 'mb-3': message.attachments.length > 0 }"
           />
 


### PR DESCRIPTION
## Summary
- Removed `whitespace-pre-wrap` from the HTML message content container in `MessageBubble.vue`, which was causing incorrect whitespace rendering in HTML emails (e.g., excessive line breaks or collapsed layouts)
- HTML emails already define their own whitespace handling via inline styles; the Tailwind `whitespace-pre-wrap` class was overriding that and producing visual artifacts

## Test plan
- [ ] Open a conversation containing an HTML email and verify whitespace renders correctly
- [ ] Verify plain text messages still display with proper line breaks
- [ ] Check emails with mixed content (attachments + HTML body) for correct spacing