### PR TITLE
fix dark-mode mention highlight leaking a yellow background 

### DIFF
--- a/frontend/apps/main/src/features/conversation/message/MessageList.vue
+++ b/frontend/apps/main/src/features/conversation/message/MessageList.vue
@@ -295,7 +295,7 @@ const messageRows = computed(() => {
   animation: highlightFade 2.5s ease-out forwards;
 }
 
-:global(.dark) .highlight-mention::after {
+:global(.dark .highlight-mention::after) {
   background-color: rgb(250 204 21 / 0.2);
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark mode styling for highlighted mentions in chat messages, ensuring the overlay appears correctly with the updated selector behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->