### PR TITLE
Add theme switcher with drop-in theme discovery

### DIFF
--- a/frontend/apps/main/src/App.vue
+++ b/frontend/apps/main/src/App.vue
@@ -86,6 +86,9 @@
               </Tooltip>
             </SidebarMenuItem>
             <SidebarMenuItem>
+              <ThemeSwitcher />
+            </SidebarMenuItem>
+            <SidebarMenuItem>
               <SidebarNavUser />
             </SidebarMenuItem>
           </SidebarMenu>
@@ -172,10 +175,17 @@ import {
 import { Tooltip, TooltipContent, TooltipTrigger } from '@shared-ui/components/ui/tooltip'
 import SidebarNavUser from '@main/components/sidebar/SidebarNavUser.vue'
 import NotificationBell from '@main/components/sidebar/NotificationBell.vue'
+import ThemeSwitcher from '@main/components/sidebar/ThemeSwitcher.vue'
+import { useTheme } from '@main/composables/useTheme'
 import api from '@main/api'
 
 const route = useRoute()
 const emitter = useEmitter()
+
+// Apply the persisted theme to <html data-theme="..."> on app start. Called
+// here (not just inside ThemeSwitcher) so the attribute is set even when
+// only one theme is registered and the switcher UI is hidden.
+useTheme()
 
 // Small screen overlay - shown once per session for screens < 768px.
 const showSmallScreenOverlay = ref(window.screen.width < 768 && !sessionStorage.getItem('smallScreenDismissed'))

--- a/frontend/apps/main/src/components/sidebar/ThemeSwitcher.vue
+++ b/frontend/apps/main/src/components/sidebar/ThemeSwitcher.vue
@@ -1,0 +1,45 @@
+<template>
+  <DropdownMenu v-if="hasMultipleThemes">
+    <Tooltip>
+      <TooltipTrigger as-child>
+        <DropdownMenuTrigger as-child>
+          <SidebarMenuButton>
+            <Palette />
+          </SidebarMenuButton>
+        </DropdownMenuTrigger>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        <p>{{ t('theme.switcher') }}</p>
+      </TooltipContent>
+    </Tooltip>
+    <DropdownMenuContent side="right" align="end">
+      <DropdownMenuItem
+        v-for="t in THEMES"
+        :key="t.id"
+        @click="setTheme(t.id)"
+        :class="{ 'bg-accent': currentTheme === t.id }"
+      >
+        <Check v-if="currentTheme === t.id" class="mr-2 h-4 w-4" />
+        <span v-else class="mr-2 h-4 w-4" />
+        {{ t.label }}
+      </DropdownMenuItem>
+    </DropdownMenuContent>
+  </DropdownMenu>
+</template>
+
+<script setup>
+import { useI18n } from 'vue-i18n'
+import { Palette, Check } from 'lucide-vue-next'
+import { SidebarMenuButton } from '@shared-ui/components/ui/sidebar'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@shared-ui/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@shared-ui/components/ui/tooltip'
+import { useTheme } from '@main/composables/useTheme'
+
+const { t } = useI18n()
+const { THEMES, currentTheme, setTheme, hasMultipleThemes } = useTheme()
+</script>

--- a/frontend/apps/main/src/composables/useTheme.js
+++ b/frontend/apps/main/src/composables/useTheme.js
@@ -1,0 +1,63 @@
+import { computed, watch } from 'vue'
+import { useStorage } from '@vueuse/core'
+
+// Auto-discover themes from `frontend/apps/main/src/themes/*/theme.js`.
+// Each theme directory should export a `{ id, label }` object as default and
+// (optionally) ship a `theme.scss` next to it. Both files are picked up by
+// Vite glob so a drop-in theme requires zero edits to this file or any other
+// upstream code.
+//
+//   themes/
+//     <name>/
+//       theme.js      // export default { id: '<name>', label: '<Label>' }
+//       theme.scss    // [data-theme="<name>"] { --primary: ...; ... }
+//
+// CSS targets `[data-theme="<id>"]` so themes are scoped to opt-in. The
+// default theme has no data-theme attribute, so stock upstream is unchanged.
+const themeModules = import.meta.glob('../themes/*/theme.js', { eager: true })
+// Side-effect import so each theme's stylesheet is included in the bundle.
+import.meta.glob('../themes/*/theme.scss', { eager: true })
+
+const DEFAULT_THEME = { id: 'default', label: 'Default' }
+
+const discovered = Object.values(themeModules)
+  .map((mod) => mod.default || mod)
+  .filter((t) => t && typeof t.id === 'string' && t.id !== 'default')
+
+export const THEMES = [DEFAULT_THEME, ...discovered]
+
+const STORAGE_KEY = 'libredesk-theme'
+const DEFAULT_ID = DEFAULT_THEME.id
+
+const isValid = (id) => THEMES.some((t) => t.id === id)
+
+export function useTheme () {
+  const stored = useStorage(STORAGE_KEY, DEFAULT_ID)
+  const activeTheme = computed(() => (isValid(stored.value) ? stored.value : DEFAULT_ID))
+
+  // Reflect the active theme on <html data-theme="..."> so themes can opt in
+  // via attribute selectors. Default is left as-is so it costs nothing.
+  watch(
+    activeTheme,
+    (id) => {
+      if (typeof document === 'undefined') return
+      if (id === DEFAULT_ID) {
+        document.documentElement.removeAttribute('data-theme')
+      } else {
+        document.documentElement.setAttribute('data-theme', id)
+      }
+    },
+    { immediate: true }
+  )
+
+  function setTheme (id) {
+    if (isValid(id)) stored.value = id
+  }
+
+  return {
+    THEMES,
+    currentTheme: activeTheme,
+    setTheme,
+    hasMultipleThemes: computed(() => THEMES.length > 1)
+  }
+}

--- a/frontend/apps/main/src/themes/README.md
+++ b/frontend/apps/main/src/themes/README.md
@@ -1,0 +1,48 @@
+# Themes
+
+Drop-in directory for custom UI themes. Auto-discovered by `useTheme.js` via
+Vite glob — adding a theme requires **no edits to upstream files**.
+
+## Convention
+
+Each theme lives in its own subdirectory:
+
+```
+themes/
+  <name>/
+    theme.js      # required — exports the theme descriptor
+    theme.scss    # optional — your stylesheet
+```
+
+`theme.js` exports a default object:
+
+```js
+export default {
+  id: 'fresh',     // matches the [data-theme="..."] selector
+  label: 'Fresh'   // shown in the theme switcher dropdown
+}
+```
+
+`theme.scss` (or `.css`) opts in via the attribute selector:
+
+```scss
+[data-theme="fresh"] {
+  --primary: 173 80% 40%;
+  --sidebar-background: 173 30% 95%;
+  // ...override any CSS variables or write theme-scoped rules
+}
+```
+
+The default theme uses no `data-theme` attribute, so the bare upstream UI is
+unchanged when no themes are installed.
+
+## How the switcher behaves
+
+- 1 theme registered (default only) → switcher UI is hidden
+- 2+ themes registered → palette icon appears in the sidebar
+
+## Limitations
+
+This mechanism is for **visual theming via CSS only**. Replacing Vue
+components (custom layouts, different message bubble, etc.) is out of scope
+and would need a separate component-override system.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -974,6 +974,7 @@
   "template.deletionConfirmation": "This action cannot be undone. This will permanently delete this template.",
   "template.edit": "Edit template",
   "template.new": "New template",
+  "theme.switcher": "Theme",
   "toast.apiKeyGenerated": "API key generated",
   "toast.authorizationDenied": "Authorization denied",
   "toast.avatarUpdated": "Avatar updated successfully",


### PR DESCRIPTION
## Summary
Adds a tiny extensibility module so users and forks can build their own UI themes without modifying any upstream files. Defaults are unchanged — the switcher UI hides itself when only the default theme is registered, and the default theme uses no `data-theme` attribute, so stock installs see **zero visual or DOM change**.

## Pathway towards modular themes that don't conflict with core
A common pain for downstream users today is that any visual customisation requires patching upstream Vue/SCSS files, which conflict on every release. This PR proposes a contract that breaks that cycle for **CSS-based theming**:

- **Drop-in directory.** Themes live under `frontend/apps/main/src/themes/<name>/` and are auto-discovered via Vite glob (`import.meta.glob`). Adding a theme requires zero edits to upstream files — no rebase pain.
- **Attribute-scoped CSS.** Themes target `[data-theme="<name>"]` selectors, so they never bleed into the default look.
- **Switcher auto-hides.** With one theme registered (default), the switcher UI does not render. Forks adding a theme automatically get the dropdown.

A theme is two files:
```
themes/<name>/
  theme.js       // export default { id: '<name>', label: '<Label>' }
  theme.scss     // [data-theme="<name>"] { --primary: ...; ... }
```
(See the README in that directory for the full convention.)

Choice persists in `localStorage` and syncs across tabs via `useStorage`.

**Out of scope:** swapping Vue components (custom layouts, replacement message bubbles, etc.) — that's a separate, larger discussion around component override points. This PR covers visual theming via CSS only.

## Test plan
- [ ] Stock install: no theme switcher icon in sidebar, `<html>` has no `data-theme` attribute, no visual difference vs `main`
- [ ] Drop a `themes/foo/theme.js` exporting `{ id: 'foo', label: 'Foo' }` and `themes/foo/theme.scss` with `[data-theme="foo"] { --primary: ... }` → switcher appears in the icon rail; picking "Foo" sets `data-theme="foo"` on `<html>` and the styles apply
- [ ] Switching back to "Default" removes the attribute
- [ ] Choice persists across reloads (localStorage) and across browser tabs (`useStorage`)
- [ ] Choosing a theme that no longer exists falls back to default silently