### PR TITLE
Add contact notes to conversation sidebar

### DIFF
--- a/frontend/apps/main/src/features/contact/ContactNotes.vue
+++ b/frontend/apps/main/src/features/contact/ContactNotes.vue
@@ -203,19 +203,20 @@ const latestFetchId = ref(0)
 
 
 const fetchNotes = async (contactId = props.contactId) => {
-  const fetchId = ++latestFetchId.value 
+  const fetchId = ++latestFetchId.value
   try {
     isLoading.value = true
     const { data } = await api.getContactNotes(contactId)
     if (fetchId !== latestFetchId.value) return
     notes.value = data.data
   } catch (error) {
+    if (fetchId !== latestFetchId.value) return
     emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
       variant: 'destructive',
       description: handleHTTPError(error).message
     })
   } finally {
-    if (fetchId === latestFetchId.value){
+    if (fetchId === latestFetchId.value) {
       isLoading.value = false
     }
   }
@@ -265,13 +266,15 @@ const visibleNotes = computed(() => {
 })
 
 watch(() => props.contactId, (newId) => {
-    showAll.value = false
-    cancelAddNote()
-    if (!newId){
-      notes.value = []
-      return
-    }
-    fetchNotes(newId)
+  latestFetchId.value++
+  showAll.value = false
+  cancelAddNote()
+  notes.value = []
+  if (!newId) {
+    isLoading.value = false
+    return
+  }
+  fetchNotes(newId)
 }, { immediate: true })
 
 </script>

--- a/frontend/apps/main/src/features/contact/ContactNotes.vue
+++ b/frontend/apps/main/src/features/contact/ContactNotes.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full space-y-6 pb-8 relative">
+  <div class="w-full space-y-4 relative">
     <!-- Header -->
     <div class="flex items-center justify-between mb-4">
       <span class="text-xl font-semibold text-foreground">

--- a/frontend/apps/main/src/features/contact/ContactNotes.vue
+++ b/frontend/apps/main/src/features/contact/ContactNotes.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="w-full space-y-4 relative">
     <!-- Header -->
-    <div class="flex items-center justify-between mb-4">
-      <span class="text-xl font-semibold text-foreground">
+    <div class="flex items-center mb-4" :class="compact ? 'justify-end' : 'justify-between'">
+      <span v-if="!compact" class="text-xl font-semibold text-foreground">
         {{ $t('globals.terms.note', 2) }}
       </span>
       <Button
         variant="outline"
         size="sm"
         @click="startAddingNote"
-        v-if="!isAddingNote && !isLoading && notes.length !== 0"
+        v-if="!isAddingNote && !isLoading && notes.length !== 0 && userStore.can('contact_notes:write')"
         class="transition-all hover:bg-primary/10 hover:border-primary/30"
       >
         <PlusIcon size="18" />
@@ -22,7 +22,7 @@
     </div>
 
     <!-- Note input -->
-    <div v-if="isAddingNote">
+    <div v-if="isAddingNote && userStore.can('contact_notes:write')">
       <form @submit.prevent="addOrUpdateNote" @keydown.ctrl.enter="addOrUpdateNote">
         <div class="space-y-4">
           <div class="box p-2 h-52 min-h-52">
@@ -50,16 +50,25 @@
         class="overflow-hidden hover:border-border transition-all duration-200 box hover:shadow"
       >
         <!-- Header -->
-        <CardHeader class="bg-background border-b p-2">
+        <CardHeader :class="compact ? 'p-3 pb-2' : 'bg-background border-b p-2'">
           <div class="flex items-center justify-between">
-            <div class="flex items-center space-x-3">
-              <Avatar class="border shadow-sm">
+            <div class="flex items-center" :class="compact ? 'space-x-2 min-w-0' : 'space-x-3'">
+              <Avatar :class="compact ? 'h-5 w-5' : 'border shadow-sm'">
                 <AvatarImage :src="note.avatar_url" />
-                <AvatarFallback>
+                <AvatarFallback :class="{ 'text-[10px]': compact }">
                   {{ getInitials(note.first_name, note.last_name) }}
                 </AvatarFallback>
               </Avatar>
-              <div>
+              <div v-if="compact" class="flex items-center gap-1.5 min-w-0 text-xs">
+                <span class="font-medium text-foreground truncate">
+                  {{ note.first_name }} {{ note.last_name }}
+                </span>
+                <span class="text-muted-foreground">·</span>
+                <span class="text-muted-foreground truncate" :title="formatDate(note.created_at)">
+                  {{ relativeDate(note.created_at) }}
+                </span>
+              </div>
+              <div v-else>
                 <p class="text-sm font-medium text-foreground">
                   {{ note.first_name }} {{ note.last_name }}
                 </p>
@@ -77,8 +86,13 @@
               "
             >
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" class="h-8 w-8 rounded-full">
-                  <MoreVerticalIcon class="h-4 w-4" />
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  class="rounded-full"
+                  :class="compact ? 'h-6 w-6 -mr-1' : 'h-8 w-8'"
+                >
+                  <MoreVerticalIcon :class="compact ? 'h-3.5 w-3.5' : 'h-4 w-4'" />
                   <span class="sr-only">{{ $t('globals.terms.openMenu') }}</span>
                 </Button>
               </DropdownMenuTrigger>
@@ -98,7 +112,7 @@
         </CardHeader>
 
         <!-- Note content -->
-        <CardContent class="pt-4 pb-5">
+        <CardContent :class="compact ? 'px-3 pb-3 pt-0' : 'pt-4 pb-5'">
           <Letter
             :html="note.note"
             :allowedSchemas="['cid', 'https', 'http', 'mailto']"
@@ -107,7 +121,7 @@
         </CardContent>
       </Card>
       <!-- Load more notes -->
-      <div v-if="notes.length > NOTES_LIMIT && !showAll" class="flex justify-center pt-2">
+      <div v-if="compact && notes.length > NOTES_LIMIT && !showAll" class="flex justify-center pt-2">
        <Button variant="ghost" size="sm" @click="showAll = true">
          {{ $t('globals.terms.loadMore') }} ({{ notes.length - NOTES_LIMIT }})
        </Button>
@@ -129,7 +143,12 @@
         <p class="mt-1 text-sm text-muted-foreground max-w-sm mx-auto">
           {{ $t('contact.notes.help') }}
         </p>
-        <Button variant="outline" class="mt-3" @click="startAddingNote">
+        <Button
+          v-if="userStore.can('contact_notes:write')"
+          variant="outline"
+          class="mt-3"
+          @click="startAddingNote"
+        >
           <PlusIcon size="15" />
           {{ $t('contact.addNote') }}
         </Button>
@@ -140,7 +159,7 @@
 
 <script setup>
 import { ref, watch, computed } from 'vue'
-import { format } from 'date-fns'
+import { format, formatDistanceToNow } from 'date-fns'
 import { Button } from '@shared-ui/components/ui/button'
 import { Card, CardHeader, CardContent } from '@shared-ui/components/ui/card'
 import { Avatar, AvatarImage, AvatarFallback } from '@shared-ui/components/ui/avatar'
@@ -168,7 +187,8 @@ import { useUserStore } from '@main/stores/user'
 import { Letter } from 'vue-letter'
 import api from '@main/api'
 
-const props = defineProps({ contactId: Number })
+const props = defineProps({ contactId: Number, compact: { type: Boolean, default: false } })
+
 const { t } = useI18n()
 const emitter = useEmitter()
 const userStore = useUserStore()
@@ -202,6 +222,7 @@ const fetchNotes = async (contactId = props.contactId) => {
 }
 
 const formatDate = (date) => format(new Date(date), 'PPP p')
+const relativeDate = (date) => formatDistanceToNow(new Date(date), { addSuffix: true })
 
 const startAddingNote = () => {
   isAddingNote.value = true
@@ -238,7 +259,10 @@ const deleteNote = async (noteId) => {
   }
 }
 
-const visibleNotes = computed(() => showAll.value ? notes.value : notes.value.slice(0, NOTES_LIMIT))
+const visibleNotes = computed(() => {
+  if (!props.compact || showAll.value) return notes.value
+  return notes.value.slice(0, NOTES_LIMIT)
+})
 
 watch(() => props.contactId, (newId) => {
     showAll.value = false

--- a/frontend/apps/main/src/features/contact/ContactNotes.vue
+++ b/frontend/apps/main/src/features/contact/ContactNotes.vue
@@ -179,11 +179,15 @@ const newNote = ref('')
 const isLoading = ref(false)
 const NOTES_LIMIT = 10
 const showAll = ref(false)
+const latestFetchId = ref(0)
 
-const fetchNotes = async () => {
+
+const fetchNotes = async (contactId = props.contactId) => {
+  const fetchId = ++latestFetchId.value 
   try {
     isLoading.value = true
-    const { data } = await api.getContactNotes(props.contactId)
+    const { data } = await api.getContactNotes(contactId)
+    if (fetchId !== latestFetchId.value) return
     notes.value = data.data
   } catch (error) {
     emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
@@ -191,7 +195,9 @@ const fetchNotes = async () => {
       description: handleHTTPError(error).message
     })
   } finally {
-    isLoading.value = false
+    if (fetchId === latestFetchId.value){
+      isLoading.value = false
+    }
   }
 }
 
@@ -235,11 +241,13 @@ const deleteNote = async (noteId) => {
 const visibleNotes = computed(() => showAll.value ? notes.value : notes.value.slice(0, NOTES_LIMIT))
 
 watch(() => props.contactId, (newId) => {
-  if (newId) {
     showAll.value = false
     cancelAddNote()
-    fetchNotes()
-  }
+    if (!newId){
+      notes.value = []
+      return
+    }
+    fetchNotes(newId)
 }, { immediate: true })
 
 </script>

--- a/frontend/apps/main/src/features/contact/ContactNotes.vue
+++ b/frontend/apps/main/src/features/contact/ContactNotes.vue
@@ -133,7 +133,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, watch } from 'vue'
 import { format } from 'date-fns'
 import { Button } from '@shared-ui/components/ui/button'
 import { Card, CardHeader, CardContent } from '@shared-ui/components/ui/card'
@@ -187,8 +187,6 @@ const fetchNotes = async () => {
   }
 }
 
-onMounted(fetchNotes)
-
 const formatDate = (date) => format(new Date(date), 'PPP p')
 
 const startAddingNote = () => {
@@ -225,4 +223,12 @@ const deleteNote = async (noteId) => {
     await fetchNotes()
   }
 }
+
+watch(() => props.contactId, (newId) => {
+  if (newId) {
+    cancelAddNote()
+    fetchNotes()
+  }
+}, { immediate: true })
+
 </script>

--- a/frontend/apps/main/src/features/contact/ContactNotes.vue
+++ b/frontend/apps/main/src/features/contact/ContactNotes.vue
@@ -45,7 +45,7 @@
     <!-- Notes card list -->
     <div class="space-y-4">
       <Card
-        v-for="note in notes"
+        v-for="note in visibleNotes"
         :key="note.id"
         class="overflow-hidden hover:border-border transition-all duration-200 box hover:shadow"
       >
@@ -106,6 +106,12 @@
           />
         </CardContent>
       </Card>
+      <!-- Load more notes -->
+      <div v-if="notes.length > NOTES_LIMIT && !showAll" class="flex justify-center pt-2">
+       <Button variant="ghost" size="sm" @click="showAll = true">
+         {{ $t('globals.terms.loadMore') }} ({{ notes.length - NOTES_LIMIT }})
+       </Button>
+      </div>
     </div>
 
     <!-- No notes message -->
@@ -133,7 +139,7 @@
 </template>
 
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { format } from 'date-fns'
 import { Button } from '@shared-ui/components/ui/button'
 import { Card, CardHeader, CardContent } from '@shared-ui/components/ui/card'
@@ -171,6 +177,8 @@ const notes = ref([])
 const isAddingNote = ref(false)
 const newNote = ref('')
 const isLoading = ref(false)
+const NOTES_LIMIT = 10
+const showAll = ref(false)
 
 const fetchNotes = async () => {
   try {
@@ -224,8 +232,11 @@ const deleteNote = async (noteId) => {
   }
 }
 
+const visibleNotes = computed(() => showAll.value ? notes.value : notes.value.slice(0, NOTES_LIMIT))
+
 watch(() => props.contactId, (newId) => {
   if (newId) {
+    showAll.value = false
     cancelAddNote()
     fetchNotes()
   }

--- a/frontend/apps/main/src/features/conversation/sidebar/ConversationSideBar.vue
+++ b/frontend/apps/main/src/features/conversation/sidebar/ConversationSideBar.vue
@@ -94,12 +94,16 @@
       </AccordionItem>
 
       <!-- Contact notes -->
-      <AccordionItem value="contact_notes" class="accordion-item" v-if="conversationStore.current?.contact?.id">
+      <AccordionItem
+        value="contact_notes"
+        class="accordion-item"
+        v-if="conversationStore.current?.contact?.id && userStore.can('contact_notes:read')"
+      >
         <AccordionTrigger class="accordion-trigger">
-          {{ $t('conversation.sidebar.contactNotes') }}
+          {{ $t('globals.terms.note', 2) }}
         </AccordionTrigger>
         <AccordionContent class="accordion-content">
-          <ContactNotes :contact-id="conversationStore.current.contact.id" />
+          <ContactNotes :contact-id="conversationStore.current.contact.id" compact />
         </AccordionContent>
       </AccordionItem>
 
@@ -122,6 +126,7 @@ import { useConversationStore } from '@/stores/conversation'
 import { useUsersStore } from '@/stores/users'
 import { useTeamStore } from '@/stores/team'
 import { useTagStore } from '@/stores/tag'
+import { useUserStore } from '@/stores/user'
 import {
   Accordion,
   AccordionContent,
@@ -151,6 +156,7 @@ const conversationStore = useConversationStore()
 const usersStore = useUsersStore()
 const teamsStore = useTeamStore()
 const tagStore = useTagStore()
+const userStore = useUserStore()
 const tags = ref([])
 // Save the accordion state in local storage
 const accordionState = useStorage('conversation-sidebar-accordion', [])

--- a/frontend/apps/main/src/features/conversation/sidebar/ConversationSideBar.vue
+++ b/frontend/apps/main/src/features/conversation/sidebar/ConversationSideBar.vue
@@ -93,6 +93,16 @@
         </AccordionContent>
       </AccordionItem>
 
+      <!-- Contact notes -->
+      <AccordionItem value="contact_notes" class="accordion-item" v-if="conversationStore.current?.contact?.id">
+        <AccordionTrigger class="accordion-trigger">
+          {{ $t('conversation.sidebar.contactNotes') }}
+        </AccordionTrigger>
+        <AccordionContent class="accordion-content">
+          <ContactNotes :contact-id="conversationStore.current.contact.id" />
+        </AccordionContent>
+      </AccordionItem>
+
       <!-- Previous conversations -->
       <AccordionItem value="previous_conversations" class="accordion-item">
         <AccordionTrigger class="accordion-trigger">
@@ -128,6 +138,7 @@ import { useI18n } from 'vue-i18n'
 import { useStorage } from '@vueuse/core'
 import CustomAttributes from '@/features/conversation/sidebar/CustomAttributes.vue'
 import { useCustomAttributeStore } from '../../../stores/customAttributes'
+import ContactNotes from '@/features/contact/ContactNotes.vue'
 import PreviousConversations from '@/features/conversation/sidebar/PreviousConversations.vue'
 import ConversationSideBarPageVisits from '@/features/conversation/sidebar/ConversationSideBarPageVisits.vue'
 import SelectComboBox from '@main/components/combobox/SelectCombobox.vue'

--- a/frontend/apps/main/src/layouts/contact/ContactDetail.vue
+++ b/frontend/apps/main/src/layouts/contact/ContactDetail.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-screen overflow-y-auto px-6 sm:px-6 md:px-12 lg:px-24 xl:px-24 2xl:px-96 pt-6">
+  <div class="w-full h-screen overflow-y-auto px-6 sm:px-6 md:px-12 lg:px-24 xl:px-24 2xl:px-96 pt-6 pb-12">
     <slot></slot>
   </div>
 </template>

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -493,7 +493,6 @@
   "conversation.sentViaEmail": "Sent via email",
   "conversation.showQuotedText": "Show quoted text",
   "conversation.sidebar.contactAttributes": "Contact attributes",
-  "conversation.sidebar.contactNotes": "Contact notes",
   "conversation.sidebar.information": "Information",
   "conversation.sidebar.lastVisitedPages": "Last visited pages",
   "conversation.sidebar.noPreviousConvo": "No previous conversations",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -493,6 +493,7 @@
   "conversation.sentViaEmail": "Sent via email",
   "conversation.showQuotedText": "Show quoted text",
   "conversation.sidebar.contactAttributes": "Contact attributes",
+  "conversation.sidebar.contactNotes": "Contact notes",
   "conversation.sidebar.information": "Information",
   "conversation.sidebar.lastVisitedPages": "Last visited pages",
   "conversation.sidebar.noPreviousConvo": "No previous conversations",


### PR DESCRIPTION
# Summary

This PR adds a **Contact Notes** section to the conversation sidebar in LibreDesk.
(Closes #301)

### Changes Made
- Added accordion section for contact notes in the conversation sidebar
- Added i18n key for contact notes
- Refetched notes when the selected contact changes
- Reduced spacing in the contact notes component for better UI consistency
- Limited displayed notes to 10 with a **Load more** option

### Demo
A demo video showcasing the feature implementation has been attached to this PR.


https://github.com/user-attachments/assets/07045e10-3020-411a-bacf-29de5679c10d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Contact Notes section to the conversation sidebar (shown when a contact exists and the user has read permission).
  * Notes now use client-side pagination; a "Load more" button appears when more notes exist.

* **UI Improvements**
  * Compact mode provides a denser notes layout and adjusted controls.
  * Add-note editor/button visibility is gated by write permission.
  * Increased vertical spacing on contact detail pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/abhinavxd/libredesk/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->