### PR TITLE
feat: add "Send and set status" split button to reply box.

### DIFF
--- a/frontend/apps/main/src/features/conversation/ReplyBox.vue
+++ b/frontend/apps/main/src/features/conversation/ReplyBox.vue
@@ -103,6 +103,7 @@
           v-model:mentions="mentions"
           @toggleFullscreen="isEditorFullscreen = !isEditorFullscreen"
           @send="processSend"
+          @sendAndSetStatus="processSendAndSetStatus"
           @fileUpload="handleFileUpload"
           @fileDelete="handleFileDelete"
           @filesDropped="uploadFiles"
@@ -137,6 +138,7 @@
         v-model:mentions="mentions"
         @toggleFullscreen="isEditorFullscreen = !isEditorFullscreen"
         @send="processSend"
+        @sendAndSetStatus="processSendAndSetStatus"
         @fileUpload="handleFileUpload"
         @fileDelete="handleFileDelete"
         @filesDropped="uploadFiles"
@@ -464,6 +466,20 @@ const processSend = async (skipContactEmailCheck = false, skipMissingTagsCheck =
     mentions.value = []
   }
   isSending.value = false
+
+  // Return whether the message was sent successfully.
+  return !hasMessageSendingErrored
+}
+
+/**
+ * Processes the send action and update conversation status. 
+ * The status is only updated if the message is sent successfully.
+ */
+const processSendAndSetStatus = async (status) => {
+  const success = await processSend()
+  if (success) {
+    conversationStore.updateStatus(status)
+  }
 }
 
 /**

--- a/frontend/apps/main/src/features/conversation/ReplyBox.vue
+++ b/frontend/apps/main/src/features/conversation/ReplyBox.vue
@@ -467,7 +467,6 @@ const processSend = async (skipContactEmailCheck = false, skipMissingTagsCheck =
     if (statusToSet) conversationStore.updateStatus(statusToSet)
   }
   isSending.value = false
-  return !hasMessageSendingErrored
 }
 
 const processSendAndSetStatus = (status) => processSend(false, false, status)

--- a/frontend/apps/main/src/features/conversation/ReplyBox.vue
+++ b/frontend/apps/main/src/features/conversation/ReplyBox.vue
@@ -13,7 +13,7 @@
       </AlertDialogHeader>
       <AlertDialogFooter>
         <AlertDialogCancel>{{ $t('globals.messages.cancel') }}</AlertDialogCancel>
-        <AlertDialogAction @click="processSend(true, true)">{{
+        <AlertDialogAction @click="processSend(true, true, deferredStatus)">{{
           $t('replyBox.sendAnyway')
         }}</AlertDialogAction>
       </AlertDialogFooter>
@@ -30,7 +30,7 @@
       </AlertDialogHeader>
       <AlertDialogFooter>
         <AlertDialogCancel>{{ $t('globals.messages.cancel') }}</AlertDialogCancel>
-        <AlertDialogAction @click="processSend(false, true)">{{
+        <AlertDialogAction @click="processSend(false, true, deferredStatus)">{{
           $t('replyBox.sendAnyway')
         }}</AlertDialogAction>
       </AlertDialogFooter>
@@ -249,6 +249,7 @@ const aiPrompts = computed(() => aiPromptStore.prompts)
 const replyBoxContentRef = ref(null)
 const showContactEmailWarning = ref(false)
 const showMissingTagsWarning = ref(false)
+const deferredStatus = ref(null)
 const mentions = ref([])
 
 aiPromptStore.fetchPrompts()
@@ -307,10 +308,7 @@ const hasTextContent = computed(() => {
   return textContent.value.trim().length > 0
 })
 
-/**
- * Processes the send action.
- */
-const processSend = async (skipContactEmailCheck = false, skipMissingTagsCheck = false) => {
+const processSend = async (skipContactEmailCheck = false, skipMissingTagsCheck = false, statusToSet = null) => {
   let hasMessageSendingErrored = false
   isEditorFullscreen.value = false
 
@@ -329,6 +327,7 @@ const processSend = async (skipContactEmailCheck = false, skipMissingTagsCheck =
     currentInbox?.prompt_tags_on_reply &&
     !(conversationStore.current.tags?.length > 0)
   ) {
+    deferredStatus.value = statusToSet
     showMissingTagsWarning.value = true
     return
   }
@@ -354,6 +353,7 @@ const processSend = async (skipContactEmailCheck = false, skipMissingTagsCheck =
             .map((e) => e.trim())
             .includes(contactEmail)
         ) {
+          deferredStatus.value = statusToSet
           showContactEmailWarning.value = true
           return
         }
@@ -464,23 +464,13 @@ const processSend = async (skipContactEmailCheck = false, skipMissingTagsCheck =
     clearMediaFiles()
     emailErrors.value = []
     mentions.value = []
+    if (statusToSet) conversationStore.updateStatus(statusToSet)
   }
   isSending.value = false
-
-  // Return whether the message was sent successfully.
   return !hasMessageSendingErrored
 }
 
-/**
- * Processes the send action and update conversation status. 
- * The status is only updated if the message is sent successfully.
- */
-const processSendAndSetStatus = async (status) => {
-  const success = await processSend()
-  if (success) {
-    conversationStore.updateStatus(status)
-  }
-}
+const processSendAndSetStatus = (status) => processSend(false, false, status)
 
 /**
  * Watches for changes in the conversation's macro id and update message content.

--- a/frontend/apps/main/src/features/conversation/ReplyBoxContent.vue
+++ b/frontend/apps/main/src/features/conversation/ReplyBoxContent.vue
@@ -130,6 +130,7 @@
       :isSending="isSending"
       :enableSend="enableSend"
       :handleSend="handleSend"
+      :handleSendAndSetStatus="handleSendAndSetStatus"
       @emojiSelect="handleEmojiSelect"
     />
   </div>
@@ -239,6 +240,7 @@ const props = defineProps({
 const emit = defineEmits([
   'toggleFullscreen',
   'send',
+  'sendAndSetStatus',
   'fileUpload',
   'inlineImageUpload',
   'fileDelete',
@@ -302,19 +304,32 @@ const validateEmails = async () => {
   })
 }
 
-/**
- * Send the reply or private note
- */
-const handleSend = async () => {
+const validateBeforeSend = async () => {
   await validateEmails()
   if (emailErrors.value.length > 0) {
     emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
       variant: 'destructive',
       description: t('globals.messages.correctEmailErrors')
     })
-    return
+    return false
   }
+  return true
+}
+
+/**
+ * Send the reply or private note
+ */
+const handleSend = async () => {
+  if (!(await validateBeforeSend())) return
   emit('send')
+}
+
+/**
+ * Send the reply or private note and set conversation status
+ */
+const handleSendAndSetStatus = async (status) => {
+  if (!(await validateBeforeSend())) return
+  emit('sendAndSetStatus', status)
 }
 
 const handleFileUpload = (event) => {

--- a/frontend/apps/main/src/features/conversation/ReplyBoxMenuBar.vue
+++ b/frontend/apps/main/src/features/conversation/ReplyBoxMenuBar.vue
@@ -40,7 +40,7 @@
     </div>
     <div class="flex items-center">
       <Button
-        class="h-8 w-6 px-8 rounded-r-none"
+        class="h-8 px-4 rounded-r-none"
         @click="handleSend"
         :disabled="!enableSend"
         :isLoading="isSending"
@@ -54,7 +54,7 @@
             class="h-8 px-2 rounded-l-none border-l border-primary-foreground/30 [&[data-state=open]>svg]:rotate-180"
             :disabled="!enableSend"
           >
-            <ChevronDownIcon class="text-white transition-transform" />
+            <ChevronDownIcon class="text-primary-foreground transition-transform" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>

--- a/frontend/apps/main/src/features/conversation/ReplyBoxMenuBar.vue
+++ b/frontend/apps/main/src/features/conversation/ReplyBoxMenuBar.vue
@@ -38,9 +38,37 @@
         <Smile class="h-4 w-4" />
       </Toggle>
     </div>
-    <Button class="h-8 w-6 px-8" @click="handleSend" :disabled="!enableSend" :isLoading="isSending" v-if="showSendButton">
-      {{ $t('globals.messages.send') }}
-    </Button>
+    <div class="flex items-center">
+      <Button
+        class="h-8 w-6 px-8 rounded-r-none"
+        @click="handleSend"
+        :disabled="!enableSend"
+        :isLoading="isSending"
+        v-if="showSendButton"
+      >
+        {{ $t('globals.messages.send') }}
+      </Button>
+      <DropdownMenu v-if="showSendButton">
+        <DropdownMenuTrigger as-child>
+          <Button
+            class="h-8 px-2 rounded-l-none border-l border-primary-foreground/30 [&[data-state=open]>svg]:rotate-180"
+            :disabled="!enableSend"
+          >
+            <ChevronDownIcon class="text-white transition-transform" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel>{{ $t('replyBox.sendAndSetAs') }}</DropdownMenuLabel>
+          <DropdownMenuItem
+            v-for="status in conversationStore.statusOptionsNoSnooze"
+            :key="status.value"
+            @click="handleSendAndSetStatus(status.label)"
+          >
+            {{ status.label }}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   </div>
 </template>
 
@@ -49,7 +77,14 @@ import { ref, defineAsyncComponent } from 'vue'
 import { onClickOutside } from '@vueuse/core'
 import { Button } from '@shared-ui/components/ui/button'
 import { Toggle } from '@shared-ui/components/ui/toggle'
-import { Paperclip, Smile } from 'lucide-vue-next'
+import { Paperclip, Smile, ChevronDownIcon } from 'lucide-vue-next'
+import DropdownMenu from '@shared-ui/components/ui/dropdown-menu/DropdownMenu.vue'
+import DropdownMenuTrigger from '@shared-ui/components/ui/dropdown-menu/DropdownMenuTrigger.vue'
+import DropdownMenuItem from '@shared-ui/components/ui/dropdown-menu/DropdownMenuItem.vue'
+import DropdownMenuContent from '@shared-ui/components/ui/dropdown-menu/DropdownMenuContent.vue'
+import DropdownMenuLabel from '@shared-ui/components/ui/dropdown-menu/DropdownMenuLabel.vue'
+import { useConversationStore } from '@main/stores/conversation'
+const conversationStore = useConversationStore()
 
 const EmojiPicker = defineAsyncComponent(async () => {
   const [mod] = await Promise.all([
@@ -71,6 +106,7 @@ defineProps({
   isSending: Boolean,
   enableSend: Boolean,
   handleSend: Function,
+  handleSendAndSetStatus: Function,
   showSendButton: {
     type: Boolean,
     default: true

--- a/frontend/apps/main/src/features/conversation/ReplyBoxMenuBar.vue
+++ b/frontend/apps/main/src/features/conversation/ReplyBoxMenuBar.vue
@@ -78,11 +78,13 @@ import { onClickOutside } from '@vueuse/core'
 import { Button } from '@shared-ui/components/ui/button'
 import { Toggle } from '@shared-ui/components/ui/toggle'
 import { Paperclip, Smile, ChevronDownIcon } from 'lucide-vue-next'
-import DropdownMenu from '@shared-ui/components/ui/dropdown-menu/DropdownMenu.vue'
-import DropdownMenuTrigger from '@shared-ui/components/ui/dropdown-menu/DropdownMenuTrigger.vue'
-import DropdownMenuItem from '@shared-ui/components/ui/dropdown-menu/DropdownMenuItem.vue'
-import DropdownMenuContent from '@shared-ui/components/ui/dropdown-menu/DropdownMenuContent.vue'
-import DropdownMenuLabel from '@shared-ui/components/ui/dropdown-menu/DropdownMenuLabel.vue'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuItem,
+  DropdownMenuContent,
+  DropdownMenuLabel
+} from '@shared-ui/components/ui/dropdown-menu'
 import { useConversationStore } from '@main/stores/conversation'
 const conversationStore = useConversationStore()
 

--- a/frontend/apps/main/src/stores/conversation.js
+++ b/frontend/apps/main/src/stores/conversation.js
@@ -40,7 +40,7 @@ export const useConversationStore = defineStore('conversation', () => {
     return statuses.value.map(s => ({ label: s.name, value: s.id }))
   })
   const statusOptionsNoSnooze = computed(() =>
-    statuses.value.filter(s => s.name !== 'Snoozed').map(s => ({
+    statuses.value.filter(s => s.name !== CONVERSATION_DEFAULT_STATUSES.SNOOZED).map(s => ({
       label: s.name,
       value: s.id
     }))

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -940,6 +940,7 @@
   "replyBox.missingTagsTitle": "No tags on this conversation",
   "replyBox.removeBCC": "Remove BCC",
   "replyBox.sendAnyway": "Send anyway",
+  "replyBox.sendAndSetAs": "Send and set as",
   "replyBox.toRequired": "At least one recipient is required in the To field.",
   "report.agentStatus": "Agent Status",
   "report.chart.newConversations": "New conversations",


### PR DESCRIPTION
Add a dropdown next to the Send button that allows agents to send a reply and update the conversation status in a single action.

<img width="1002" height="207" alt="image" src="https://github.com/user-attachments/assets/67ae0553-144e-4b91-86f3-855856a48461" />


- Add split button with dropdown to  ReplyBoxMenuBar
- Extract email validation into reusable validateBeforeSend helper
- Guard for status update on successful message send
- Exclude Snoozed from status options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Send and set as" option in the reply composer to send a message and update conversation status in one action.
  * Send control split into a primary Send button plus a status dropdown.
  * Centralized pre-send email validation that blocks sending and shows a destructive toast for invalid addresses.
  * UI text added for the new "Send and set as" action.

* **Bug Fixes**
  * Send flow preserves and applies a queued status after confirming warning dialogs.
  * Status options no longer include snoozed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->