### PR TITLE
calculate message sidebar counts and show in the sidebar UI, issue #361

### DIFF
--- a/frontend/apps/main/src/components/sidebar/Sidebar.vue
+++ b/frontend/apps/main/src/components/sidebar/Sidebar.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { onMounted } from 'vue'
 import {
   adminNavItems,
   reportsNavItems,
@@ -233,6 +234,9 @@ const hoveredViewId = ref(null)
 // Track delete confirmation dialog state
 const isDeleteOpen = ref(false)
 const viewToDelete = ref(null)
+onMounted(() => {
+  conversationStore.fetchSidebarCounts()
+})
 </script>
 
 <template>
@@ -443,6 +447,9 @@ const viewToDelete = ref(null)
                 <SidebarMenuButton :isActive="isActiveParent('/inboxes/assigned')" @click="navigateToInbox('assigned')">
                     <User />
                     <span>{{ t('globals.terms.myInbox') }}</span>
+                    <span class="ml-auto bg-gray-200 text-gray-700 px-2 py-0.5 rounded-full text-xs font-semibold">
+                      {{ conversationStore.sidebarCounts.assigned }}
+                    </span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
 
@@ -452,6 +459,9 @@ const viewToDelete = ref(null)
                     <span>
                       {{ t('globals.terms.mention', 2) }}
                     </span>
+                    <span class="ml-auto bg-gray-200 text-gray-700 px-2 py-0.5 rounded-full text-xs font-semibold">
+                      {{ conversationStore.sidebarCounts.mentioned }}
+                    </span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
 
@@ -460,6 +470,10 @@ const viewToDelete = ref(null)
                     <CircleDashed />
                     <span>
                       {{ t('globals.terms.unassigned') }}
+                    </span>
+
+                    <span class="ml-auto bg-gray-200 text-gray-700 px-2 py-0.5 rounded-full text-xs font-semibold">
+                      {{ conversationStore.sidebarCounts.unassigned }}
                     </span>
                 </SidebarMenuButton>
               </SidebarMenuItem>

--- a/frontend/apps/main/src/stores/conversation.js
+++ b/frontend/apps/main/src/stores/conversation.js
@@ -682,6 +682,7 @@ export const useConversationStore = defineStore('conversation', () => {
     conversation.data.status = v
     try {
       await api.updateConversationStatus(conversation.data.uuid, { status: v })
+      await fetchSidebarCounts()
     } catch (error) {
       if (conversation.data) conversation.data.status = previous
       emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
@@ -743,6 +744,7 @@ export const useConversationStore = defineStore('conversation', () => {
   async function updateAssignee (type, v) {
     try {
       await api.updateAssignee(conversation.data.uuid, type, v)
+      await fetchSidebarCounts()
     } catch (error) {
       emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
         variant: 'destructive',
@@ -1085,6 +1087,38 @@ export const useConversationStore = defineStore('conversation', () => {
     if (contentType.startsWith('audio/')) return t('globals.terms.audio')
     return t('globals.terms.file')
   }
+  
+  const sidebarCounts = reactive({
+    unassigned: 0,
+    assigned: 0,
+    all: 0,
+    mentioned: 0
+  })
+  
+  // 2. Fetch counts concurrently on page boot without breaking the main viewport
+  async function fetchSidebarCounts() {
+    const openFilter = [{
+      model: 'conversation_statuses',
+      field: 'name',
+      operator: 'equals',
+      value: 'Open'
+    }]
+    const filters = JSON.stringify(openFilter)
+    // Fire all requests simultaneously. page_size: 1 keeps payload sizes tiny.
+    const [unassignedRes, assignedRes, allRes, mentionedRes] = await Promise.all([
+      api.getUnassignedConversations({ page: 1, page_size: 1, filters: filters }),
+      api.getAssignedConversations({ page: 1, page_size: 1, filters: filters }),
+      api.getAllConversations({ page: 1, page_size: 1, filters: filters }),
+      api.getMentionedConversations({ page: 1, page_size: 1, filters: filters })
+    ])
+    console.debug(unassignedRes)
+    // Extract the raw database total row counts from the Go API response
+    sidebarCounts.unassigned = unassignedRes?.data?.data?.total || 0
+    sidebarCounts.assigned = assignedRes?.data?.data?.total || 0
+    sidebarCounts.all = allRes?.data?.data?.total || 0
+    sidebarCounts.mentioned = mentionedRes?.data?.data?.total || 0
+    console.debug(sidebarCounts)
+  }
 
   // On new conversation uuids, subscribere user to those conversations.
   watch(
@@ -1167,6 +1201,8 @@ export const useConversationStore = defineStore('conversation', () => {
     toggleSelect,
     selectAll,
     clearSelection,
-    isSelected
+    isSelected,
+    fetchSidebarCounts,
+    sidebarCounts,
   }
 })


### PR DESCRIPTION
Resolves #367 - please check closely, not sure if everything is in the correct place for efficiency. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Sidebar now displays numeric count badges for Assigned, Mentioned, and Unassigned conversations in the Inbox, providing a quick overview of conversation volumes.
* Conversation counts automatically refresh when conversations are reassigned or their status is updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->