### PR TITLE
add learn more link to roles admin page

### DIFF
--- a/frontend/apps/main/src/views/admin/roles/Roles.vue
+++ b/frontend/apps/main/src/views/admin/roles/Roles.vue
@@ -6,6 +6,14 @@
 
     <template #help>
       <p>{{ $t('admin.role.help') }}</p>
+      <a
+        href="https://docs.libredesk.io/roles/overview"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="link-style"
+      >
+        {{ $t('globals.terms.learnMore') }}
+      </a>
     </template>
   </AdminSplitLayout>
 </template>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Learn more” link to the admin roles help section for quicker access to role overview guidance.
  * The link opens in a new tab for easier navigation and uses the existing localized label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->