### PR TITLE
Resolves #363, implement CTRL+M hotkey to access the macro dialog

### DIFF
--- a/frontend/apps/main/src/features/command/CommandBox.vue
+++ b/frontend/apps/main/src/features/command/CommandBox.vue
@@ -299,6 +299,23 @@ const { Meta_K, Ctrl_K } = useMagicKeys({
 })
 
 watch([Meta_K, Ctrl_K], ([mac, win]) => {
+  setNestedCommand(null)
+  if (mac || win) toggleOpen()
+})
+
+const { Meta_M, Ctrl_M } = useMagicKeys({
+  passive: false,
+  onEventFired(e) {
+    if (e.key === 'm' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+    }
+  }
+})
+
+watch([Meta_M, Ctrl_M], ([mac, win]) => {
+  if (nestedCommand.value != 'apply-macro-to-new-conversation') {
+    setNestedCommand('apply-macro-to-existing-conversation')
+  }
   if (mac || win) toggleOpen()
 })
 
@@ -338,9 +355,10 @@ const otherActions = computed(
 )
 
 function toggleOpen() {
-  if (nestedCommand.value != 'apply-macro-to-new-conversation' && !open.value) {
-    nestedCommand.value = null
-  }
+  // Allow it to be set from the outside
+  // if (nestedCommand.value != 'apply-macro-to-new-conversation' && !open.value) {
+  //   nestedCommand.value = null
+  // }
   open.value = !open.value
 }
 

--- a/frontend/apps/main/src/features/command/CommandBox.vue
+++ b/frontend/apps/main/src/features/command/CommandBox.vue
@@ -289,34 +289,38 @@ const visibleMacros = computed(() => {
   return matched
 })
 
-const { Meta_K, Ctrl_K } = useMagicKeys({
-  passive: false,
-  onEventFired(e) {
-    if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+function preventDefaultOnHotkey(key) {
+  return (e) => {
+    if (e.key === key && (e.metaKey || e.ctrlKey)) {
       e.preventDefault()
     }
   }
+}
+
+const { Meta_K, Ctrl_K } = useMagicKeys({
+  passive: false,
+  onEventFired: preventDefaultOnHotkey('k')
 })
 
 watch([Meta_K, Ctrl_K], ([mac, win]) => {
-  setNestedCommand(null)
-  if (mac || win) toggleOpen()
+  if (mac || win) {
+    if (nestedCommand.value !== 'apply-macro-to-new-conversation') setNestedCommand(null)
+    toggleOpen()
+  }
 })
 
 const { Meta_M, Ctrl_M } = useMagicKeys({
   passive: false,
-  onEventFired(e) {
-    if (e.key === 'm' && (e.metaKey || e.ctrlKey)) {
-      e.preventDefault()
-    }
-  }
+  onEventFired: preventDefaultOnHotkey('m')
 })
 
 watch([Meta_M, Ctrl_M], ([mac, win]) => {
-  if (nestedCommand.value != 'apply-macro-to-new-conversation') {
-    setNestedCommand('apply-macro-to-existing-conversation')
+  if (mac || win) {
+    if (nestedCommand.value !== 'apply-macro-to-new-conversation') {
+      setNestedCommand('apply-macro-to-existing-conversation')
+    }
+    toggleOpen()
   }
-  if (mac || win) toggleOpen()
 })
 
 const highlightedMacro = ref(null)
@@ -355,10 +359,6 @@ const otherActions = computed(
 )
 
 function toggleOpen() {
-  // Allow it to be set from the outside
-  // if (nestedCommand.value != 'apply-macro-to-new-conversation' && !open.value) {
-  //   nestedCommand.value = null
-  // }
   open.value = !open.value
 }
 

--- a/frontend/apps/main/src/features/conversation/CreateConversation.vue
+++ b/frontend/apps/main/src/features/conversation/CreateConversation.vue
@@ -321,6 +321,7 @@ const emailQuery = ref('')
 const conversationStore = useConversationStore()
 const macroStore = useMacroStore()
 let timeoutId = null
+let previousMacroView = ''
 const insertContent = ref('')
 const selectedContact = ref(null)
 const emailInputRef = ref(null)
@@ -367,6 +368,7 @@ onUnmounted(() => {
   clearTimeout(timeoutId)
   clearMediaFiles()
   conversationStore.resetMacro(MACRO_CONTEXT.NEW_CONVERSATION)
+  macroStore.setCurrentView(previousMacroView)
   emitter.emit(EMITTER_EVENTS.SET_NESTED_COMMAND, {
     command: null,
     open: false
@@ -374,6 +376,7 @@ onUnmounted(() => {
 })
 
 onMounted(() => {
+  previousMacroView = macroStore.currentView
   macroStore.setCurrentView('starting_conversation')
   emitter.emit(EMITTER_EVENTS.SET_NESTED_COMMAND, {
     command: 'apply-macro-to-new-conversation',

--- a/frontend/apps/main/src/stores/macro.js
+++ b/frontend/apps/main/src/stores/macro.js
@@ -81,6 +81,7 @@ export const useMacroStore = defineStore('macroStore', () => {
     return {
         macroList,
         macroOptions,
+        currentView,
         loadMacros,
         setCurrentView
     }


### PR DESCRIPTION
CTRL+M for quick access to macro dialog.  It works from either the new conversation or reply conversation paths. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Command dialog keyboard shortcut now reliably clears prior nested command state when opened, preventing stale command behavior.
* **New Features**
  * Macro dialog now preserves and restores the previously selected macro view across open/close cycles for a smoother workflow.
* **Store**
  * Macro view state is now exposed for consistent UI coordination across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->