### PR TITLE
fix: remove inbox keep-alive that caused duplicate admin requests

### DIFF
--- a/frontend/apps/main/src/App.vue
+++ b/frontend/apps/main/src/App.vue
@@ -112,11 +112,7 @@
           <PageHeader />
 
           <!-- Main content -->
-          <RouterView v-slot="{ Component }">
-            <keep-alive include="InboxLayout">
-              <component :is="Component" class="flex-grow" />
-            </keep-alive>
-          </RouterView>
+          <RouterView class="flex-grow" />
         </div>
         <ViewForm v-model:openDialog="openCreateViewForm" v-model:view="view" />
       </Sidebar>

--- a/frontend/apps/main/src/views/inbox/InboxView.vue
+++ b/frontend/apps/main/src/views/inbox/InboxView.vue
@@ -36,11 +36,15 @@ const fetchForCurrentRoute = () => {
   if (key === lastFetchedKey) return
   lastFetchedKey = key
 
-  const showLoader = !storeHasCurrentList()
+  // List already loaded: soft-refresh in place. A full fetch resets the list first and blanks it.
+  if (storeHasCurrentList()) {
+    conversationStore.refreshConversationList()
+    return
+  }
 
   if (viewID.value) {
     conversationStore.setListStatus('', false)
-    conversationStore.fetchConversationsList(showLoader, CONVERSATION_LIST_TYPE.VIEW, 0, [], viewID.value)
+    conversationStore.fetchConversationsList(true, CONVERSATION_LIST_TYPE.VIEW, 0, [], viewID.value)
     return
   }
 
@@ -48,9 +52,9 @@ const fetchForCurrentRoute = () => {
     conversationStore.setListStatus(CONVERSATION_DEFAULT_STATUSES.OPEN, false)
   }
   if (type.value) {
-    conversationStore.fetchConversationsList(showLoader, type.value)
+    conversationStore.fetchConversationsList(true, type.value)
   } else {
-    conversationStore.fetchConversationsList(showLoader, CONVERSATION_LIST_TYPE.TEAM_UNASSIGNED, teamID.value)
+    conversationStore.fetchConversationsList(true, CONVERSATION_LIST_TYPE.TEAM_UNASSIGNED, teamID.value)
   }
 }
 

--- a/frontend/apps/main/src/views/inbox/InboxView.vue
+++ b/frontend/apps/main/src/views/inbox/InboxView.vue
@@ -20,6 +20,15 @@ const conversationStore = useConversationStore()
 
 let lastFetchedKey = ''
 
+const storeHasCurrentList = () => {
+  const c = conversationStore.conversations
+  if (!c.initialized) return false
+  if (viewID.value) return c.listType === CONVERSATION_LIST_TYPE.VIEW && String(c.viewID) === String(viewID.value)
+  if (type.value) return c.listType === type.value
+  if (teamID.value) return c.listType === CONVERSATION_LIST_TYPE.TEAM_UNASSIGNED && String(c.teamID) === String(teamID.value)
+  return false
+}
+
 const fetchForCurrentRoute = () => {
   if (!type.value && !teamID.value && !viewID.value) return
 
@@ -27,9 +36,11 @@ const fetchForCurrentRoute = () => {
   if (key === lastFetchedKey) return
   lastFetchedKey = key
 
+  const showLoader = !storeHasCurrentList()
+
   if (viewID.value) {
     conversationStore.setListStatus('', false)
-    conversationStore.fetchConversationsList(true, CONVERSATION_LIST_TYPE.VIEW, 0, [], viewID.value)
+    conversationStore.fetchConversationsList(showLoader, CONVERSATION_LIST_TYPE.VIEW, 0, [], viewID.value)
     return
   }
 
@@ -37,9 +48,9 @@ const fetchForCurrentRoute = () => {
     conversationStore.setListStatus(CONVERSATION_DEFAULT_STATUSES.OPEN, false)
   }
   if (type.value) {
-    conversationStore.fetchConversationsList(true, type.value)
+    conversationStore.fetchConversationsList(showLoader, type.value)
   } else {
-    conversationStore.fetchConversationsList(true, CONVERSATION_LIST_TYPE.TEAM_UNASSIGNED, teamID.value)
+    conversationStore.fetchConversationsList(showLoader, CONVERSATION_LIST_TYPE.TEAM_UNASSIGNED, teamID.value)
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified routing render in the main layout and removed automatic preservation of the inbox layout so routed views refresh consistently

* **Bug Fixes**
  * Conversation list now avoids unnecessary full reloads: when the current list matches the route it performs a lightweight refresh and suppresses redundant loading indicators
<!-- end of auto-generated comment: release notes by coderabbit.ai -->