### PR TITLE
Add unread list filter for conversations

### DIFF
--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -60,16 +60,17 @@ type createConversationRequest struct {
 // handleGetAllConversations retrieves all conversations.
 func handleGetAllConversations(r *fastglue.Request) error {
 	var (
-		app     = r.Context.(*App)
-		user    = r.RequestCtx.UserValue("user").(amodels.User)
-		order   = string(r.RequestCtx.QueryArgs().Peek("order"))
-		orderBy = string(r.RequestCtx.QueryArgs().Peek("order_by"))
-		filters = string(r.RequestCtx.QueryArgs().Peek("filters"))
-		total   = 0
+		app        = r.Context.(*App)
+		user       = r.RequestCtx.UserValue("user").(amodels.User)
+		order      = string(r.RequestCtx.QueryArgs().Peek("order"))
+		orderBy    = string(r.RequestCtx.QueryArgs().Peek("order_by"))
+		filters    = string(r.RequestCtx.QueryArgs().Peek("filters"))
+		unreadOnly = r.RequestCtx.QueryArgs().GetBool("unread_only")
+		total      = 0
 	)
 	page, pageSize := getPagination(r)
 
-	conversations, err := app.conversation.GetAllConversationsList(user.ID, order, orderBy, filters, page, pageSize)
+	conversations, err := app.conversation.GetAllConversationsList(user.ID, order, orderBy, filters, unreadOnly, page, pageSize)
 	if err != nil {
 		return sendErrorEnvelope(r, err)
 	}
@@ -90,15 +91,16 @@ func handleGetAllConversations(r *fastglue.Request) error {
 // handleGetAssignedConversations retrieves conversations assigned to the current user.
 func handleGetAssignedConversations(r *fastglue.Request) error {
 	var (
-		app     = r.Context.(*App)
-		user    = r.RequestCtx.UserValue("user").(amodels.User)
-		order   = string(r.RequestCtx.QueryArgs().Peek("order"))
-		orderBy = string(r.RequestCtx.QueryArgs().Peek("order_by"))
-		filters = string(r.RequestCtx.QueryArgs().Peek("filters"))
-		total   = 0
+		app        = r.Context.(*App)
+		user       = r.RequestCtx.UserValue("user").(amodels.User)
+		order      = string(r.RequestCtx.QueryArgs().Peek("order"))
+		orderBy    = string(r.RequestCtx.QueryArgs().Peek("order_by"))
+		filters    = string(r.RequestCtx.QueryArgs().Peek("filters"))
+		unreadOnly = r.RequestCtx.QueryArgs().GetBool("unread_only")
+		total      = 0
 	)
 	page, pageSize := getPagination(r)
-	conversations, err := app.conversation.GetAssignedConversationsList(user.ID, user.ID, order, orderBy, filters, page, pageSize)
+	conversations, err := app.conversation.GetAssignedConversationsList(user.ID, user.ID, order, orderBy, filters, unreadOnly, page, pageSize)
 	if err != nil {
 		return sendErrorEnvelope(r, err)
 	}
@@ -118,16 +120,17 @@ func handleGetAssignedConversations(r *fastglue.Request) error {
 // handleGetUnassignedConversations retrieves unassigned conversations.
 func handleGetUnassignedConversations(r *fastglue.Request) error {
 	var (
-		app     = r.Context.(*App)
-		user    = r.RequestCtx.UserValue("user").(amodels.User)
-		order   = string(r.RequestCtx.QueryArgs().Peek("order"))
-		orderBy = string(r.RequestCtx.QueryArgs().Peek("order_by"))
-		filters = string(r.RequestCtx.QueryArgs().Peek("filters"))
-		total   = 0
+		app        = r.Context.(*App)
+		user       = r.RequestCtx.UserValue("user").(amodels.User)
+		order      = string(r.RequestCtx.QueryArgs().Peek("order"))
+		orderBy    = string(r.RequestCtx.QueryArgs().Peek("order_by"))
+		filters    = string(r.RequestCtx.QueryArgs().Peek("filters"))
+		unreadOnly = r.RequestCtx.QueryArgs().GetBool("unread_only")
+		total      = 0
 	)
 	page, pageSize := getPagination(r)
 
-	conversations, err := app.conversation.GetUnassignedConversationsList(user.ID, order, orderBy, filters, page, pageSize)
+	conversations, err := app.conversation.GetUnassignedConversationsList(user.ID, order, orderBy, filters, unreadOnly, page, pageSize)
 	if err != nil {
 		return sendErrorEnvelope(r, err)
 	}

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -51,6 +51,17 @@ var (
 	conversationsAllowedFields      = []string{"status_id", "priority_id", "assigned_team_id", "assigned_user_id", "inbox_id", "last_message_at", "last_interaction_at", "created_at", "waiting_since", "next_sla_deadline_at", "priority_id"}
 	conversationStatusAllowedFields = []string{"id", "name"}
 	usersAllowedFields              = []string{"email"}
+	unreadConversationCondition     = `EXISTS (
+		SELECT 1
+		FROM conversation_messages cm
+		WHERE cm.conversation_id = conversations.id
+		AND cm.created_at > COALESCE(
+			(SELECT cls.last_seen_at FROM conversation_last_seen cls
+			 WHERE cls.conversation_id = conversations.id AND cls.user_id = $1),
+			'1970-01-01'::TIMESTAMPTZ
+		)
+		AND (cm.meta IS NULL OR NOT COALESCE((cm.meta->>'continuity_email')::boolean, false))
+	)`
 )
 
 const (
@@ -525,28 +536,28 @@ func (c *Manager) GetConversationUUID(id int) (string, error) {
 }
 
 // GetAllConversationsList retrieves all conversations with optional filtering, ordering, and pagination.
-func (c *Manager) GetAllConversationsList(viewingUserID int, order, orderBy, filters string, page, pageSize int) ([]models.ConversationListItem, error) {
-	return c.GetConversations(viewingUserID, 0, []int{}, []string{models.AllConversations}, order, orderBy, filters, page, pageSize)
+func (c *Manager) GetAllConversationsList(viewingUserID int, order, orderBy, filters string, unreadOnly bool, page, pageSize int) ([]models.ConversationListItem, error) {
+	return c.GetConversations(viewingUserID, 0, []int{}, []string{models.AllConversations}, order, orderBy, filters, unreadOnly, page, pageSize)
 }
 
 // GetAssignedConversationsList retrieves conversations assigned to a specific user with optional filtering, ordering, and pagination.
-func (c *Manager) GetAssignedConversationsList(viewingUserID, userID int, order, orderBy, filters string, page, pageSize int) ([]models.ConversationListItem, error) {
-	return c.GetConversations(viewingUserID, userID, []int{}, []string{models.AssignedConversations}, order, orderBy, filters, page, pageSize)
+func (c *Manager) GetAssignedConversationsList(viewingUserID, userID int, order, orderBy, filters string, unreadOnly bool, page, pageSize int) ([]models.ConversationListItem, error) {
+	return c.GetConversations(viewingUserID, userID, []int{}, []string{models.AssignedConversations}, order, orderBy, filters, unreadOnly, page, pageSize)
 }
 
 // GetUnassignedConversationsList retrieves conversations assigned to a team the user is part of with optional filtering, ordering, and pagination.
-func (c *Manager) GetUnassignedConversationsList(viewingUserID int, order, orderBy, filters string, page, pageSize int) ([]models.ConversationListItem, error) {
-	return c.GetConversations(viewingUserID, 0, []int{}, []string{models.UnassignedConversations}, order, orderBy, filters, page, pageSize)
+func (c *Manager) GetUnassignedConversationsList(viewingUserID int, order, orderBy, filters string, unreadOnly bool, page, pageSize int) ([]models.ConversationListItem, error) {
+	return c.GetConversations(viewingUserID, 0, []int{}, []string{models.UnassignedConversations}, order, orderBy, filters, unreadOnly, page, pageSize)
 }
 
 // GetTeamUnassignedConversationsList retrieves conversations assigned to a team with optional filtering, ordering, and pagination.
 func (c *Manager) GetTeamUnassignedConversationsList(viewingUserID, teamID int, order, orderBy, filters string, page, pageSize int) ([]models.ConversationListItem, error) {
-	return c.GetConversations(viewingUserID, 0, []int{teamID}, []string{models.TeamUnassignedConversations}, order, orderBy, filters, page, pageSize)
+	return c.GetConversations(viewingUserID, 0, []int{teamID}, []string{models.TeamUnassignedConversations}, order, orderBy, filters, false, page, pageSize)
 }
 
 // GetMentionedConversationsList retrieves conversations where the user is mentioned (directly or via team).
 func (c *Manager) GetMentionedConversationsList(viewingUserID int, order, orderBy, filters string, page, pageSize int) ([]models.ConversationListItem, error) {
-	return c.GetConversations(viewingUserID, 0, []int{}, []string{models.MentionedConversations}, order, orderBy, filters, page, pageSize)
+	return c.GetConversations(viewingUserID, 0, []int{}, []string{models.MentionedConversations}, order, orderBy, filters, false, page, pageSize)
 }
 
 // InsertMentions inserts mentions for a message.
@@ -571,16 +582,16 @@ func (c *Manager) InsertMentions(conversationID, messageID, mentionedByUserID in
 }
 
 func (c *Manager) GetViewConversationsList(viewingUserID, userID int, teamIDs []int, listType []string, order, orderBy, filters string, page, pageSize int) ([]models.ConversationListItem, error) {
-	return c.GetConversations(viewingUserID, userID, teamIDs, listType, order, orderBy, filters, page, pageSize)
+	return c.GetConversations(viewingUserID, userID, teamIDs, listType, order, orderBy, filters, false, page, pageSize)
 }
 
 // GetConversations retrieves conversations list based on user ID, type, and optional filtering, ordering, and pagination.
 // viewingUserID is used to calculate per-agent unread counts.
-func (c *Manager) GetConversations(viewingUserID, userID int, teamIDs []int, listTypes []string, order, orderBy, filters string, page, pageSize int) ([]models.ConversationListItem, error) {
+func (c *Manager) GetConversations(viewingUserID, userID int, teamIDs []int, listTypes []string, order, orderBy, filters string, unreadOnly bool, page, pageSize int) ([]models.ConversationListItem, error) {
 	var conversations = make([]models.ConversationListItem, 0)
 
 	// Make the query.
-	query, qArgs, err := c.makeConversationsListQuery(viewingUserID, userID, teamIDs, listTypes, c.q.GetConversations, order, orderBy, page, pageSize, filters)
+	query, qArgs, err := c.makeConversationsListQuery(viewingUserID, userID, teamIDs, listTypes, c.q.GetConversations, order, orderBy, unreadOnly, page, pageSize, filters)
 	if err != nil {
 		c.lo.Error("error making conversations query", "error", err)
 		return conversations, envelope.NewError(envelope.GeneralError, c.i18n.T("globals.messages.somethingWentWrong"), nil)
@@ -1482,7 +1493,7 @@ func (c *Manager) getConversationTags(uuid string) ([]string, error) {
 // makeConversationsListQuery prepares a SQL query string for conversations list
 // viewingUserID is used as $1 for per-agent unread count calculation
 // $2 is includeMentions bool for conditional mentioned_message_uuid column
-func (c *Manager) makeConversationsListQuery(viewingUserID, userID int, teamIDs []int, listTypes []string, baseQuery, order, orderBy string, page, pageSize int, filtersJSON string) (string, []interface{}, error) {
+func (c *Manager) makeConversationsListQuery(viewingUserID, userID int, teamIDs []int, listTypes []string, baseQuery, order, orderBy string, unreadOnly bool, page, pageSize int, filtersJSON string) (string, []interface{}, error) {
 	includeMentions := slices.Contains(listTypes, models.MentionedConversations)
 	qArgs := []any{viewingUserID, includeMentions}
 
@@ -1584,6 +1595,9 @@ func (c *Manager) makeConversationsListQuery(viewingUserID, userID int, teamIDs 
 	var whereClause string
 	if len(conditions) > 0 {
 		whereClause = "AND (" + strings.Join(conditions, " OR ") + ")"
+	}
+	if unreadOnly {
+		whereClause += " AND " + unreadConversationCondition
 	}
 
 	// Add tag filter conditions

--- a/internal/conversation/conversation_query_test.go
+++ b/internal/conversation/conversation_query_test.go
@@ -1,0 +1,72 @@
+package conversation
+
+import (
+	"strings"
+	"testing"
+
+	cmodels "github.com/abhinavxd/libredesk/internal/conversation/models"
+)
+
+const conversationsListTestQuery = "SELECT conversations.id FROM conversations WHERE 1=1 %s"
+
+func TestMakeConversationsListQueryAddsUnreadOnlyFilter(t *testing.T) {
+	query, args, err := (&Manager{}).makeConversationsListQuery(
+		42,
+		42,
+		nil,
+		[]string{cmodels.AssignedConversations},
+		conversationsListTestQuery,
+		"",
+		"",
+		true,
+		1,
+		30,
+		"[]",
+	)
+	if err != nil {
+		t.Fatalf("make query: %v", err)
+	}
+
+	for _, want := range []string{
+		"conversations.assigned_user_id = $3",
+		"EXISTS (",
+		"FROM conversation_messages cm",
+		"FROM conversation_last_seen cls",
+		"cls.user_id = $1",
+		"continuity_email",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("query does not contain %q:\n%s", want, query)
+		}
+	}
+
+	if len(args) != 5 {
+		t.Fatalf("args length = %d, want 5: %#v", len(args), args)
+	}
+	if args[0] != 42 || args[1] != false || args[2] != 42 || args[3] != 30 || args[4] != 0 {
+		t.Fatalf("unexpected args: %#v", args)
+	}
+}
+
+func TestMakeConversationsListQueryOmitsUnreadOnlyFilter(t *testing.T) {
+	query, _, err := (&Manager{}).makeConversationsListQuery(
+		42,
+		42,
+		nil,
+		[]string{cmodels.AssignedConversations},
+		conversationsListTestQuery,
+		"",
+		"",
+		false,
+		1,
+		30,
+		"[]",
+	)
+	if err != nil {
+		t.Fatalf("make query: %v", err)
+	}
+
+	if strings.Contains(query, "conversation_last_seen cls") {
+		t.Fatalf("query contains unread filter when unreadOnly is false:\n%s", query)
+	}
+}


### PR DESCRIPTION
This pull request adds support for filtering conversations by unread status across several endpoints. It introduces an `unread_only` query parameter that, when set, restricts results to only those conversations with unread messages for the user. The changes propagate this filter through the handler, manager, and query layers, and include a new SQL condition and tests to ensure correctness.

**Unread conversations filter support:**

* Added an `unread_only` query parameter to the `handleGetAllConversations`, `handleGetAssignedConversations`, and `handleGetUnassignedConversations` handlers, passing it through to the conversation manager methods. [[1]](diffhunk://#diff-e1fe32b14ef69071e753f6a9db5b6d80f4e58b354a35686f58655863f4f96318R68-R73) [[2]](diffhunk://#diff-e1fe32b14ef69071e753f6a9db5b6d80f4e58b354a35686f58655863f4f96318R99-R103) [[3]](diffhunk://#diff-e1fe32b14ef69071e753f6a9db5b6d80f4e58b354a35686f58655863f4f96318R128-R133)
* Updated `GetAllConversationsList`, `GetAssignedConversationsList`, and `GetUnassignedConversationsList` in `conversation.go` to accept and forward the `unreadOnly` parameter, ensuring the filter is applied throughout the call chain. [[1]](diffhunk://#diff-e5109e2424cdf3edbb770486c06f408c61547cb9169d0a363b68d2d69d607dc3L528-R560) [[2]](diffhunk://#diff-e5109e2424cdf3edbb770486c06f408c61547cb9169d0a363b68d2d69d607dc3L574-R594)

**Query logic and SQL changes:**

* Introduced the `unreadConversationCondition` SQL fragment, which checks for the existence of messages newer than the user's last seen timestamp and excludes continuity emails. This condition is appended to the query when the `unreadOnly` filter is active. [[1]](diffhunk://#diff-e5109e2424cdf3edbb770486c06f408c61547cb9169d0a363b68d2d69d607dc3R54-R64) [[2]](diffhunk://#diff-e5109e2424cdf3edbb770486c06f408c61547cb9169d0a363b68d2d69d607dc3L1485-R1496) [[3]](diffhunk://#diff-e5109e2424cdf3edbb770486c06f408c61547cb9169d0a363b68d2d69d607dc3R1599-R1601)

**Testing:**

* Added unit tests in `conversation_query_test.go` to verify that the unread filter is correctly included or omitted in the generated SQL query based on the `unreadOnly` parameter.