### PR TITLE
fix: hide Yahoo + Gmail forward quoted text.

### DIFF
--- a/frontend/apps/main/src/utils/quotedContent.test.js
+++ b/frontend/apps/main/src/utils/quotedContent.test.js
@@ -43,6 +43,14 @@ describe('containsQuoteMarkers', () => {
     expect(containsQuoteMarkers('<div class="OutlookMessageHeader">x</div>')).toBe(true)
   })
 
+  test('detects Yahoo Mail yahoo_quoted class', () => {
+    const html = `<div id="yahoo_quoted_9284519336" class="yahoo_quoted">
+      <div>On Monday, 18 May 2026, Support wrote:</div>
+      <div>Original message body</div>
+    </div>`
+    expect(containsQuoteMarkers(html)).toBe(true)
+  })
+
   test('detects real Hotmail reply payload', () => {
     const html = `<div class="elementToProof">Quoted reply!</div>
       <div id="appendonsend"></div>

--- a/frontend/apps/main/src/utils/quotedContent.test.js
+++ b/frontend/apps/main/src/utils/quotedContent.test.js
@@ -51,6 +51,14 @@ describe('containsQuoteMarkers', () => {
     expect(containsQuoteMarkers(html)).toBe(true)
   })
 
+  test('detects Gmail forward gmail_quote_container', () => {
+    const html = `<div class="gmail_quote gmail_quote_container">
+      <div dir="ltr" class="gmail_attr">---------- Forwarded message ---------</div>
+      <div>Original message body</div>
+    </div>`
+    expect(containsQuoteMarkers(html)).toBe(true)
+  })
+
   test('detects real Hotmail reply payload', () => {
     const html = `<div class="elementToProof">Quoted reply!</div>
       <div id="appendonsend"></div>

--- a/frontend/shared-ui/assets/styles/main.scss
+++ b/frontend/shared-ui/assets/styles/main.scss
@@ -311,7 +311,8 @@
   [id$="_OLK_SRC_BODY_SECTION"] ~ *,
   [class*="_OutlookMessageHeader"],
   [class*="_OutlookMessageHeader"] ~ *,
-  [class*="_yahoo_quoted"] {
+  [class*="_yahoo_quoted"],
+  [class*="_gmail_quote_container"] {
     @apply hidden;
   }
 }

--- a/frontend/shared-ui/assets/styles/main.scss
+++ b/frontend/shared-ui/assets/styles/main.scss
@@ -310,7 +310,8 @@
   [id$="_OLK_SRC_BODY_SECTION"],
   [id$="_OLK_SRC_BODY_SECTION"] ~ *,
   [class*="_OutlookMessageHeader"],
-  [class*="_OutlookMessageHeader"] ~ * {
+  [class*="_OutlookMessageHeader"] ~ *,
+  [class*="_yahoo_quoted"] {
     @apply hidden;
   }
 }

--- a/frontend/shared-ui/utils/quotedContent.js
+++ b/frontend/shared-ui/utils/quotedContent.js
@@ -4,13 +4,15 @@
 // attribute-suffix selectors (see .hide-quoted-text in main.scss).
 //
 // Scope: <blockquote> covers Gmail/Apple/Thunderbird. The id/class markers
-// below cover the Microsoft variants (Outlook desktop/web/mac, Hotmail).
+// below cover the Microsoft variants (Outlook desktop/web/mac, Hotmail)
+// and Yahoo Mail.
 export const QUOTE_MARKERS = [
   '<blockquote',
   'id="divRplyFwdMsg"',
   'id="appendonsend"',
   'id="OLK_SRC_BODY_SECTION"',
-  'class="OutlookMessageHeader"'
+  'class="OutlookMessageHeader"',
+  'class="yahoo_quoted"'
 ]
 
 export const containsQuoteMarkers = (html) => {

--- a/frontend/shared-ui/utils/quotedContent.js
+++ b/frontend/shared-ui/utils/quotedContent.js
@@ -3,16 +3,18 @@
 // render time, so any CSS that needs to match the rendered DOM must use
 // attribute-suffix selectors (see .hide-quoted-text in main.scss).
 //
-// Scope: <blockquote> covers Gmail/Apple/Thunderbird. The id/class markers
-// below cover the Microsoft variants (Outlook desktop/web/mac, Hotmail)
-// and Yahoo Mail.
+// Scope: <blockquote> covers Gmail/Apple/Thunderbird *replies*. Gmail
+// *forwards* wrap content in <div class="gmail_quote gmail_quote_container">
+// instead. The id/class markers below cover the Microsoft variants
+// (Outlook desktop/web/mac, Hotmail) and Yahoo Mail.
 export const QUOTE_MARKERS = [
   '<blockquote',
   'id="divRplyFwdMsg"',
   'id="appendonsend"',
   'id="OLK_SRC_BODY_SECTION"',
   'class="OutlookMessageHeader"',
-  'class="yahoo_quoted"'
+  'class="yahoo_quoted"',
+  'gmail_quote_container'
 ]
 
 export const containsQuoteMarkers = (html) => {


### PR DESCRIPTION
Yahoo wraps replies in `<div class="yahoo_quoted">`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Extended test coverage to verify detection of quoted email content from additional mail clients (Yahoo, Gmail).

* **Style**
  * Updated styling rules to consistently hide quoted email blocks from Yahoo and Gmail alongside existing providers.

* **Bug Fixes**
  * Improved recognition and handling of quoted content from more email sources for cleaner message display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/abhinavxd/libredesk/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->