### PR TITLE
fixes autoassigner overriding a manual assignment

### DIFF
--- a/internal/autoassigner/autoassigner.go
+++ b/internal/autoassigner/autoassigner.go
@@ -29,7 +29,7 @@ const (
 
 type conversationStore interface {
 	GetUnassignedConversations() ([]models.Conversation, error)
-	AssignUnassignedConversationUser(conversationUUID string, userID, expectedTeamID int, user umodels.User) error
+	ClaimUnassignedConversation(conversationUUID string, userID, expectedTeamID int, user umodels.User) error
 	ActiveUserConversationsCount(userID int) (int, error)
 }
 
@@ -239,7 +239,7 @@ func (e *Engine) assignConversations() error {
 				continue
 			}
 
-			if err := e.conversationStore.AssignUnassignedConversationUser(conv.UUID, userID, teamID, e.systemUser); err != nil {
+			if err := e.conversationStore.ClaimUnassignedConversation(conv.UUID, userID, teamID, e.systemUser); err != nil {
 				// Already assigned by someone else, stop trying.
 				if errors.Is(err, conversation.ErrConversationAlreadyAssigned) {
 					e.lo.Debug("conversation already assigned, skipping", "conversation_uuid", conv.UUID)

--- a/internal/autoassigner/autoassigner.go
+++ b/internal/autoassigner/autoassigner.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/abhinavxd/libredesk/internal/conversation"
 	"github.com/abhinavxd/libredesk/internal/conversation/models"
 	tmodels "github.com/abhinavxd/libredesk/internal/team/models"
 	umodels "github.com/abhinavxd/libredesk/internal/user/models"
@@ -28,7 +29,7 @@ const (
 
 type conversationStore interface {
 	GetUnassignedConversations() ([]models.Conversation, error)
-	UpdateConversationUserAssignee(conversationUUID string, userID int, user umodels.User) error
+	AssignUnassignedConversationUser(conversationUUID string, userID, expectedTeamID int, user umodels.User) error
 	ActiveUserConversationsCount(userID int) (int, error)
 }
 
@@ -204,8 +205,8 @@ func (e *Engine) assignConversations() error {
 		e.lo.Debug("found unassigned conversations", "count", len(unassignedConversations))
 	}
 
-	for _, conversation := range unassignedConversations {
-		teamID := conversation.AssignedTeamID.Int
+	for _, conv := range unassignedConversations {
+		teamID := conv.AssignedTeamID.Int
 		teamMax := e.teamMaxAutoAssignments[teamID]
 		poolSize := e.poolSize(teamID)
 
@@ -215,7 +216,7 @@ func (e *Engine) assignConversations() error {
 			if err != nil {
 				// Log other errors.
 				if err != ErrTeamNotFound && err != ErrNoUsersInPool {
-					e.lo.Error("error fetching user from balancer pool", "conversation_uuid", conversation.UUID, "error", err)
+					e.lo.Error("error fetching user from balancer pool", "conversation_uuid", conv.UUID, "error", err)
 				}
 				break
 			}
@@ -238,8 +239,13 @@ func (e *Engine) assignConversations() error {
 				continue
 			}
 
-			if err := e.conversationStore.UpdateConversationUserAssignee(conversation.UUID, userID, e.systemUser); err != nil {
-				e.lo.Error("error assigning conversation", "conversation_uuid", conversation.UUID, "user_id", userID, "error", err)
+			if err := e.conversationStore.AssignUnassignedConversationUser(conv.UUID, userID, teamID, e.systemUser); err != nil {
+				// Already assigned by someone else, stop trying.
+				if errors.Is(err, conversation.ErrConversationAlreadyAssigned) {
+					e.lo.Debug("conversation already assigned, skipping", "conversation_uuid", conv.UUID)
+					break
+				}
+				e.lo.Error("error assigning conversation", "conversation_uuid", conv.UUID, "user_id", userID, "error", err)
 				continue
 			}
 			break

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -50,6 +50,7 @@ var (
 	//go:embed queries.sql
 	efs                             embed.FS
 	errConversationNotFound         = errors.New("conversation not found")
+	ErrConversationAlreadyAssigned  = errors.New("conversation already assigned")
 	conversationsAllowedFields      = []string{"status_id", "priority_id", "assigned_team_id", "assigned_user_id", "inbox_id", "last_message_at", "last_interaction_at", "created_at", "waiting_since", "next_sla_deadline_at", "priority_id"}
 	conversationStatusAllowedFields = []string{"id", "name"}
 	usersAllowedFields              = []string{"email"}
@@ -277,6 +278,7 @@ type queries struct {
 	UpsertUserLastSeen                 *sqlx.Stmt `query:"upsert-user-last-seen"`
 	MarkConversationUnread             *sqlx.Stmt `query:"mark-conversation-unread"`
 	UpdateConversationAssignedUser     *sqlx.Stmt `query:"update-conversation-assigned-user"`
+	ClaimUnassignedConversation        *sqlx.Stmt `query:"claim-unassigned-conversation"`
 	UpdateConversationAssignedTeam     *sqlx.Stmt `query:"update-conversation-assigned-team"`
 	UpdateConversationCustomAttributes *sqlx.Stmt `query:"update-conversation-custom-attributes"`
 	UpdateConversationPriority         *sqlx.Stmt `query:"update-conversation-priority"`
@@ -681,8 +683,33 @@ func (c *Manager) UpdateConversationUserAssignee(uuid string, assigneeID int, ac
 	if err := c.UpdateAssignee(uuid, assigneeID, models.AssigneeTypeUser); err != nil {
 		return envelope.NewError(envelope.GeneralError, c.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
+	return c.afterUserAssigned(uuid, assigneeID, actor)
+}
 
-	// Refetch the conversation to get the updated details.
+// AssignUnassignedConversationUser atomically assigns a conversation only if still unassigned and still in expectedTeamID, else returns ErrConversationAlreadyAssigned.
+func (c *Manager) AssignUnassignedConversationUser(uuid string, assigneeID, expectedTeamID int, actor umodels.User) error {
+	prev, prevErr := c.GetConversationListItem(uuid)
+
+	res, err := c.q.ClaimUnassignedConversation.Exec(uuid, assigneeID, expectedTeamID)
+	if err != nil {
+		c.lo.Error("error claiming unassigned conversation", "uuid", uuid, "error", err)
+		return envelope.NewError(envelope.GeneralError, c.i18n.T("globals.messages.somethingWentWrong"), nil)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		c.lo.Error("error reading rows affected for conversation claim", "uuid", uuid, "error", err)
+		return envelope.NewError(envelope.GeneralError, c.i18n.T("globals.messages.somethingWentWrong"), nil)
+	}
+	if rows == 0 {
+		return ErrConversationAlreadyAssigned
+	}
+
+	c.broadcastReassignment(uuid, prev, prevErr)
+	return c.afterUserAssigned(uuid, assigneeID, actor)
+}
+
+// afterUserAssigned runs the side-effects shared by every user-assignment path.
+func (c *Manager) afterUserAssigned(uuid string, assigneeID int, actor umodels.User) error {
 	conversation, err := c.GetConversation(0, uuid, "")
 	if err != nil {
 		return err
@@ -695,10 +722,8 @@ func (c *Manager) UpdateConversationUserAssignee(uuid string, assigneeID int, ac
 		"conversation":      conversation,
 	})
 
-	// Evaluate automation rules.
 	c.automation.EvaluateConversationUpdateRules(conversation, amodels.EventConversationUserAssigned)
 
-	// Send notifications to assignee (skip if self-assigning).
 	if assigneeID != actor.ID {
 		if err := c.NotifyAssignment([]int{assigneeID}, conversation); err != nil {
 			c.lo.Error("error sending assignment notification", "error", err)
@@ -709,7 +734,6 @@ func (c *Manager) UpdateConversationUserAssignee(uuid string, assigneeID int, ac
 		return envelope.NewError(envelope.GeneralError, c.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
 
-	// Broadcast conversation update to widget clients with assignee info.
 	agent, err := c.userStore.GetAgent(assigneeID, "")
 	if err == nil {
 		c.SignAvatarURL(&agent.AvatarURL)
@@ -799,17 +823,22 @@ func (c *Manager) UpdateAssignee(uuid string, assigneeID int, assigneeType strin
 	default:
 		return fmt.Errorf("invalid assignee type: %s", assigneeType)
 	}
+	c.broadcastReassignment(uuid, prev, prevErr)
+	return nil
+}
+
+// broadcastReassignment broadcasts a reassignment to agents, given the conversation's prior list item.
+func (c *Manager) broadcastReassignment(uuid string, prev models.ConversationListItem, prevErr error) {
 	next, nextErr := c.GetConversationListItem(uuid)
 	if nextErr != nil {
 		c.lo.Error("error fetching conversation list item for assignee broadcast", "uuid", uuid, "error", nextErr)
-		return nil
+		return
 	}
 	var prevPtr *models.ConversationListItem
 	if prevErr == nil {
 		prevPtr = &prev
 	}
 	c.BroadcastConvReassignment(prevPtr, &next)
-	return nil
 }
 
 // UpdateConversationPriority updates the priority of a conversation.

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -683,11 +683,11 @@ func (c *Manager) UpdateConversationUserAssignee(uuid string, assigneeID int, ac
 	if err := c.updateAssignee(uuid, assigneeID, models.AssigneeTypeUser); err != nil {
 		return envelope.NewError(envelope.GeneralError, c.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
-	return c.afterUserAssigned(uuid, assigneeID, actor)
+	return c.afterUserAssignedHooks(uuid, assigneeID, actor)
 }
 
-// AssignUnassignedConversationUser atomically assigns a conversation only if still unassigned and still in expectedTeamID, else returns ErrConversationAlreadyAssigned.
-func (c *Manager) AssignUnassignedConversationUser(uuid string, assigneeID, expectedTeamID int, actor umodels.User) error {
+// ClaimUnassignedConversation atomically assigns a conversation only if still unassigned and still in expectedTeamID, else returns ErrConversationAlreadyAssigned.
+func (c *Manager) ClaimUnassignedConversation(uuid string, assigneeID, expectedTeamID int, actor umodels.User) error {
 	prev, prevErr := c.GetConversationListItem(uuid)
 
 	res, err := c.q.ClaimUnassignedConversation.Exec(uuid, assigneeID, expectedTeamID)
@@ -705,11 +705,11 @@ func (c *Manager) AssignUnassignedConversationUser(uuid string, assigneeID, expe
 	}
 
 	c.broadcastReassignment(uuid, prev, prevErr)
-	return c.afterUserAssigned(uuid, assigneeID, actor)
+	return c.afterUserAssignedHooks(uuid, assigneeID, actor)
 }
 
-// afterUserAssigned runs the side-effects shared by every user-assignment path.
-func (c *Manager) afterUserAssigned(uuid string, assigneeID int, actor umodels.User) error {
+// afterUserAssignedHooks runs the side-effects shared by every user-assignment path.
+func (c *Manager) afterUserAssignedHooks(uuid string, assigneeID int, actor umodels.User) error {
 	conversation, err := c.GetConversation(0, uuid, "")
 	if err != nil {
 		return err
@@ -1949,7 +1949,7 @@ func (c *Manager) FilterAuthorizedListUUIDs(agentID int, uuids []string) ([]stri
 	return authorized, nil
 }
 
-// updateAssignee updates the assignee of a conversation.
+// updateAssignee updates the team / user assignee of a conversation and broadcasts the reassignment to connected clients.
 func (c *Manager) updateAssignee(uuid string, assigneeID int, assigneeType string) error {
 	prev, prevErr := c.GetConversationListItem(uuid)
 	switch assigneeType {

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -680,7 +680,7 @@ func (c *Manager) UpdateConversationWaitingSince(conversationUUID string, at *ti
 
 // UpdateConversationUserAssignee sets the assignee of a conversation to a specifc user.
 func (c *Manager) UpdateConversationUserAssignee(uuid string, assigneeID int, actor umodels.User) error {
-	if err := c.UpdateAssignee(uuid, assigneeID, models.AssigneeTypeUser); err != nil {
+	if err := c.updateAssignee(uuid, assigneeID, models.AssigneeTypeUser); err != nil {
 		return envelope.NewError(envelope.GeneralError, c.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
 	return c.afterUserAssigned(uuid, assigneeID, actor)
@@ -760,7 +760,7 @@ func (c *Manager) UpdateConversationTeamAssignee(uuid string, teamID int, actor 
 	}
 	previousAssignedTeamID := conversation.AssignedTeamID.Int
 
-	if err := c.UpdateAssignee(uuid, teamID, models.AssigneeTypeTeam); err != nil {
+	if err := c.updateAssignee(uuid, teamID, models.AssigneeTypeTeam); err != nil {
 		return envelope.NewError(envelope.GeneralError, c.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
 
@@ -803,27 +803,6 @@ func (c *Manager) UpdateConversationTeamAssignee(uuid string, teamID int, actor 
 		"assigned_team_id": teamID,
 	})
 
-	return nil
-}
-
-// UpdateAssignee updates the assignee of a conversation.
-func (c *Manager) UpdateAssignee(uuid string, assigneeID int, assigneeType string) error {
-	prev, prevErr := c.GetConversationListItem(uuid)
-	switch assigneeType {
-	case models.AssigneeTypeUser:
-		if _, err := c.q.UpdateConversationAssignedUser.Exec(uuid, assigneeID); err != nil {
-			c.lo.Error("error updating conversation assignee", "error", err)
-			return fmt.Errorf("updating assignee: %w", err)
-		}
-	case models.AssigneeTypeTeam:
-		if _, err := c.q.UpdateConversationAssignedTeam.Exec(uuid, assigneeID); err != nil {
-			c.lo.Error("error updating conversation assignee", "error", err)
-			return fmt.Errorf("updating assignee: %w", err)
-		}
-	default:
-		return fmt.Errorf("invalid assignee type: %s", assigneeType)
-	}
-	c.broadcastReassignment(uuid, prev, prevErr)
 	return nil
 }
 
@@ -1968,6 +1947,27 @@ func (c *Manager) FilterAuthorizedListUUIDs(agentID int, uuids []string) ([]stri
 		return nil, err
 	}
 	return authorized, nil
+}
+
+// updateAssignee updates the assignee of a conversation.
+func (c *Manager) updateAssignee(uuid string, assigneeID int, assigneeType string) error {
+	prev, prevErr := c.GetConversationListItem(uuid)
+	switch assigneeType {
+	case models.AssigneeTypeUser:
+		if _, err := c.q.UpdateConversationAssignedUser.Exec(uuid, assigneeID); err != nil {
+			c.lo.Error("error updating conversation assignee", "error", err)
+			return fmt.Errorf("updating assignee: %w", err)
+		}
+	case models.AssigneeTypeTeam:
+		if _, err := c.q.UpdateConversationAssignedTeam.Exec(uuid, assigneeID); err != nil {
+			c.lo.Error("error updating conversation assignee", "error", err)
+			return fmt.Errorf("updating assignee: %w", err)
+		}
+	default:
+		return fmt.Errorf("invalid assignee type: %s", assigneeType)
+	}
+	c.broadcastReassignment(uuid, prev, prevErr)
+	return nil
 }
 
 func nullTimeOrNil(t null.Time) any {

--- a/internal/conversation/queries.sql
+++ b/internal/conversation/queries.sql
@@ -391,6 +391,12 @@ SET assigned_user_id = $2,
 updated_at = NOW()
 WHERE uuid = $1;
 
+-- name: claim-unassigned-conversation
+UPDATE conversations
+SET assigned_user_id = $2,
+updated_at = NOW()
+WHERE uuid = $1 AND assigned_user_id IS NULL AND assigned_team_id = $3;
+
 -- name: update-conversation-contact-last-seen
 UPDATE conversations
 SET contact_last_seen_at = NOW(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-assignment reliability by atomically claiming unassigned conversations, preventing duplicate assignments during concurrent attempts.
  * Added safeguards to only assign when the conversation matches the expected team, with clearer handling when a conversation is already assigned.
  * Refined post-assignment processing so evaluation, notifications, and reassignment handling occur in a more consistent order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->