### PR TITLE
Fix: evaluate automation rules for API-created conversations

### DIFF
--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -824,10 +824,11 @@ func handleCreateConversation(r *fastglue.Request) error {
 		app.conversation.UpdateConversationUserAssignee(conversationUUID, req.AssignedAgentID, user)
 	}
 
-	// Trigger webhook event for conversation created.
+	// Trigger webhook event and evaluate automation rules for the new conversation.
 	conversation, err := app.conversation.GetConversation(conversationID, "", "")
 	if err == nil {
 		app.webhook.TriggerEvent(wmodels.EventConversationCreated, conversation)
+		app.automation.EvaluateNewConversationRules(conversation)
 	}
 
 	return r.SendEnvelope(conversation)


### PR DESCRIPTION
## Summary

Conversations created via `POST /api/v1/conversations` (e.g. from external integrations, email workers, or webhook-based form submissions) are not evaluated against automation rules. Only conversations created through the incoming message flow trigger `EvaluateNewConversationRules`.

This adds the missing call in `handleCreateConversation`, matching the existing behaviour in the incoming message handler (`internal/conversation/message.go`).

## The bug

In `cmd/conversation.go`, `handleCreateConversation` triggers the webhook event but does not call `EvaluateNewConversationRules`:

```go
// Before (line 827-831)
conversation, err := app.conversation.GetConversation(conversationID, "", "")
if err == nil {
    app.webhook.TriggerEvent(wmodels.EventConversationCreated, conversation)
}
```

Compare to `internal/conversation/message.go` (line 776-782), which does both:

```go
if isNewConversation {
    conversation, err := m.GetConversation(in.Message.ConversationID, "", "")
    if err == nil {
        m.webhookStore.TriggerEvent(wmodels.EventConversationCreated, conversation)
        m.automation.EvaluateNewConversationRules(conversation)
    }
}
```

## The fix

One-line addition after the webhook trigger:

```go
app.automation.EvaluateNewConversationRules(conversation)
```

## How we found it

We have a `new_conversation` automation rule that auto-closes tickets from known spam domains using the `contains` operator on `contact_email`. It never fired. Tracing through the code, we found that all our inbound tickets arrive via the API (Cloudflare email worker and Gravity Forms webhooks), which bypasses the automation engine entirely.