### PR TITLE
fix: use standard IMAP SEARCH instead of ESEARCH to avoid UID/seqnum mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ uploads
 .env
 dist/
 .vscode/
+.cursor/

--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -182,6 +182,18 @@ func initHandlers(g *fastglue.Fastglue, hub *ws.Hub) {
 	g.PUT("/api/v1/roles/{id}", perm(handleUpdateRole, "roles:manage"))
 	g.DELETE("/api/v1/roles/{id}", perm(handleDeleteRole, "roles:manage"))
 
+	// Integrations.
+	g.GET("/api/v1/integrations", perm(handleGetIntegrations, "integrations:manage"))
+	g.GET("/api/v1/integrations/shopify/customer", perm(handleGetShopifyCustomer, "conversations:read"))
+	g.GET("/api/v1/integrations/shopify/oauth/authorize", perm(handleShopifyOAuthAuthorize, "integrations:manage"))
+	g.GET("/api/v1/integrations/shopify/oauth/callback", handleShopifyOAuthCallback)
+	g.GET("/api/v1/integrations/{provider}", perm(handleGetIntegration, "integrations:manage"))
+	g.POST("/api/v1/integrations", perm(handleCreateIntegration, "integrations:manage"))
+	g.PUT("/api/v1/integrations/{provider}", perm(handleUpdateIntegration, "integrations:manage"))
+	g.DELETE("/api/v1/integrations/{provider}", perm(handleDeleteIntegration, "integrations:manage"))
+	g.PUT("/api/v1/integrations/{provider}/toggle", perm(handleToggleIntegration, "integrations:manage"))
+	g.POST("/api/v1/integrations/{provider}/test", perm(handleTestIntegration, "integrations:manage"))
+
 	// Webhooks.
 	g.GET("/api/v1/webhooks", perm(handleGetWebhooks, "webhooks:manage"))
 	g.GET("/api/v1/webhooks/{id}", perm(handleGetWebhook, "webhooks:manage"))

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -27,6 +27,7 @@ import (
 	"github.com/abhinavxd/libredesk/internal/csat"
 	customAttribute "github.com/abhinavxd/libredesk/internal/custom_attribute"
 	"github.com/abhinavxd/libredesk/internal/importer"
+	"github.com/abhinavxd/libredesk/internal/integration"
 	"github.com/abhinavxd/libredesk/internal/inbox"
 	"github.com/abhinavxd/libredesk/internal/inbox/channel/email"
 	imodels "github.com/abhinavxd/libredesk/internal/inbox/models"
@@ -938,6 +939,21 @@ func initWebhook(db *sqlx.DB, i18n *i18n.I18n) *webhook.Manager {
 	})
 	if err != nil {
 		log.Fatalf("error initializing webhook manager: %v", err)
+	}
+	return m
+}
+
+// initIntegration initializes the integration manager.
+func initIntegration(db *sqlx.DB, i18n *i18n.I18n) *integration.Manager {
+	var lo = initLogger("integration")
+	m, err := integration.New(integration.Opts{
+		DB:            db,
+		Lo:            lo,
+		I18n:          i18n,
+		EncryptionKey: ko.MustString("app.encryption_key"),
+	})
+	if err != nil {
+		log.Fatalf("error initializing integration manager: %v", err)
 	}
 	return m
 }

--- a/cmd/integration.go
+++ b/cmd/integration.go
@@ -1,0 +1,391 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/abhinavxd/libredesk/internal/envelope"
+	imodels "github.com/abhinavxd/libredesk/internal/integration/models"
+	"github.com/abhinavxd/libredesk/internal/stringutil"
+	"github.com/valyala/fasthttp"
+	"github.com/zerodha/fastglue"
+)
+
+// handleGetIntegrations returns all integrations.
+func handleGetIntegrations(r *fastglue.Request) error {
+	app := r.Context.(*App)
+	out, err := app.integration.GetAll()
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	for i := range out {
+		maskSecrets(&out[i])
+	}
+	return r.SendEnvelope(out)
+}
+
+// handleGetIntegration returns a single integration by provider.
+func handleGetIntegration(r *fastglue.Request) error {
+	app := r.Context.(*App)
+	provider := r.RequestCtx.UserValue("provider").(string)
+	if provider == "" {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.invalid", "name", "`provider`"), nil, envelope.InputError)
+	}
+
+	intg, err := app.integration.Get(provider)
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	maskSecrets(&intg)
+	return r.SendEnvelope(intg)
+}
+
+// handleCreateIntegration creates or updates an integration.
+// It merges the incoming config with any existing config so that
+// fields like access_token (set via OAuth) are not wiped out.
+func handleCreateIntegration(r *fastglue.Request) error {
+	app := r.Context.(*App)
+	var intg imodels.Integration
+	if err := r.Decode(&intg, "json"); err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.errorParsing", "name", "{globals.terms.request}"), err.Error(), envelope.InputError)
+	}
+	if intg.Provider == "" {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.empty", "name", "`provider`"), nil, envelope.InputError)
+	}
+
+	intg.Config = mergeWithExistingConfig(app, intg.Provider, intg.Config)
+
+	result, err := app.integration.Upsert(intg)
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	maskSecrets(&result)
+	return r.SendEnvelope(result)
+}
+
+// handleUpdateIntegration updates an existing integration.
+func handleUpdateIntegration(r *fastglue.Request) error {
+	app := r.Context.(*App)
+	provider := r.RequestCtx.UserValue("provider").(string)
+	if provider == "" {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.invalid", "name", "`provider`"), nil, envelope.InputError)
+	}
+
+	var intg imodels.Integration
+	if err := r.Decode(&intg, "json"); err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.errorParsing", "name", "{globals.terms.request}"), err.Error(), envelope.InputError)
+	}
+	intg.Provider = provider
+	intg.Config = mergeWithExistingConfig(app, provider, intg.Config)
+
+	result, err := app.integration.Upsert(intg)
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	maskSecrets(&result)
+	return r.SendEnvelope(result)
+}
+
+// handleDeleteIntegration deletes an integration.
+func handleDeleteIntegration(r *fastglue.Request) error {
+	app := r.Context.(*App)
+	provider := r.RequestCtx.UserValue("provider").(string)
+	if provider == "" {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.invalid", "name", "`provider`"), nil, envelope.InputError)
+	}
+	if err := app.integration.Delete(provider); err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	return r.SendEnvelope(true)
+}
+
+// handleToggleIntegration toggles the enabled status.
+func handleToggleIntegration(r *fastglue.Request) error {
+	app := r.Context.(*App)
+	provider := r.RequestCtx.UserValue("provider").(string)
+	if provider == "" {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.invalid", "name", "`provider`"), nil, envelope.InputError)
+	}
+	result, err := app.integration.Toggle(provider)
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	maskSecrets(&result)
+	return r.SendEnvelope(result)
+}
+
+// handleTestIntegration tests the connection for a provider.
+func handleTestIntegration(r *fastglue.Request) error {
+	app := r.Context.(*App)
+	provider := r.RequestCtx.UserValue("provider").(string)
+
+	switch provider {
+	case "shopify":
+		return handleTestShopifyConnection(r, app)
+	default:
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "unsupported integration provider", nil, envelope.InputError)
+	}
+}
+
+// handleTestShopifyConnection tests the Shopify API credentials.
+func handleTestShopifyConnection(r *fastglue.Request, app *App) error {
+	intg, err := app.integration.Get("shopify")
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+
+	cfg, err := parseShopifyConfig(intg.Config)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "invalid Shopify configuration", nil, envelope.InputError)
+	}
+
+	shopName, err := app.shopify.TestConnection(cfg.StoreURL, cfg.AccessToken)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadGateway, err.Error(), nil, envelope.GeneralError)
+	}
+
+	return r.SendEnvelope(map[string]string{"shop_name": shopName})
+}
+
+// handleGetShopifyCustomer looks up a Shopify customer by email.
+func handleGetShopifyCustomer(r *fastglue.Request) error {
+	app := r.Context.(*App)
+	email := string(r.RequestCtx.QueryArgs().Peek("email"))
+	if email == "" {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.empty", "name", "`email`"), nil, envelope.InputError)
+	}
+
+	intg, err := app.integration.Get("shopify")
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	if !intg.Enabled {
+		return r.SendErrorEnvelope(fasthttp.StatusNotFound, "Shopify integration is disabled", nil, envelope.NotFoundError)
+	}
+
+	cfg, err := parseShopifyConfig(intg.Config)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "invalid Shopify configuration", nil, envelope.GeneralError)
+	}
+
+	result, err := app.shopify.LookupCustomer(cfg.StoreURL, cfg.AccessToken, email)
+	if err != nil {
+		app.lo.Error("error looking up Shopify customer", "email", email, "error", err)
+		return r.SendErrorEnvelope(fasthttp.StatusBadGateway, "error contacting Shopify", nil, envelope.GeneralError)
+	}
+
+	return r.SendEnvelope(result)
+}
+
+// handleShopifyOAuthAuthorize builds the Shopify OAuth authorize URL and returns it.
+func handleShopifyOAuthAuthorize(r *fastglue.Request) error {
+	app := r.Context.(*App)
+
+	intg, err := app.integration.Get("shopify")
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	cfg, err := parseShopifyConfig(intg.Config)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "invalid Shopify configuration", nil, envelope.InputError)
+	}
+	if cfg.StoreURL == "" || cfg.APIKey == "" {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, "store URL and API key are required before authorizing", nil, envelope.InputError)
+	}
+
+	rootURL, err := app.setting.GetAppRootURL()
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, "unable to determine app root URL", nil, envelope.GeneralError)
+	}
+
+	redirectURI := rootURL + "/api/v1/integrations/shopify/oauth/callback"
+	scopes := "read_customers,read_orders"
+
+	authURL := fmt.Sprintf("https://%s/admin/oauth/authorize?client_id=%s&scope=%s&redirect_uri=%s",
+		cfg.StoreURL,
+		url.QueryEscape(cfg.APIKey),
+		url.QueryEscape(scopes),
+		url.QueryEscape(redirectURI))
+
+	return r.SendEnvelope(map[string]string{"authorize_url": authURL})
+}
+
+// handleShopifyOAuthCallback handles the redirect from Shopify after the merchant approves.
+// This is a public endpoint (no auth) because Shopify redirects the browser here.
+func handleShopifyOAuthCallback(r *fastglue.Request) error {
+	app := r.Context.(*App)
+
+	code := string(r.RequestCtx.QueryArgs().Peek("code"))
+	shop := string(r.RequestCtx.QueryArgs().Peek("shop"))
+	providedHMAC := string(r.RequestCtx.QueryArgs().Peek("hmac"))
+
+	if code == "" || shop == "" {
+		r.RequestCtx.SetStatusCode(fasthttp.StatusBadRequest)
+		r.RequestCtx.SetBodyString("Missing code or shop parameter")
+		return nil
+	}
+
+	intg, err := app.integration.Get("shopify")
+	if err != nil {
+		r.RequestCtx.SetStatusCode(fasthttp.StatusInternalServerError)
+		r.RequestCtx.SetBodyString("Shopify integration not configured")
+		return nil
+	}
+	cfg, err := parseShopifyConfig(intg.Config)
+	if err != nil || cfg.APISecret == "" {
+		r.RequestCtx.SetStatusCode(fasthttp.StatusInternalServerError)
+		r.RequestCtx.SetBodyString("Invalid Shopify configuration")
+		return nil
+	}
+
+	// Verify HMAC signature from Shopify.
+	if providedHMAC != "" {
+		if !verifyShopifyHMAC(r, cfg.APISecret, providedHMAC) {
+			r.RequestCtx.SetStatusCode(fasthttp.StatusForbidden)
+			r.RequestCtx.SetBodyString("HMAC verification failed")
+			return nil
+		}
+	}
+
+	// Exchange the code for a permanent access token.
+	accessToken, err := app.shopify.ExchangeOAuthToken(cfg.StoreURL, cfg.APIKey, cfg.APISecret, code)
+	if err != nil {
+		app.lo.Error("error exchanging Shopify OAuth code", "error", err)
+		r.RequestCtx.SetStatusCode(fasthttp.StatusBadGateway)
+		r.RequestCtx.SetBodyString("Failed to exchange OAuth code: " + err.Error())
+		return nil
+	}
+
+	// Update the integration with the access token.
+	cfgMap := map[string]interface{}{
+		"store_url":    cfg.StoreURL,
+		"api_key":      cfg.APIKey,
+		"api_secret":   cfg.APISecret,
+		"access_token": accessToken,
+	}
+	cfgJSON, _ := json.Marshal(cfgMap)
+	intg.Config = cfgJSON
+	intg.Enabled = true
+	if _, err := app.integration.Upsert(intg); err != nil {
+		app.lo.Error("error saving Shopify access token", "error", err)
+		r.RequestCtx.SetStatusCode(fasthttp.StatusInternalServerError)
+		r.RequestCtx.SetBodyString("Failed to save access token")
+		return nil
+	}
+
+	// Redirect the admin back to the Shopify integration page.
+	rootURL, _ := app.setting.GetAppRootURL()
+	redirectTo := rootURL + "/admin/integrations/shopify?oauth=success"
+	r.RequestCtx.Redirect(redirectTo, fasthttp.StatusFound)
+	return nil
+}
+
+// verifyShopifyHMAC validates the HMAC signature from a Shopify OAuth callback.
+func verifyShopifyHMAC(r *fastglue.Request, apiSecret, providedHMAC string) bool {
+	args := r.RequestCtx.QueryArgs()
+	params := make(map[string]string)
+	args.VisitAll(func(key, value []byte) {
+		k := string(key)
+		if k != "hmac" {
+			params[k] = string(value)
+		}
+	})
+
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var parts []string
+	for _, k := range keys {
+		parts = append(parts, k+"="+params[k])
+	}
+	message := strings.Join(parts, "&")
+
+	mac := hmac.New(sha256.New, []byte(apiSecret))
+	mac.Write([]byte(message))
+	computed := hex.EncodeToString(mac.Sum(nil))
+
+	return hmac.Equal([]byte(computed), []byte(providedHMAC))
+}
+
+// shopifyConfig holds the parsed Shopify integration config.
+type shopifyConfig struct {
+	StoreURL    string `json:"store_url"`
+	APIKey      string `json:"api_key"`
+	APISecret   string `json:"api_secret"`
+	AccessToken string `json:"access_token"`
+}
+
+func parseShopifyConfig(raw json.RawMessage) (shopifyConfig, error) {
+	var cfg shopifyConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+// maskSecrets replaces secret values in the config with dummy strings.
+func maskSecrets(intg *imodels.Integration) {
+	secretKeys := map[string][]string{
+		"shopify": {"access_token", "api_secret"},
+	}
+	keys, ok := secretKeys[intg.Provider]
+	if !ok {
+		return
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(intg.Config, &cfg); err != nil {
+		return
+	}
+	for _, k := range keys {
+		if val, exists := cfg[k]; exists {
+			if s, ok := val.(string); ok && s != "" {
+				cfg[k] = strings.Repeat(stringutil.PasswordDummy, 10)
+			}
+		}
+	}
+	if b, err := json.Marshal(cfg); err == nil {
+		intg.Config = b
+	}
+}
+
+// mergeWithExistingConfig loads the current config from DB and merges new values on top,
+// preserving fields (like access_token) that the caller didn't provide.
+func mergeWithExistingConfig(app *App, provider string, incoming json.RawMessage) json.RawMessage {
+	existing, err := app.integration.Get(provider)
+	if err != nil {
+		return incoming
+	}
+
+	var base map[string]interface{}
+	if err := json.Unmarshal(existing.Config, &base); err != nil {
+		return incoming
+	}
+
+	var overlay map[string]interface{}
+	if err := json.Unmarshal(incoming, &overlay); err != nil {
+		return incoming
+	}
+
+	for k, v := range overlay {
+		if s, ok := v.(string); ok && s == "" {
+			continue
+		}
+		base[k] = v
+	}
+
+	merged, err := json.Marshal(base)
+	if err != nil {
+		return incoming
+	}
+	return merged
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,6 +44,8 @@ import (
 	"github.com/abhinavxd/libredesk/internal/team"
 	"github.com/abhinavxd/libredesk/internal/template"
 	"github.com/abhinavxd/libredesk/internal/user"
+	"github.com/abhinavxd/libredesk/internal/integration"
+	shopifyclient "github.com/abhinavxd/libredesk/internal/integration/shopify"
 	"github.com/abhinavxd/libredesk/internal/webhook"
 	"github.com/knadh/go-i18n"
 	"github.com/knadh/koanf/v2"
@@ -103,6 +105,8 @@ type App struct {
 	customAttribute  *customAttribute.Manager
 	report           *report.Manager
 	webhook          *webhook.Manager
+	integration      *integration.Manager
+	shopify          *shopifyclient.Client
 	importer         *importer.Importer
 
 	// Global state that stores data on an available app update.
@@ -271,6 +275,8 @@ func main() {
 		macro:            initMacro(db, i18n),
 		ai:               initAI(db, i18n),
 		webhook:          webhook,
+		integration:      initIntegration(db, i18n),
+		shopify:          shopifyclient.New(lo),
 	}
 	app.consts.Store(constants)
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -40,6 +40,7 @@ var migList = []migFunc{
 	{"v0.9.1", migrations.V0_9_1},
 	{"v0.10.0", migrations.V0_10_0},
 	{"v1.0.1", migrations.V1_0_1},
+	{"v1.0.4", migrations.V1_0_4},
 }
 
 // upgrade upgrades the database to the current version by running SQL migration files

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -141,6 +141,7 @@ import { useMacroStore } from '@/stores/macro'
 import { useSharedViewStore } from '@/stores/sharedView'
 import { useTagStore } from '@/stores/tag'
 import { useCustomAttributeStore } from '@/stores/customAttributes'
+import { useIntegrationStore } from '@/stores/integration'
 import { useIdleDetection } from '@/composables/useIdleDetection'
 import PageHeader from './components/layout/PageHeader.vue'
 import ViewForm from '@/features/view/ViewForm.vue'
@@ -180,6 +181,7 @@ const macroStore = useMacroStore()
 const sharedViewStore = useSharedViewStore()
 const tagStore = useTagStore()
 const customAttributeStore = useCustomAttributeStore()
+const integrationStore = useIntegrationStore()
 const userViews = ref([])
 const view = ref({})
 const openCreateViewForm = ref(false)
@@ -212,7 +214,8 @@ const initStores = async () => {
     slaStore.fetchSlas(),
     macroStore.loadMacros(),
     tagStore.fetchTags(),
-    customAttributeStore.fetchCustomAttributes()
+    customAttributeStore.fetchCustomAttributes(),
+    integrationStore.fetchIntegrations()
   ])
 }
 

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -445,6 +445,24 @@ const createContactNote = (id, data) => http.post(`/api/v1/contacts/${id}/notes`
 })
 const deleteContactNote = (id, noteId) => http.delete(`/api/v1/contacts/${id}/notes/${noteId}`)
 const getActivityLogs = (params) => http.get('/api/v1/activity-logs', { params })
+// Integrations.
+const getIntegrations = () => http.get('/api/v1/integrations')
+const getIntegration = (provider) => http.get(`/api/v1/integrations/${provider}`)
+const createIntegration = (data) =>
+  http.post('/api/v1/integrations', data, {
+    headers: { 'Content-Type': 'application/json' }
+  })
+const updateIntegration = (provider, data) =>
+  http.put(`/api/v1/integrations/${provider}`, data, {
+    headers: { 'Content-Type': 'application/json' }
+  })
+const deleteIntegration = (provider) => http.delete(`/api/v1/integrations/${provider}`)
+const toggleIntegration = (provider) => http.put(`/api/v1/integrations/${provider}/toggle`)
+const testIntegration = (provider) => http.post(`/api/v1/integrations/${provider}/test`)
+const getShopifyCustomer = (email) =>
+  http.get('/api/v1/integrations/shopify/customer', { params: { email } })
+const getShopifyOAuthURL = () => http.get('/api/v1/integrations/shopify/oauth/authorize')
+
 const getWebhooks = () => http.get('/api/v1/webhooks')
 const getWebhook = (id) => http.get(`/api/v1/webhooks/${id}`)
 const createWebhook = (data) =>
@@ -646,5 +664,14 @@ export default {
   markNotificationAsRead,
   markAllNotificationsAsRead,
   deleteNotification,
-  deleteAllNotifications
+  deleteAllNotifications,
+  getIntegrations,
+  getIntegration,
+  createIntegration,
+  updateIntegration,
+  deleteIntegration,
+  toggleIntegration,
+  testIntegration,
+  getShopifyCustomer,
+  getShopifyOAuthURL
 }

--- a/frontend/src/constants/navigation.js
+++ b/frontend/src/constants/navigation.js
@@ -166,6 +166,11 @@ export const adminNavItems = [
         href: '/admin/webhooks',
         permission: 'webhooks:manage',
         isTitleKeyPlural: true
+      },
+      {
+        titleKey: 'Shopify',
+        href: '/admin/integrations/shopify',
+        permission: 'integrations:manage'
       }
     ]
   }

--- a/frontend/src/features/conversation/sidebar/ConversationSideBar.vue
+++ b/frontend/src/features/conversation/sidebar/ConversationSideBar.vue
@@ -2,6 +2,20 @@
   <div>
     <ConversationSideBarContact class="p-4" />
     <Accordion type="multiple" collapsible v-model="accordionState">
+      <!-- Shopify customer data -->
+      <AccordionItem
+        v-if="integrationStore.shopifyEnabled"
+        value="shopify"
+        class="accordion-item"
+      >
+        <AccordionTrigger class="accordion-trigger">
+          Shopify
+        </AccordionTrigger>
+        <AccordionContent class="accordion-content">
+          <ShopifyCustomerPanel />
+        </AccordionContent>
+      </AccordionItem>
+
       <AccordionItem value="actions" class="accordion-item">
         <AccordionTrigger class="accordion-trigger">
           {{ $t('globals.terms.action', 2) }}
@@ -119,10 +133,13 @@ import { useStorage } from '@vueuse/core'
 import CustomAttributes from '@/features/conversation/sidebar/CustomAttributes.vue'
 import { useCustomAttributeStore } from '@/stores/customAttributes'
 import PreviousConversations from '@/features/conversation/sidebar/PreviousConversations.vue'
+import ShopifyCustomerPanel from '@/features/conversation/sidebar/ShopifyCustomerPanel.vue'
+import { useIntegrationStore } from '@/stores/integration'
 import SelectComboBox from '@/components/combobox/SelectCombobox.vue'
 import api from '@/api'
 
 const customAttributeStore = useCustomAttributeStore()
+const integrationStore = useIntegrationStore()
 const emitter = useEmitter()
 const conversationStore = useConversationStore()
 const usersStore = useUsersStore()

--- a/frontend/src/features/conversation/sidebar/ShopifyCustomerPanel.vue
+++ b/frontend/src/features/conversation/sidebar/ShopifyCustomerPanel.vue
@@ -1,0 +1,227 @@
+<template>
+  <div v-if="integrationStore.shopifyEnabled">
+    <!-- Loading skeleton -->
+    <div v-if="integrationStore.shopifyLoading" class="space-y-3">
+      <Skeleton class="h-4 w-3/4" />
+      <Skeleton class="h-4 w-1/2" />
+      <Skeleton class="h-4 w-2/3" />
+    </div>
+
+    <!-- Customer not found -->
+    <div
+      v-else-if="integrationStore.shopifyCustomer && !integrationStore.shopifyCustomer.found"
+      class="text-sm text-muted-foreground"
+    >
+      No Shopify customer found for this email.
+    </div>
+
+    <!-- Error -->
+    <div
+      v-else-if="integrationStore.shopifyError"
+      class="text-sm text-muted-foreground"
+    >
+      Could not load Shopify data.
+    </div>
+
+    <!-- Customer data -->
+    <div v-else-if="customer" class="space-y-4 text-sm">
+      <!-- Profile header -->
+      <div class="space-y-1.5">
+        <div class="flex items-center gap-2">
+          <span class="font-medium">
+            {{ customer.first_name }} {{ customer.last_name }}
+          </span>
+        </div>
+        <Badge variant="secondary" class="text-xs">
+          {{ isReturning ? 'Returning customer' : 'New customer' }}
+        </Badge>
+        <div class="text-muted-foreground text-xs">
+          Customer for {{ customerTenure }}
+        </div>
+      </div>
+
+      <!-- Stats -->
+      <div class="grid grid-cols-2 gap-3">
+        <div class="rounded-md bg-muted/50 p-2">
+          <div class="text-xs text-muted-foreground">Lifetime spend</div>
+          <div class="font-medium text-sm">
+            {{ formatMoney(customer.total_spent, customer.currency_code) }}
+          </div>
+        </div>
+        <div class="rounded-md bg-muted/50 p-2">
+          <div class="text-xs text-muted-foreground">Orders</div>
+          <div class="font-medium text-sm">{{ customer.number_of_orders }}</div>
+        </div>
+      </div>
+
+      <!-- Location -->
+      <div v-if="customer.default_address" class="flex items-start gap-2 text-muted-foreground">
+        <MapPin class="h-4 w-4 shrink-0 mt-0.5" />
+        <span>
+          {{ locationString }}
+        </span>
+      </div>
+
+      <!-- Recent orders -->
+      <div v-if="orders.length > 0">
+        <div class="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+          Recent orders
+        </div>
+        <div class="space-y-2">
+          <div
+            v-for="order in orders"
+            :key="order.id"
+            class="rounded-md border p-2.5 space-y-1.5"
+          >
+            <div class="flex items-center justify-between">
+              <span class="font-medium text-xs">{{ order.name }}</span>
+              <span class="text-xs text-muted-foreground">
+                {{ formatDate(order.created_at) }}
+              </span>
+            </div>
+            <div class="flex items-center gap-1.5 flex-wrap">
+              <Badge
+                :variant="financialBadgeVariant(order.financial_status)"
+                class="text-[10px] px-1.5 py-0"
+              >
+                {{ formatStatus(order.financial_status) }}
+              </Badge>
+              <Badge
+                v-if="order.fulfillment_status"
+                variant="outline"
+                class="text-[10px] px-1.5 py-0"
+              >
+                {{ formatStatus(order.fulfillment_status) }}
+              </Badge>
+              <span class="ml-auto text-xs font-medium">
+                {{ formatMoney(order.total_price, order.currency_code) }}
+              </span>
+            </div>
+
+            <!-- Line items (collapsed by default) -->
+            <details v-if="order.line_items && order.line_items.length > 0" class="mt-1">
+              <summary class="text-xs text-muted-foreground cursor-pointer hover:text-foreground">
+                {{ order.line_items.length }} item{{ order.line_items.length !== 1 ? 's' : '' }}
+              </summary>
+              <div class="mt-1.5 space-y-1.5">
+                <div
+                  v-for="(item, idx) in order.line_items"
+                  :key="idx"
+                  class="flex items-center gap-2"
+                >
+                  <img
+                    v-if="item.image_url"
+                    :src="item.image_url"
+                    :alt="item.title"
+                    class="h-8 w-8 rounded object-cover shrink-0"
+                  />
+                  <div
+                    v-else
+                    class="h-8 w-8 rounded bg-muted flex items-center justify-center shrink-0"
+                  >
+                    <Package class="h-4 w-4 text-muted-foreground" />
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <div class="text-xs truncate">{{ item.title }}</div>
+                    <div class="text-[10px] text-muted-foreground">
+                      Qty: {{ item.quantity }}
+                      <span v-if="item.price"> &middot; {{ formatMoney(item.price, order.currency_code) }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </details>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, watch } from 'vue'
+import { useConversationStore } from '@/stores/conversation'
+import { useIntegrationStore } from '@/stores/integration'
+import { Badge } from '@/components/ui/badge'
+import { Skeleton } from '@/components/ui/skeleton'
+import { MapPin, Package } from 'lucide-vue-next'
+
+const conversationStore = useConversationStore()
+const integrationStore = useIntegrationStore()
+
+const customer = computed(() => integrationStore.shopifyCustomer?.customer)
+const orders = computed(() => integrationStore.shopifyCustomer?.orders || [])
+
+const isReturning = computed(() => {
+  const count = parseInt(customer.value?.number_of_orders || '0', 10)
+  return count > 1
+})
+
+const customerTenure = computed(() => {
+  if (!customer.value?.created_at) return ''
+  const created = new Date(customer.value.created_at)
+  const now = new Date()
+  const diffMs = now - created
+  const days = Math.floor(diffMs / (1000 * 60 * 60 * 24))
+  if (days < 1) return 'less than a day'
+  if (days === 1) return '1 day'
+  if (days < 30) return `${days} days`
+  const months = Math.floor(days / 30)
+  if (months < 12) return `about ${months} month${months !== 1 ? 's' : ''}`
+  const years = Math.floor(months / 12)
+  const rem = months % 12
+  if (rem === 0) return `${years} year${years !== 1 ? 's' : ''}`
+  return `${years} year${years !== 1 ? 's' : ''}, ${rem} month${rem !== 1 ? 's' : ''}`
+})
+
+const locationString = computed(() => {
+  const a = customer.value?.default_address
+  if (!a) return ''
+  const parts = [a.city, a.province, a.country].filter(Boolean)
+  return parts.join(', ')
+})
+
+const formatMoney = (amount, currency) => {
+  if (!amount) return '$0.00'
+  const num = parseFloat(amount)
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency || 'USD'
+    }).format(num)
+  } catch {
+    return `$${num.toFixed(2)}`
+  }
+}
+
+const formatDate = (dateStr) => {
+  if (!dateStr) return ''
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+const formatStatus = (status) => {
+  if (!status) return ''
+  return status.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+const financialBadgeVariant = (status) => {
+  if (!status) return 'secondary'
+  const s = status.toLowerCase()
+  if (s === 'paid') return 'default'
+  if (s === 'refunded' || s === 'voided') return 'destructive'
+  return 'secondary'
+}
+
+watch(
+  () => conversationStore.current?.contact?.email,
+  (email) => {
+    if (email && integrationStore.shopifyEnabled) {
+      integrationStore.fetchShopifyCustomer(email)
+    } else {
+      integrationStore.clearShopifyCustomer()
+    }
+  },
+  { immediate: true }
+)
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -454,6 +454,12 @@ const routes = [
             ]
           },
           {
+            path: 'integrations/shopify',
+            name: 'shopify-integration',
+            component: () => import('@/views/admin/integrations/ShopifyIntegrationView.vue'),
+            meta: { title: 'Shopify Integration' }
+          },
+          {
             path: 'conversations',
             meta: { title: 'Conversations' },
             children: [

--- a/frontend/src/stores/integration.js
+++ b/frontend/src/stores/integration.js
@@ -1,0 +1,72 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import api from '@/api'
+
+export const useIntegrationStore = defineStore('integration', () => {
+  const integrations = ref([])
+  const shopifyCustomer = ref(null)
+  const shopifyLoading = ref(false)
+  const shopifyError = ref(null)
+  const customerCache = ref({})
+
+  const shopifyEnabled = computed(() => {
+    const shopify = integrations.value.find((i) => i.provider === 'shopify')
+    return shopify?.enabled ?? false
+  })
+
+  const shopifyConfigured = computed(() => {
+    return integrations.value.some((i) => i.provider === 'shopify')
+  })
+
+  async function fetchIntegrations() {
+    try {
+      const resp = await api.getIntegrations()
+      integrations.value = resp.data.data || []
+    } catch {
+      integrations.value = []
+    }
+  }
+
+  async function fetchShopifyCustomer(email) {
+    if (!email || !shopifyEnabled.value) {
+      shopifyCustomer.value = null
+      return
+    }
+
+    if (customerCache.value[email]) {
+      shopifyCustomer.value = customerCache.value[email]
+      return
+    }
+
+    shopifyLoading.value = true
+    shopifyError.value = null
+    try {
+      const resp = await api.getShopifyCustomer(email)
+      const data = resp.data.data
+      shopifyCustomer.value = data
+      customerCache.value[email] = data
+    } catch (err) {
+      shopifyError.value = err
+      shopifyCustomer.value = null
+    } finally {
+      shopifyLoading.value = false
+    }
+  }
+
+  function clearShopifyCustomer() {
+    shopifyCustomer.value = null
+    shopifyError.value = null
+  }
+
+  return {
+    integrations,
+    shopifyEnabled,
+    shopifyConfigured,
+    shopifyCustomer,
+    shopifyLoading,
+    shopifyError,
+    fetchIntegrations,
+    fetchShopifyCustomer,
+    clearShopifyCustomer
+  }
+})

--- a/frontend/src/views/admin/integrations/ShopifyIntegrationView.vue
+++ b/frontend/src/views/admin/integrations/ShopifyIntegrationView.vue
@@ -1,0 +1,309 @@
+<template>
+  <AdminPageWithHelp>
+    <template #content>
+      <Spinner v-if="pageLoading" />
+      <div v-else>
+        <div class="space-y-6">
+          <div>
+            <h3 class="text-lg font-medium">Shopify Integration</h3>
+            <p class="text-sm text-muted-foreground">
+              Connect your Shopify store to view customer profiles, order history, and lifetime
+              spend directly in the conversation sidebar.
+            </p>
+          </div>
+
+          <!-- OAuth success banner -->
+          <div v-if="oauthSuccess" class="rounded-md border border-green-300 bg-green-50 p-4">
+            <div class="flex items-center gap-2">
+              <CheckCircle2 class="h-5 w-5 text-green-600" />
+              <span class="text-sm font-medium text-green-800">
+                Shopify app installed successfully. Your access token has been saved.
+              </span>
+            </div>
+          </div>
+
+          <form @submit.prevent="saveIntegration" class="space-y-4">
+            <div class="space-y-2">
+              <Label for="store_url">Store URL</Label>
+              <Input
+                id="store_url"
+                v-model="form.store_url"
+                placeholder="yourstore.myshopify.com"
+              />
+              <p class="text-xs text-muted-foreground">
+                Your Shopify store's myshopify.com domain (without https://).
+              </p>
+            </div>
+
+            <div class="space-y-2">
+              <Label for="api_key">API Key (Client ID)</Label>
+              <Input
+                id="api_key"
+                v-model="form.api_key"
+                placeholder="e.g. 1a2b3c4d5e6f..."
+              />
+              <p class="text-xs text-muted-foreground">
+                Found in your Shopify Custom App's "Client credentials" section.
+              </p>
+            </div>
+
+            <div class="space-y-2">
+              <Label for="api_secret">API Secret Key (Client Secret)</Label>
+              <Input
+                id="api_secret"
+                v-model="form.api_secret"
+                type="password"
+                placeholder="shpss_..."
+              />
+              <p class="text-xs text-muted-foreground">
+                Found in your Shopify Custom App's "Client credentials" section.
+              </p>
+            </div>
+
+            <div class="flex items-center space-x-2">
+              <Switch id="enabled" :checked="form.enabled" @update:checked="form.enabled = $event" />
+              <Label for="enabled">Enabled</Label>
+            </div>
+
+            <div class="flex flex-wrap gap-3 pt-2">
+              <Button type="submit" :disabled="saving">
+                {{ saving ? 'Saving...' : (isConfigured ? 'Update' : 'Save') }}
+              </Button>
+              <Button
+                v-if="isConfigured && !hasAccessToken"
+                type="button"
+                variant="default"
+                :disabled="authorizing"
+                @click="startOAuth"
+              >
+                <ExternalLink class="h-4 w-4 mr-1" />
+                {{ authorizing ? 'Redirecting...' : 'Install on Shopify' }}
+              </Button>
+              <Button
+                v-if="isConfigured && hasAccessToken"
+                type="button"
+                variant="outline"
+                :disabled="testing"
+                @click="testConnection"
+              >
+                {{ testing ? 'Testing...' : 'Test Connection' }}
+              </Button>
+              <Button
+                v-if="isConfigured"
+                type="button"
+                variant="destructive"
+                :disabled="deleting"
+                @click="deleteIntegration"
+              >
+                {{ deleting ? 'Removing...' : 'Remove' }}
+              </Button>
+            </div>
+          </form>
+
+          <!-- Connection status -->
+          <div v-if="hasAccessToken && !testResult && !testError" class="rounded-md border p-4">
+            <div class="flex items-center gap-2">
+              <CheckCircle2 class="h-5 w-5 text-green-600" />
+              <span class="text-sm font-medium">Access token configured</span>
+            </div>
+          </div>
+
+          <div v-if="testResult" class="rounded-md border p-4">
+            <div class="flex items-center gap-2">
+              <CheckCircle2 class="h-5 w-5 text-green-600" />
+              <span class="text-sm font-medium">Connected to {{ testResult.shop_name }}</span>
+            </div>
+          </div>
+
+          <div v-if="testError" class="rounded-md border border-destructive p-4">
+            <div class="flex items-center gap-2">
+              <XCircle class="h-5 w-5 text-destructive" />
+              <span class="text-sm text-destructive">{{ testError }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <template #help>
+      <p>
+        The Shopify integration enriches conversations with customer data from your Shopify store.
+      </p>
+      <p>
+        When an agent opens a conversation, the sidebar will automatically display the customer's
+        profile, recent orders, and lifetime spend based on their email address.
+      </p>
+      <p class="font-medium mt-2">Setup steps:</p>
+      <ol class="list-decimal ml-4 space-y-1 text-sm">
+        <li>Go to your Shopify Admin &rarr; Settings &rarr; Apps and sales channels</li>
+        <li>Click "Develop apps" &rarr; "Create an app"</li>
+        <li>
+          Under "Configuration &rarr; Admin API access scopes", select
+          <code class="text-xs bg-muted px-1 py-0.5 rounded">read_customers</code> and
+          <code class="text-xs bg-muted px-1 py-0.5 rounded">read_orders</code>
+        </li>
+        <li>
+          Set the <strong>App URL</strong> to:
+          <code class="text-xs bg-muted px-1 py-0.5 rounded select-all">{{ rootURL }}</code>
+        </li>
+        <li>
+          Add <strong>Allowed redirection URL</strong>:
+          <code class="text-xs bg-muted px-1 py-0.5 rounded select-all break-all">{{ callbackURL }}</code>
+        </li>
+        <li>Copy the <strong>Client ID</strong> and <strong>Client secret</strong> and paste them here</li>
+        <li>Click <strong>Save</strong>, then click <strong>Install on Shopify</strong></li>
+      </ol>
+    </template>
+  </AdminPageWithHelp>
+</template>
+
+<script setup>
+import { ref, onMounted, computed } from 'vue'
+import { useRoute } from 'vue-router'
+import api from '@/api'
+import AdminPageWithHelp from '@/layouts/admin/AdminPageWithHelp.vue'
+import { Spinner } from '@/components/ui/spinner'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
+import { CheckCircle2, XCircle, ExternalLink } from 'lucide-vue-next'
+import { EMITTER_EVENTS } from '@/constants/emitterEvents.js'
+import { useEmitter } from '@/composables/useEmitter'
+import { handleHTTPError } from '@/utils/http'
+import { useIntegrationStore } from '@/stores/integration'
+import { useAppSettingsStore } from '@/stores/appSettings'
+
+const emitter = useEmitter()
+const appSettingsStore = useAppSettingsStore()
+const route = useRoute()
+const integrationStore = useIntegrationStore()
+const pageLoading = ref(true)
+const saving = ref(false)
+const testing = ref(false)
+const deleting = ref(false)
+const authorizing = ref(false)
+const testResult = ref(null)
+const testError = ref(null)
+const oauthSuccess = ref(false)
+
+const form = ref({
+  store_url: '',
+  api_key: '',
+  api_secret: '',
+  enabled: true
+})
+
+const isConfigured = computed(() => integrationStore.shopifyConfigured)
+const rootURL = computed(() => appSettingsStore.settings['app.root_url'] || window.location.origin)
+const callbackURL = computed(() => `${rootURL.value}/api/v1/integrations/shopify/oauth/callback`)
+const hasAccessToken = ref(false)
+const isDummy = (val) => val && val.includes('\u2022')
+
+onMounted(async () => {
+  if (route.query.oauth === 'success') {
+    oauthSuccess.value = true
+    await integrationStore.fetchIntegrations()
+  }
+
+  try {
+    const resp = await api.getIntegration('shopify')
+    const data = resp.data.data
+    const cfg = data.config || {}
+    form.value = {
+      store_url: cfg.store_url || '',
+      api_key: cfg.api_key || '',
+      api_secret: cfg.api_secret || '',
+      enabled: data.enabled
+    }
+    hasAccessToken.value = !!(cfg.access_token && cfg.access_token.length > 0)
+  } catch {
+    // Not configured yet
+  } finally {
+    pageLoading.value = false
+  }
+})
+
+const saveIntegration = async () => {
+  saving.value = true
+  testResult.value = null
+  testError.value = null
+  try {
+    const config = {
+      store_url: form.value.store_url
+    }
+    if (!isDummy(form.value.api_key)) {
+      config.api_key = form.value.api_key
+    }
+    if (!isDummy(form.value.api_secret)) {
+      config.api_secret = form.value.api_secret
+    }
+
+    const payload = {
+      provider: 'shopify',
+      enabled: form.value.enabled,
+      config
+    }
+
+    await api.createIntegration(payload)
+    await integrationStore.fetchIntegrations()
+    emitter.emit(EMITTER_EVENTS.SHOW_TOAST, { description: 'Shopify integration saved.' })
+  } catch (error) {
+    emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
+      variant: 'destructive',
+      description: handleHTTPError(error).message
+    })
+  } finally {
+    saving.value = false
+  }
+}
+
+const startOAuth = async () => {
+  authorizing.value = true
+  try {
+    const resp = await api.getShopifyOAuthURL()
+    const url = resp.data.data.authorize_url
+    window.location.href = url
+  } catch (error) {
+    authorizing.value = false
+    emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
+      variant: 'destructive',
+      description: handleHTTPError(error).message
+    })
+  }
+}
+
+const testConnection = async () => {
+  testing.value = true
+  testResult.value = null
+  testError.value = null
+  try {
+    const resp = await api.testIntegration('shopify')
+    testResult.value = resp.data.data
+  } catch (error) {
+    testError.value = handleHTTPError(error).message
+  } finally {
+    testing.value = false
+  }
+}
+
+const deleteIntegration = async () => {
+  deleting.value = true
+  try {
+    await api.deleteIntegration('shopify')
+    await integrationStore.fetchIntegrations()
+    form.value = { store_url: '', api_key: '', api_secret: '', enabled: true }
+    hasAccessToken.value = false
+    testResult.value = null
+    oauthSuccess.value = false
+    emitter.emit(EMITTER_EVENTS.SHOW_TOAST, { description: 'Shopify integration removed.' })
+  } catch (error) {
+    emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
+      variant: 'destructive',
+      description: handleHTTPError(error).message
+    })
+  } finally {
+    deleting.value = false
+  }
+}
+</script>

--- a/internal/inbox/channel/email/imap.go
+++ b/internal/inbox/channel/email/imap.go
@@ -131,43 +131,22 @@ func (e *Email) processMailbox(ctx context.Context, scanInboxSince time.Duration
 }
 
 // searchMessages searches for messages in the specified time range.
-// Uses ESEARCH if supported by the server, otherwise falls back to standard SEARCH.
+// Always uses standard SEARCH to avoid ESEARCH UID/sequence number
+// mismatches with some IMAP servers that return UIDs without the UID tag.
 func (e *Email) searchMessages(client *imapclient.Client, since time.Time) (*imap.SearchData, error) {
 	criteria := &imap.SearchCriteria{
 		Since: since,
 	}
-
-	// Attempt ESEARCH if server supports it
-	if client.Caps().Has(imap.CapESearch) {
-		opts := &imap.SearchOptions{
-			ReturnMin:   true,
-			ReturnMax:   true,
-			ReturnAll:   true,
-			ReturnCount: true,
-		}
-
-		result, err := client.Search(criteria, opts).Wait()
-		if err == nil {
-			return result, nil
-		}
-
-		e.lo.Warn("ESEARCH failed, falling back to standard SEARCH", "error", err, "inbox_id", e.Identifier())
-	}
-
 	return client.Search(criteria, nil).Wait()
 }
 
 // fetchAndProcessMessages fetches and processes messages based on the search results.
 func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.Client, searchResults *imap.SearchData, inboxID int) error {
 	seqSet := imap.SeqSet{}
-	if searchResults.Min > 0 && searchResults.Max > 0 {
-		e.lo.Debug("using ESEARCH range", "min", searchResults.Min, "max", searchResults.Max, "inbox_id", inboxID)
-		seqSet.AddRange(searchResults.Min, searchResults.Max)
-	} else if seqNums := searchResults.AllSeqNums(); len(seqNums) > 0 {
-		e.lo.Debug("using SEARCH fallback (no ESEARCH support)", "count", len(seqNums), "inbox_id", inboxID)
+	if seqNums := searchResults.AllSeqNums(); len(seqNums) > 0 {
+		e.lo.Debug("fetching messages", "count", len(seqNums), "inbox_id", inboxID)
 		seqSet.AddNum(seqNums...)
 	} else {
-		// No results found
 		e.lo.Debug("no messages found in search results", "inbox_id", inboxID)
 		return nil
 	}

--- a/internal/integration/integration.go
+++ b/internal/integration/integration.go
@@ -1,0 +1,206 @@
+// Package integration manages external integration configurations.
+package integration
+
+import (
+	"database/sql"
+	"embed"
+	"encoding/json"
+
+	"github.com/abhinavxd/libredesk/internal/crypto"
+	"github.com/abhinavxd/libredesk/internal/dbutil"
+	"github.com/abhinavxd/libredesk/internal/envelope"
+	"github.com/abhinavxd/libredesk/internal/integration/models"
+	"github.com/jmoiron/sqlx"
+	"github.com/knadh/go-i18n"
+	"github.com/zerodha/logf"
+)
+
+var (
+	//go:embed queries.sql
+	efs embed.FS
+)
+
+// secretFields lists config keys whose values must be encrypted at rest.
+var secretFields = map[string][]string{
+	"shopify": {"access_token", "api_secret"},
+}
+
+// Manager handles integration CRUD.
+type Manager struct {
+	q             queries
+	lo            *logf.Logger
+	i18n          *i18n.I18n
+	db            *sqlx.DB
+	encryptionKey string
+}
+
+// Opts contains options for creating a Manager.
+type Opts struct {
+	DB            *sqlx.DB
+	Lo            *logf.Logger
+	I18n          *i18n.I18n
+	EncryptionKey string
+}
+
+// queries contains prepared SQL statements.
+type queries struct {
+	GetAll  *sqlx.Stmt `query:"get-all-integrations"`
+	Get     *sqlx.Stmt `query:"get-integration"`
+	Upsert  *sqlx.Stmt `query:"upsert-integration"`
+	Delete  *sqlx.Stmt `query:"delete-integration"`
+	Toggle  *sqlx.Stmt `query:"toggle-integration"`
+}
+
+// New creates a new Manager.
+func New(opts Opts) (*Manager, error) {
+	var q queries
+	if err := dbutil.ScanSQLFile("queries.sql", &q, opts.DB, efs); err != nil {
+		return nil, err
+	}
+	return &Manager{
+		q:             q,
+		lo:            opts.Lo,
+		i18n:          opts.I18n,
+		db:            opts.DB,
+		encryptionKey: opts.EncryptionKey,
+	}, nil
+}
+
+// GetAll returns all integrations with secrets decrypted.
+func (m *Manager) GetAll() ([]models.Integration, error) {
+	out := make([]models.Integration, 0)
+	if err := m.q.GetAll.Select(&out); err != nil {
+		m.lo.Error("error fetching integrations", "error", err)
+		return nil, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorFetching", "name", "integrations"), nil)
+	}
+	for i := range out {
+		m.decryptConfig(&out[i])
+	}
+	return out, nil
+}
+
+// Get returns a single integration by provider name.
+func (m *Manager) Get(provider string) (models.Integration, error) {
+	var out models.Integration
+	if err := m.q.Get.Get(&out, provider); err != nil {
+		if err == sql.ErrNoRows {
+			return out, envelope.NewError(envelope.NotFoundError, m.i18n.Ts("globals.messages.notFound", "name", "integration"), nil)
+		}
+		m.lo.Error("error fetching integration", "error", err)
+		return out, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorFetching", "name", "integration"), nil)
+	}
+	m.decryptConfig(&out)
+	return out, nil
+}
+
+// Upsert creates or updates an integration.
+func (m *Manager) Upsert(intg models.Integration) (models.Integration, error) {
+	cfg, err := m.encryptConfig(intg.Provider, intg.Config)
+	if err != nil {
+		m.lo.Error("error encrypting integration config", "error", err)
+		return models.Integration{}, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorCreating", "name", "integration"), nil)
+	}
+
+	var result models.Integration
+	if err := m.q.Upsert.Get(&result, intg.Provider, cfg, intg.Enabled); err != nil {
+		if dbutil.IsUniqueViolationError(err) {
+			return models.Integration{}, envelope.NewError(envelope.ConflictError, m.i18n.Ts("globals.messages.errorAlreadyExists", "name", "integration"), nil)
+		}
+		m.lo.Error("error upserting integration", "error", err)
+		return models.Integration{}, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorCreating", "name", "integration"), nil)
+	}
+	m.decryptConfig(&result)
+	return result, nil
+}
+
+// Delete removes an integration by provider.
+func (m *Manager) Delete(provider string) error {
+	if _, err := m.q.Delete.Exec(provider); err != nil {
+		m.lo.Error("error deleting integration", "error", err)
+		return envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorDeleting", "name", "integration"), nil)
+	}
+	return nil
+}
+
+// Toggle flips the enabled flag on an integration.
+func (m *Manager) Toggle(provider string) (models.Integration, error) {
+	var result models.Integration
+	if err := m.q.Toggle.Get(&result, provider); err != nil {
+		if err == sql.ErrNoRows {
+			return result, envelope.NewError(envelope.NotFoundError, m.i18n.Ts("globals.messages.notFound", "name", "integration"), nil)
+		}
+		m.lo.Error("error toggling integration", "error", err)
+		return models.Integration{}, envelope.NewError(envelope.GeneralError, m.i18n.Ts("globals.messages.errorUpdating", "name", "integration"), nil)
+	}
+	m.decryptConfig(&result)
+	return result, nil
+}
+
+// encryptConfig encrypts secret fields inside a config JSON blob.
+func (m *Manager) encryptConfig(provider string, raw json.RawMessage) (json.RawMessage, error) {
+	fields, ok := secretFields[provider]
+	if !ok || len(fields) == 0 {
+		return raw, nil
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return raw, err
+	}
+
+	for _, f := range fields {
+		val, ok := cfg[f]
+		if !ok {
+			continue
+		}
+		s, ok := val.(string)
+		if !ok || s == "" || crypto.IsEncrypted(s) {
+			continue
+		}
+		enc, err := crypto.Encrypt(s, m.encryptionKey)
+		if err != nil {
+			return nil, err
+		}
+		cfg[f] = enc
+	}
+
+	return json.Marshal(cfg)
+}
+
+// decryptConfig decrypts secret fields inside an integration's config.
+func (m *Manager) decryptConfig(intg *models.Integration) {
+	fields, ok := secretFields[intg.Provider]
+	if !ok || len(fields) == 0 {
+		return
+	}
+
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(intg.Config, &cfg); err != nil {
+		return
+	}
+
+	changed := false
+	for _, f := range fields {
+		val, ok := cfg[f]
+		if !ok {
+			continue
+		}
+		s, ok := val.(string)
+		if !ok || !crypto.IsEncrypted(s) {
+			continue
+		}
+		dec, err := crypto.Decrypt(s, m.encryptionKey)
+		if err != nil {
+			m.lo.Error("error decrypting integration config field", "provider", intg.Provider, "field", f, "error", err)
+			continue
+		}
+		cfg[f] = dec
+		changed = true
+	}
+
+	if changed {
+		if b, err := json.Marshal(cfg); err == nil {
+			intg.Config = b
+		}
+	}
+}

--- a/internal/integration/models/models.go
+++ b/internal/integration/models/models.go
@@ -1,0 +1,16 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Integration represents an external integration configuration.
+type Integration struct {
+	ID        int             `db:"id" json:"id"`
+	CreatedAt time.Time       `db:"created_at" json:"created_at"`
+	UpdatedAt time.Time       `db:"updated_at" json:"updated_at"`
+	Provider  string          `db:"provider" json:"provider"`
+	Config    json.RawMessage `db:"config" json:"config"`
+	Enabled   bool            `db:"enabled" json:"enabled"`
+}

--- a/internal/integration/queries.sql
+++ b/internal/integration/queries.sql
@@ -1,0 +1,51 @@
+-- name: get-all-integrations
+SELECT
+    id,
+    created_at,
+    updated_at,
+    provider,
+    config,
+    enabled
+FROM
+    integrations
+ORDER BY created_at DESC;
+
+-- name: get-integration
+SELECT
+    id,
+    created_at,
+    updated_at,
+    provider,
+    config,
+    enabled
+FROM
+    integrations
+WHERE
+    provider = $1;
+
+-- name: upsert-integration
+INSERT INTO
+    integrations (provider, config, enabled)
+VALUES
+    ($1, $2, $3)
+ON CONFLICT (provider) DO UPDATE SET
+    config = EXCLUDED.config,
+    enabled = EXCLUDED.enabled,
+    updated_at = NOW()
+RETURNING *;
+
+-- name: delete-integration
+DELETE FROM
+    integrations
+WHERE
+    provider = $1;
+
+-- name: toggle-integration
+UPDATE
+    integrations
+SET
+    enabled = NOT enabled,
+    updated_at = NOW()
+WHERE
+    provider = $1
+RETURNING *;

--- a/internal/integration/shopify/models.go
+++ b/internal/integration/shopify/models.go
@@ -1,0 +1,125 @@
+package shopify
+
+import "time"
+
+// CustomerResult is the top-level response from a customer lookup.
+type CustomerResult struct {
+	Found     bool       `json:"found"`
+	Customer  Customer   `json:"customer,omitempty"`
+	Orders    []Order    `json:"orders,omitempty"`
+	FetchedAt time.Time  `json:"fetched_at"`
+}
+
+// Customer holds Shopify customer profile data.
+type Customer struct {
+	ID             string   `json:"id"`
+	FirstName      string   `json:"first_name"`
+	LastName       string   `json:"last_name"`
+	Email          string   `json:"email"`
+	Phone          string   `json:"phone"`
+	CreatedAt      string   `json:"created_at"`
+	NumberOfOrders string   `json:"number_of_orders"`
+	TotalSpent     string   `json:"total_spent"`
+	CurrencyCode   string   `json:"currency_code"`
+	DefaultAddress *Address `json:"default_address,omitempty"`
+}
+
+// Address is a Shopify mailing address.
+type Address struct {
+	City         string `json:"city"`
+	Province     string `json:"province"`
+	ProvinceCode string `json:"province_code"`
+	Country      string `json:"country"`
+	CountryCode  string `json:"country_code"`
+	Zip          string `json:"zip"`
+}
+
+// Order holds Shopify order data.
+type Order struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	CreatedAt         string     `json:"created_at"`
+	FinancialStatus   string     `json:"financial_status"`
+	FulfillmentStatus string     `json:"fulfillment_status"`
+	TotalPrice        string     `json:"total_price"`
+	CurrencyCode      string     `json:"currency_code"`
+	LineItems         []LineItem `json:"line_items"`
+}
+
+// LineItem is one product line inside an order.
+type LineItem struct {
+	Title    string `json:"title"`
+	Quantity int    `json:"quantity"`
+	Price    string `json:"price"`
+	ImageURL string `json:"image_url,omitempty"`
+}
+
+// -- Raw GraphQL response structs (internal) --
+
+type graphQLError struct {
+	Message string `json:"message"`
+}
+
+type customerNode struct {
+	ID             string          `json:"id"`
+	FirstName      string          `json:"firstName"`
+	LastName       string          `json:"lastName"`
+	Email          string          `json:"email"`
+	Phone          string          `json:"phone"`
+	CreatedAt      string          `json:"createdAt"`
+	NumberOfOrders string          `json:"numberOfOrders"`
+	AmountSpent    moneyV2         `json:"amountSpent"`
+	DefaultAddress *addressNode    `json:"defaultAddress"`
+	Orders         orderEdges      `json:"orders"`
+}
+
+type moneyV2 struct {
+	Amount       string `json:"amount"`
+	CurrencyCode string `json:"currencyCode"`
+}
+
+type addressNode struct {
+	City           string `json:"city"`
+	Province       string `json:"province"`
+	ProvinceCode   string `json:"provinceCode"`
+	Country        string `json:"country"`
+	CountryCodeV2  string `json:"countryCodeV2"`
+	Zip            string `json:"zip"`
+}
+
+type orderEdges struct {
+	Edges []struct {
+		Node orderNode `json:"node"`
+	} `json:"edges"`
+}
+
+type orderNode struct {
+	ID                       string        `json:"id"`
+	Name                     string        `json:"name"`
+	CreatedAt                string        `json:"createdAt"`
+	DisplayFinancialStatus   string        `json:"displayFinancialStatus"`
+	DisplayFulfillmentStatus string        `json:"displayFulfillmentStatus"`
+	TotalPriceSet            totalPriceSet `json:"totalPriceSet"`
+	LineItems                lineItemEdges `json:"lineItems"`
+}
+
+type totalPriceSet struct {
+	ShopMoney moneyV2 `json:"shopMoney"`
+}
+
+type lineItemEdges struct {
+	Edges []struct {
+		Node lineItemNode `json:"node"`
+	} `json:"edges"`
+}
+
+type lineItemNode struct {
+	Title                string          `json:"title"`
+	Quantity             int             `json:"quantity"`
+	OriginalUnitPriceSet *totalPriceSet  `json:"originalUnitPriceSet"`
+	Image                *imageNode      `json:"image"`
+}
+
+type imageNode struct {
+	URL string `json:"url"`
+}

--- a/internal/integration/shopify/shopify.go
+++ b/internal/integration/shopify/shopify.go
@@ -1,0 +1,334 @@
+// Package shopify provides a client for the Shopify Admin GraphQL API,
+// focused on customer lookups for the conversation sidebar.
+package shopify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/zerodha/logf"
+)
+
+const (
+	graphqlAPIVersion = "2025-01"
+	cacheTTL          = 5 * time.Minute
+)
+
+// Client talks to the Shopify Admin GraphQL API.
+type Client struct {
+	httpClient *http.Client
+	lo         *logf.Logger
+
+	mu    sync.RWMutex
+	cache map[string]cacheEntry
+}
+
+type cacheEntry struct {
+	data      *CustomerResult
+	expiresAt time.Time
+}
+
+// New creates a new Shopify client.
+func New(lo *logf.Logger) *Client {
+	return &Client{
+		httpClient: &http.Client{Timeout: 15 * time.Second},
+		lo:         lo,
+		cache:      make(map[string]cacheEntry),
+	}
+}
+
+// LookupCustomer searches Shopify for a customer by email.
+func (c *Client) LookupCustomer(storeURL, accessToken, email string) (*CustomerResult, error) {
+	cacheKey := storeURL + ":" + email
+
+	c.mu.RLock()
+	if entry, ok := c.cache[cacheKey]; ok && time.Now().Before(entry.expiresAt) {
+		c.mu.RUnlock()
+		return entry.data, nil
+	}
+	c.mu.RUnlock()
+
+	result, err := c.fetchCustomer(storeURL, accessToken, email)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.cache[cacheKey] = cacheEntry{data: result, expiresAt: time.Now().Add(cacheTTL)}
+	c.mu.Unlock()
+
+	return result, nil
+}
+
+// ExchangeOAuthToken exchanges a temporary OAuth code for a permanent access token.
+func (c *Client) ExchangeOAuthToken(storeURL, apiKey, apiSecret, code string) (string, error) {
+	payload, _ := json.Marshal(map[string]string{
+		"client_id":     apiKey,
+		"client_secret": apiSecret,
+		"code":          code,
+	})
+
+	url := fmt.Sprintf("https://%s/admin/oauth/access_token", storeURL)
+	req, err := http.NewRequest("POST", url, bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("Shopify OAuth request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading OAuth response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Shopify OAuth returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("error parsing OAuth response: %w", err)
+	}
+	if result.AccessToken == "" {
+		return "", fmt.Errorf("Shopify returned empty access token")
+	}
+
+	return result.AccessToken, nil
+}
+
+// TestConnection verifies the credentials by fetching the shop name.
+func (c *Client) TestConnection(storeURL, accessToken string) (string, error) {
+	query := `{ shop { name myshopifyDomain } }`
+	resp, err := c.doGraphQL(storeURL, accessToken, query, nil)
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		Data struct {
+			Shop struct {
+				Name             string `json:"name"`
+				MyshopifyDomain  string `json:"myshopifyDomain"`
+			} `json:"shop"`
+		} `json:"data"`
+		Errors []graphQLError `json:"errors"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return "", fmt.Errorf("error parsing Shopify response: %w", err)
+	}
+	if len(result.Errors) > 0 {
+		return "", fmt.Errorf("Shopify API error: %s", result.Errors[0].Message)
+	}
+	return result.Data.Shop.Name, nil
+}
+
+func (c *Client) fetchCustomer(storeURL, accessToken, email string) (*CustomerResult, error) {
+	query := `
+	query customerByEmail($query: String!) {
+		customers(first: 1, query: $query) {
+			edges {
+				node {
+					id
+					firstName
+					lastName
+					email
+					phone
+					createdAt
+					numberOfOrders
+					amountSpent {
+						amount
+						currencyCode
+					}
+					defaultAddress {
+						city
+						province
+						provinceCode
+						country
+						countryCodeV2
+						zip
+					}
+					orders(first: 5, sortKey: CREATED_AT, reverse: true) {
+						edges {
+							node {
+								id
+								name
+								createdAt
+								displayFinancialStatus
+								displayFulfillmentStatus
+								totalPriceSet {
+									shopMoney {
+										amount
+										currencyCode
+									}
+								}
+								lineItems(first: 10) {
+									edges {
+										node {
+											title
+											quantity
+											originalUnitPriceSet {
+												shopMoney {
+													amount
+													currencyCode
+												}
+											}
+											image {
+												url
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}`
+
+	vars := map[string]interface{}{
+		"query": fmt.Sprintf("email:%s", email),
+	}
+
+	resp, err := c.doGraphQL(storeURL, accessToken, query, vars)
+	if err != nil {
+		return nil, err
+	}
+
+	var gqlResp struct {
+		Data struct {
+			Customers struct {
+				Edges []struct {
+					Node customerNode `json:"node"`
+				} `json:"edges"`
+			} `json:"customers"`
+		} `json:"data"`
+		Errors []graphQLError `json:"errors"`
+	}
+	if err := json.Unmarshal(resp, &gqlResp); err != nil {
+		return nil, fmt.Errorf("error parsing Shopify response: %w", err)
+	}
+	if len(gqlResp.Errors) > 0 {
+		return nil, fmt.Errorf("Shopify API error: %s", gqlResp.Errors[0].Message)
+	}
+
+	if len(gqlResp.Data.Customers.Edges) == 0 {
+		return &CustomerResult{Found: false}, nil
+	}
+
+	node := gqlResp.Data.Customers.Edges[0].Node
+	result := &CustomerResult{
+		Found:     true,
+		Customer:  mapCustomer(node),
+		Orders:    mapOrders(node.Orders),
+		FetchedAt: time.Now(),
+	}
+	return result, nil
+}
+
+func (c *Client) doGraphQL(storeURL, accessToken, query string, variables map[string]interface{}) ([]byte, error) {
+	body := map[string]interface{}{
+		"query": query,
+	}
+	if variables != nil {
+		body["variables"] = variables
+	}
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("https://%s/admin/api/%s/graphql.json", storeURL, graphqlAPIVersion)
+	req, err := http.NewRequest("POST", url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Shopify-Access-Token", accessToken)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("Shopify request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading Shopify response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Shopify API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+func mapCustomer(n customerNode) Customer {
+	var addr *Address
+	if n.DefaultAddress != nil {
+		addr = &Address{
+			City:         n.DefaultAddress.City,
+			Province:     n.DefaultAddress.Province,
+			ProvinceCode: n.DefaultAddress.ProvinceCode,
+			Country:      n.DefaultAddress.Country,
+			CountryCode:  n.DefaultAddress.CountryCodeV2,
+			Zip:          n.DefaultAddress.Zip,
+		}
+	}
+	return Customer{
+		ID:              n.ID,
+		FirstName:       n.FirstName,
+		LastName:        n.LastName,
+		Email:           n.Email,
+		Phone:           n.Phone,
+		CreatedAt:       n.CreatedAt,
+		NumberOfOrders:  n.NumberOfOrders,
+		TotalSpent:      n.AmountSpent.Amount,
+		CurrencyCode:    n.AmountSpent.CurrencyCode,
+		DefaultAddress:  addr,
+	}
+}
+
+func mapOrders(edges orderEdges) []Order {
+	out := make([]Order, 0, len(edges.Edges))
+	for _, e := range edges.Edges {
+		o := e.Node
+		order := Order{
+			ID:                o.ID,
+			Name:              o.Name,
+			CreatedAt:         o.CreatedAt,
+			FinancialStatus:   o.DisplayFinancialStatus,
+			FulfillmentStatus: o.DisplayFulfillmentStatus,
+			TotalPrice:        o.TotalPriceSet.ShopMoney.Amount,
+			CurrencyCode:      o.TotalPriceSet.ShopMoney.CurrencyCode,
+			LineItems:         make([]LineItem, 0, len(o.LineItems.Edges)),
+		}
+		for _, li := range o.LineItems.Edges {
+			item := LineItem{
+				Title:    li.Node.Title,
+				Quantity: li.Node.Quantity,
+			}
+			if li.Node.OriginalUnitPriceSet != nil {
+				item.Price = li.Node.OriginalUnitPriceSet.ShopMoney.Amount
+			}
+			if li.Node.Image != nil {
+				item.ImageURL = li.Node.Image.URL
+			}
+			order.LineItems = append(order.LineItems, item)
+		}
+		out = append(out, order)
+	}
+	return out
+}

--- a/internal/migrations/v1.0.4.go
+++ b/internal/migrations/v1.0.4.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/knadh/koanf/v2"
+	"github.com/knadh/stuffbin"
+)
+
+// V1_0_4 adds the integrations table and integrations:manage permission to the Admin role.
+func V1_0_4(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS integrations (
+			id SERIAL PRIMARY KEY,
+			created_at TIMESTAMPTZ DEFAULT NOW(),
+			updated_at TIMESTAMPTZ DEFAULT NOW(),
+			provider TEXT NOT NULL UNIQUE,
+			config JSONB DEFAULT '{}'::jsonb NOT NULL,
+			enabled BOOLEAN DEFAULT true NOT NULL,
+			CONSTRAINT constraint_integrations_on_provider CHECK (length(provider) <= 100)
+		);
+
+		UPDATE roles
+		SET permissions = array_append(permissions, 'integrations:manage')
+		WHERE name = 'Admin'
+		AND NOT ('integrations:manage' = ANY(permissions));
+	`)
+	return err
+}

--- a/schema.sql
+++ b/schema.sql
@@ -637,6 +637,17 @@ CREATE INDEX IF NOT EXISTS index_activity_logs_on_actor_id ON activity_logs (act
 CREATE INDEX IF NOT EXISTS index_activity_logs_on_activity_type ON activity_logs (activity_type);
 CREATE INDEX IF NOT EXISTS index_activity_logs_on_created_at ON activity_logs (created_at);
 
+DROP TABLE IF EXISTS integrations CASCADE;
+CREATE TABLE integrations (
+	id SERIAL PRIMARY KEY,
+	created_at TIMESTAMPTZ DEFAULT NOW(),
+	updated_at TIMESTAMPTZ DEFAULT NOW(),
+	provider TEXT NOT NULL UNIQUE,
+	config JSONB DEFAULT '{}'::jsonb NOT NULL,
+	enabled BOOLEAN DEFAULT true NOT NULL,
+	CONSTRAINT constraint_integrations_on_provider CHECK (length(provider) <= 100)
+);
+
 DROP TABLE IF EXISTS webhooks CASCADE;
 CREATE TABLE webhooks (
 	id SERIAL PRIMARY KEY,
@@ -744,7 +755,7 @@ VALUES
 	(
 		'Admin',
 		'Role for users who have complete access to everything.',
-		'{webhooks:manage,activity_logs:manage,custom_attributes:manage,contacts:read_all,contacts:read,contacts:write,contacts:block,contact_notes:read,contact_notes:write,contact_notes:delete,conversations:write,ai:manage,general_settings:manage,notification_settings:manage,oidc:manage,conversations:read_all,conversations:read_unassigned,conversations:read_assigned,conversations:read_team_inbox,conversations:read_team_all,conversations:read,conversations:update_user_assignee,conversations:update_team_assignee,conversations:update_priority,conversations:update_status,conversations:update_tags,messages:read,messages:write,view:manage,shared_views:manage,status:manage,tags:manage,macros:manage,users:manage,teams:manage,automations:manage,inboxes:manage,roles:manage,reports:manage,templates:manage,business_hours:manage,sla:manage}'
+		'{webhooks:manage,integrations:manage,activity_logs:manage,custom_attributes:manage,contacts:read_all,contacts:read,contacts:write,contacts:block,contact_notes:read,contact_notes:write,contact_notes:delete,conversations:write,ai:manage,general_settings:manage,notification_settings:manage,oidc:manage,conversations:read_all,conversations:read_unassigned,conversations:read_assigned,conversations:read_team_inbox,conversations:read_team_all,conversations:read,conversations:update_user_assignee,conversations:update_team_assignee,conversations:update_priority,conversations:update_status,conversations:update_tags,messages:read,messages:write,view:manage,shared_views:manage,status:manage,tags:manage,macros:manage,users:manage,teams:manage,automations:manage,inboxes:manage,roles:manage,reports:manage,templates:manage,business_hours:manage,sla:manage}'
 	);
 
 


### PR DESCRIPTION
## Summary

Some IMAP servers (confirmed with Purelymail) return UIDs in their ESEARCH responses without setting the `UID` tag in the response. This causes `fetchAndProcessMessages` to interpret UID values (e.g. 590–597) as sequence numbers and pass them to `client.Fetch()` via a `SeqSet`. When those values exceed the actual mailbox message count (e.g. 444 messages), the FETCH command returns zero results and **all incoming emails are silently dropped**.

### Root cause

In `searchMessages`, when the server advertises `ESEARCH` via its capability flag, the code sends a `SEARCH` command with `RETURN (MIN MAX ALL COUNT)` options. The server responds with an ESEARCH result containing `MIN`, `MAX`, and `ALL` values. Per RFC 4731, these should be sequence numbers for a non-UID SEARCH, but Purelymail returns UIDs without the `UID` tag. The go-imap v2 library then sets `SearchData.UID = false`, so `fetchAndProcessMessages` takes the `Min > 0 && Max > 0` branch and adds the UID values to a `SeqSet`:

```go
seqSet.AddRange(searchResults.Min, searchResults.Max) // UIDs treated as seqnums
```

Since `SeqSet` range 590–597 doesn't exist in a 444-message mailbox, `client.Fetch()` returns nothing.

### Why the ESEARCH capability check isn't sufficient

The original code checked `client.Caps().Has(imap.CapESearch)` before using ESEARCH, and had a fallback to standard SEARCH if ESEARCH returned an error. This is a reasonable design — use the faster protocol extension when available, degrade gracefully on failure.

The problem is that the capability flag only tells you the server *claims* to support ESEARCH, not that it *correctly implements* it. Purelymail advertises ESEARCH support, accepts the ESEARCH request without error, and returns a structurally valid response — but the data inside is wrong (UIDs where sequence numbers should be). The existing fallback only triggers on ESEARCH *errors*, and there is no error here. The server returns confidently wrong data that passes all structural validation.

There is no reliable way to detect this at the application level. You could compare Min/Max against the mailbox EXISTS count as a heuristic, but that's fragile and couples SEARCH logic to mailbox state. The safest fix is to avoid the ESEARCH code path entirely.

### Fix

- Remove the ESEARCH code path in `searchMessages` and always use standard `SEARCH` (no return options), which reliably returns sequence numbers across all IMAP servers.
- Simplify `fetchAndProcessMessages` to only use `AllSeqNums()`.

This is a minimal, safe change. A more targeted alternative would be to check `SearchData.UID` and use `UIDSet`/`UID FETCH` when true, but that still wouldn't help when the server incorrectly omits the UID tag (as Purelymail does).

### Performance note

Standard SEARCH returns the full list of matching sequence numbers rather than just a min/max range. For very large mailboxes with many matches, this means slightly more data over the wire. In practice, since `scan_inbox_since` defaults to 48 hours, the result set is typically small and the difference is negligible.

## Test plan

- [x] Tested against Purelymail IMAP server — 8 emails from the last 48h are now correctly fetched and processed (previously 0)
- [ ] Verify no regression with Gmail IMAP
- [ ] Verify no regression with Microsoft 365 IMAP