### PR TITLE
Resolves #364, Append macro content into the editors instead of replacing the entire content

### DIFF
--- a/frontend/apps/main/src/features/conversation/CreateConversation.vue
+++ b/frontend/apps/main/src/features/conversation/CreateConversation.vue
@@ -503,9 +503,10 @@ const createConversation = form.handleSubmit(async (values) => {
 watch(
   () => conversationStore.getMacro(MACRO_CONTEXT.NEW_CONVERSATION).id,
   () => {
+    const currentValue = form.values?.content || ''
     form.setFieldValue(
       'content',
-      conversationStore.getMacro(MACRO_CONTEXT.NEW_CONVERSATION).message_content
+      currentValue + conversationStore.getMacro(MACRO_CONTEXT.NEW_CONVERSATION).message_content
     )
   },
   { deep: true }

--- a/frontend/apps/main/src/features/conversation/ReplyBox.vue
+++ b/frontend/apps/main/src/features/conversation/ReplyBox.vue
@@ -477,7 +477,7 @@ watch(
 
     // If macro has message content, set it in the editor.
     if (conversationStore.getMacro('reply').message_content) {
-      htmlContent.value = conversationStore.getMacro('reply').message_content
+      htmlContent.value = htmlContent.value + conversationStore.getMacro('reply').message_content
     }
   },
   { deep: true }


### PR DESCRIPTION
Appending macros allows them to be used as composable text snippets while editing messages.  This works very well in companion with the CTRL+M feature that allows quick access to the macros from the text editor. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macro content insertion to preserve existing message content instead of replacing it. When applying a macro in conversations or replies, your current text is now appended with the macro content rather than being overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->