### PR TITLE
Keep agent assigned on team change if they belong to the new team

### DIFF
--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -120,7 +120,7 @@ type priorityStore interface {
 
 type teamStore interface {
 	Get(int) (tmodels.Team, error)
-	UserBelongsToTeam(userID, teamID int) (bool, error)
+	UserBelongsToTeam(teamID, userID int) (bool, error)
 	GetMembers(int) ([]tmodels.TeamMember, error)
 }
 
@@ -732,8 +732,23 @@ func (c *Manager) UpdateConversationTeamAssignee(uuid string, teamID int, actor 
 
 	// Team changed?
 	if previousAssignedTeamID != teamID {
-		// Remove assigned user if team has changed.
-		c.RemoveConversationAssignee(uuid, models.AssigneeTypeUser, actor)
+		// Keep the agent assigned if they're a member of the new team —
+		// otherwise cross-team reassignment punishes agents who legitimately
+		// sit in both. Membership-check failure falls back to the existing
+		// unassign behaviour so we never silently keep someone who shouldn't
+		// be there.
+		keepUser := false
+		if conversation.AssignedUserID.Valid && conversation.AssignedUserID.Int > 0 {
+			belongs, err := c.teamStore.UserBelongsToTeam(teamID, conversation.AssignedUserID.Int)
+			if err != nil {
+				c.lo.Warn("membership check failed, defaulting to unassign", "user_id", conversation.AssignedUserID.Int, "team_id", teamID, "error", err)
+			} else if belongs {
+				keepUser = true
+			}
+		}
+		if !keepUser {
+			c.RemoveConversationAssignee(uuid, models.AssigneeTypeUser, actor)
+		}
 
 		// Apply SLA policy if this new team has a SLA policy.
 		team, err := c.teamStore.Get(teamID)


### PR DESCRIPTION
## What this changes

Reassigning a conversation to a different team currently always clears the assigned user. That's annoying when an agent legitimately sits on both teams (common with shared inboxes / multi-team agents) — they have to be re-picked manually after every team move.

This PR adds a `UserBelongsToTeam` check before unassigning. If the agent belongs to the new team they stay, otherwise the existing unassign behaviour kicks in. The membership helper already exists on the team store, so this is a small surgical change in `UpdateConversationTeamAssignee`.

## Drive-by fix on the way

The `teamStore` interface declared `UserBelongsToTeam(userID, teamID)` but the implementation is `UserBelongsToTeam(teamID, userID)` and the SQL binds `team_id = $1 AND user_id = $2`. Impl + SQL agree; the interface label was reversed. With the two out of sync, an honest caller passing args in the order the interface advertises would silently get wrong results.

I caught this by writing the call against the (misleading) interface, then having the change reviewed before opening — landed on fixing the interface to match the impl rather than papering over the call site. Updated the interface declaration so the next person isn't trapped.

## Why no test

There are currently no `_test.go` files under `internal/conversation/` or `internal/team/`, so adding one would require introducing test scaffolding (mock `teamStore`, etc.) for what's effectively a 3-line behaviour change. Happy to add a focused test if you'd prefer — just say the word.

## Test plan
- [ ] Conversation assigned to Agent A on Team X → reassign to Team Y where Agent A is also a member → Agent A stays assigned, no `assigned_user_change` activity emitted
- [ ] Same setup but Agent A is NOT on Team Y → Agent A unassigned, activity emitted (existing behaviour)
- [ ] Conversation with no user assignee → reassign team → no-op on the user side, just the team change
- [ ] Same team selected (no actual change) → no-op (existing fast-path)