### PR TITLE
Mark assignment notifications read on ticket action

### DIFF
--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -608,6 +608,7 @@ func handleUpdateConversationStatus(r *fastglue.Request) error {
 	if err := app.conversation.UpdateConversationStatus(uuid, 0 /**status_id**/, status, snoozedUntil, user); err != nil {
 		return sendErrorEnvelope(r, err)
 	}
+	markAssignmentNotificationRead(app, conversation, user)
 
 	// If status is `Resolved`, send CSAT survey if enabled on inbox.
 	if status == cmodels.StatusResolved {

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -278,6 +278,7 @@ func handleSendMessage(r *fastglue.Request) error {
 	if err != nil {
 		return sendErrorEnvelope(r, err)
 	}
+	markAssignmentNotificationRead(app, conv, user)
 	resolveQuotedCIDs(app, &message)
 	resolveAttachmentCIDs(&message, rootURL)
 	return r.SendEnvelope(message)

--- a/cmd/notifications.go
+++ b/cmd/notifications.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	cmodels "github.com/abhinavxd/libredesk/internal/conversation/models"
+	umodels "github.com/abhinavxd/libredesk/internal/user/models"
+)
+
+func markAssignmentNotificationRead(app *App, conv *cmodels.Conversation, user umodels.User) {
+	if conv == nil || conv.ID == 0 || conv.AssignedUserID.Int != user.ID {
+		return
+	}
+	_ = app.userNotification.MarkAssignmentAsRead(conv.ID, user.ID)
+}

--- a/frontend/apps/main/src/features/conversation/ReplyBox.vue
+++ b/frontend/apps/main/src/features/conversation/ReplyBox.vue
@@ -161,6 +161,7 @@ import { useI18n } from 'vue-i18n'
 import { useConversationStore } from '@main/stores/conversation'
 import { useInboxStore } from '@main/stores/inbox'
 import { useAiPromptStore } from '@main/stores/aiPrompt'
+import { useNotificationStore } from '@main/stores/notification'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -205,6 +206,7 @@ const formSchema = toTypedSchema(
 
 const { t } = useI18n()
 const conversationStore = useConversationStore()
+const notificationStore = useNotificationStore()
 const inboxStore = useInboxStore()
 const emitter = useEmitter()
 const userStore = useUserStore()
@@ -429,6 +431,8 @@ const processSend = async (skipContactEmailCheck = false, skipMissingTagsCheck =
       if (isPrivate && response?.data?.data) {
         conversationStore.replacePendingMessage(convUUID, tempUUID, response.data.data)
       }
+
+      notificationStore.markAssignmentAsReadForConversation(convUUID)
     } catch (error) {
       hasMessageSendingErrored = true
       // Remove pending message and restore editor content.

--- a/frontend/apps/main/src/stores/conversation.js
+++ b/frontend/apps/main/src/stores/conversation.js
@@ -14,6 +14,7 @@ import { getI18n } from '../i18n'
 import { CONVERSATION_LIST_TYPE, CONVERSATION_DEFAULT_STATUSES, TAG_ACTION } from '@/constants/conversation'
 import { useThrottleFn } from '@vueuse/core'
 import { useUserStore } from '@/stores/user'
+import { useNotificationStore } from '@/stores/notification'
 import { delayedLoading } from '@/utils/delayed-loading'
 import api from '../api'
 
@@ -28,6 +29,7 @@ export const useConversationStore = defineStore('conversation', () => {
   const macros = ref({})
   const drafts = ref(new Map())
   const userStore = useUserStore()
+  const notificationStore = useNotificationStore()
   const router = useRouter()
   const isViewingConversation = (uuid) => router.currentRoute.value.params.uuid === uuid
 
@@ -682,6 +684,7 @@ export const useConversationStore = defineStore('conversation', () => {
     conversation.data.status = v
     try {
       await api.updateConversationStatus(conversation.data.uuid, { status: v })
+      notificationStore.markAssignmentAsReadForConversation(conversation.data.uuid)
     } catch (error) {
       if (conversation.data) conversation.data.status = previous
       emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {

--- a/frontend/apps/main/src/stores/notification.js
+++ b/frontend/apps/main/src/stores/notification.js
@@ -76,6 +76,26 @@ export const useNotificationStore = defineStore('notification', () => {
     }
   }
 
+  const markAssignmentAsReadForConversation = (conversationUUID) => {
+    if (!conversationUUID) return
+
+    let markedCount = 0
+    notifications.value.forEach(n => {
+      if (
+        !n.is_read &&
+        n.notification_type === 'assignment' &&
+        n.conversation_uuid === conversationUUID
+      ) {
+        n.is_read = true
+        markedCount++
+      }
+    })
+
+    if (markedCount > 0) {
+      unreadCount.value = Math.max(0, unreadCount.value - markedCount)
+    }
+  }
+
   // Mark all notifications as read
   const markAllAsRead = async () => {
     try {
@@ -153,6 +173,7 @@ export const useNotificationStore = defineStore('notification', () => {
     fetchNotifications,
     fetchStats,
     markAsRead,
+    markAssignmentAsReadForConversation,
     markAllAsRead,
     deleteNotification,
     deleteAll,

--- a/internal/notification/queries.sql
+++ b/internal/notification/queries.sql
@@ -27,6 +27,14 @@ RETURNING id, created_at, updated_at, user_id, notification_type, title, body, i
 -- name: mark-as-read
 UPDATE user_notifications SET is_read = true, updated_at = now() WHERE id = $1 AND user_id = $2 RETURNING id;
 
+-- name: mark-assignment-as-read
+UPDATE user_notifications
+SET is_read = true, updated_at = now()
+WHERE conversation_id = $1
+  AND user_id = $2
+  AND notification_type = 'assignment'
+  AND is_read = false;
+
 -- name: mark-all-as-read
 UPDATE user_notifications SET is_read = true, updated_at = now() WHERE user_id = $1 AND is_read = false;
 

--- a/internal/notification/user_notification.go
+++ b/internal/notification/user_notification.go
@@ -37,6 +37,7 @@ type queries struct {
 	GetNotificationStats   *sqlx.Stmt `query:"get-notification-stats"`
 	InsertNotification     *sqlx.Stmt `query:"insert-notification"`
 	MarkAsRead             *sqlx.Stmt `query:"mark-as-read"`
+	MarkAssignmentAsRead   *sqlx.Stmt `query:"mark-assignment-as-read"`
 	MarkAllAsRead          *sqlx.Stmt `query:"mark-all-as-read"`
 	DeleteNotification     *sqlx.Stmt `query:"delete-notification"`
 	DeleteAllNotifications *sqlx.Stmt `query:"delete-all-notifications"`
@@ -100,6 +101,15 @@ func (m *UserNotificationManager) MarkAsRead(id, userID int) error {
 			return nil
 		}
 		m.lo.Error("error marking notification as read", "id", id, "user_id", userID, "error", err)
+		return envelope.NewError(envelope.GeneralError, m.i18n.T("globals.messages.somethingWentWrong"), nil)
+	}
+	return nil
+}
+
+// MarkAssignmentAsRead marks unread assignment notifications as read for a conversation and user.
+func (m *UserNotificationManager) MarkAssignmentAsRead(conversationID, userID int) error {
+	if _, err := m.q.MarkAssignmentAsRead.Exec(conversationID, userID); err != nil {
+		m.lo.Error("error marking assignment notification as read", "conversation_id", conversationID, "user_id", userID, "error", err)
 		return envelope.NewError(envelope.GeneralError, m.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- mark unread assignment notifications as read when the assigned agent replies
- do the same after the assigned agent changes the ticket status

Fixes #389.

## Tests
- go test ./internal/notification ./cmd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assignment notifications are now automatically marked as read when you reply to a conversation or update its status.
* **Bug Fixes**
  * Reduced leftover unread assignment alerts after taking action on a conversation, helping keep notification counts more accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->