### PR TITLE
Harden contact create, drop set-away-on-login, make status dots color blind safe

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -104,7 +104,7 @@ func handleOIDCCallback(r *fastglue.Request) error {
 		return sendErrorEnvelope(r, err)
 	}
 
-	applyLoginAvailability(app, user.ID)
+	app.user.InvalidateAgentCache(user.ID)
 
 	// Insert activity log.
 	if err := app.activityLog.Login(user.ID, user.Email.String, ip); err != nil {

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -809,12 +809,14 @@ func handleCreateConversation(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.T("errors.parsingRequest"), nil, envelope.InputError)
 	}
 
+	req.Email = strings.ToLower(strings.TrimSpace(req.Email))
+
 	// Validate the request
 	if err := validateCreateConversationRequest(req, app); err != nil {
 		return sendErrorEnvelope(r, err)
 	}
 
-	email := strings.ToLower(strings.TrimSpace(req.Email))
+	email := req.Email
 	to := []string{email}
 	user, err := app.user.GetAgentCachedOrLoad(auser.ID)
 	if err != nil {

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	amodels "github.com/abhinavxd/libredesk/internal/auth/models"
@@ -813,22 +814,31 @@ func handleCreateConversation(r *fastglue.Request) error {
 		return sendErrorEnvelope(r, err)
 	}
 
-	to := []string{req.Email}
+	email := strings.ToLower(strings.TrimSpace(req.Email))
+	to := []string{email}
 	user, err := app.user.GetAgentCachedOrLoad(auser.ID)
 	if err != nil {
 		return sendErrorEnvelope(r, err)
 	}
 
-	// Find or create contact.
 	contact := umodels.User{
-		Email:            null.StringFrom(req.Email),
+		Email:            null.StringFrom(email),
 		FirstName:        req.FirstName,
 		LastName:         req.LastName,
 		ExternalUserID:   null.NewString(req.ExternalUserID, req.ExternalUserID != ""),
 		CustomAttributes: json.RawMessage(`{}`),
 	}
-	if err := app.user.CreateContact(&contact); err != nil {
-		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
+	// Reuse an existing contact as-is; this endpoint is gated only on conversations:write and must never rename a contact.
+	existing, err := app.user.GetContactByEmail(email)
+	if err != nil {
+		if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError {
+			return sendErrorEnvelope(r, err)
+		}
+		if err := app.user.CreateContact(&contact); err != nil {
+			return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
+		}
+	} else {
+		contact.ID = existing.ID
 	}
 
 	// Create conversation first.

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -3,7 +3,6 @@ package main
 import (
 	amodels "github.com/abhinavxd/libredesk/internal/auth/models"
 	"github.com/abhinavxd/libredesk/internal/envelope"
-	umodels "github.com/abhinavxd/libredesk/internal/user/models"
 	realip "github.com/ferluci/fast-realip"
 	"github.com/valyala/fasthttp"
 	"github.com/zerodha/fastglue"
@@ -62,7 +61,7 @@ func handleLogin(r *fastglue.Request) error {
 		return sendErrorEnvelope(r, err)
 	}
 
-	applyLoginAvailability(app, user.ID)
+	app.user.InvalidateAgentCache(user.ID)
 
 	// Insert activity log.
 	if err := app.activityLog.Login(user.ID, user.Email.String, ip); err != nil {
@@ -95,21 +94,4 @@ func handleLogout(r *fastglue.Request) error {
 	r.RequestCtx.Response.Header.Add("Pragma", "no-cache")
 	r.RequestCtx.Response.Header.Add("Expires", "-1")
 	return r.RedirectURI("/", fasthttp.StatusFound, nil, "")
-}
-
-// applyLoginAvailability sets the agent away on login if set_away_on_login is enabled.
-func applyLoginAvailability(app *App, userID int) {
-	app.Lock()
-	setAway := ko.Bool("app.set_away_on_login")
-	app.Unlock()
-	if setAway {
-		if err := app.user.UpdateAvailability(userID, umodels.AwayManual); err != nil {
-			app.lo.Error("error setting availability on login", "error", err)
-			return
-		}
-	}
-	app.user.InvalidateAgentCache(userID)
-	if setAway {
-		go app.conversation.BroadcastAgentAvailability(userID, umodels.AwayManual)
-	}
 }

--- a/frontend/apps/main/src/features/admin/general/GeneralSettingForm.vue
+++ b/frontend/apps/main/src/features/admin/general/GeneralSettingForm.vue
@@ -155,17 +155,6 @@
     </div>
 
     <div class="grid gap-6 md:grid-cols-2">
-      <FormField v-slot="{ componentField, handleChange }" name="set_away_on_login">
-        <FormItem>
-          <SwitchField
-            :title="t('admin.general.setAwayOnLogin')"
-            :description="t('admin.general.setAwayOnLogin.description')"
-            :checked="componentField.modelValue"
-            @update:checked="handleChange"
-          />
-        </FormItem>
-      </FormField>
-
       <FormField v-slot="{ componentField, handleChange }" name="show_conversation_subject">
         <FormItem>
           <SwitchField

--- a/frontend/apps/main/src/features/admin/general/formSchema.js
+++ b/frontend/apps/main/src/features/admin/general/formSchema.js
@@ -40,6 +40,5 @@ export const createFormSchema = (t) => z.object({
       message: t('admin.general.maxAllowedFileUploadSize.valid')
     }),
   allowed_file_upload_extensions: z.array(z.string()).nullable().default([]).optional(),
-  set_away_on_login: z.boolean().optional(),
   show_conversation_subject: z.boolean().optional()
 })

--- a/frontend/shared-ui/components/StatusDot.vue
+++ b/frontend/shared-ui/components/StatusDot.vue
@@ -36,9 +36,9 @@ const statusClass = computed(() => {
     case 'away':
     case 'away_manual':
     case 'away_and_reassigning':
-      return 'bg-amber-500'
+      return 'border-2 border-amber-500 bg-[linear-gradient(to_right,theme(colors.amber.500)_50%,transparent_50%)]'
     default:
-      return 'bg-gray-400'
+      return 'border-2 border-gray-400'
   }
 })
 </script>

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -115,8 +115,6 @@
   "admin.general.rootURL.valid": "Root URL should be a valid URL",
   "admin.general.siteName": "Site name",
   "admin.general.siteName.min": "Site name should be at least 1 character",
-  "admin.general.setAwayOnLogin": "Set agents away on login",
-  "admin.general.setAwayOnLogin.description": "Agents will be set to away when they log in and must manually go online.",
   "admin.general.showConversationSubject": "Show subject in conversation list",
   "admin.general.showConversationSubject.description": "Display the conversation subject line in the conversation list when available.",
   "admin.general.timezone.placeholder": "Select timezone",

--- a/internal/migrations/v2.5.0.go
+++ b/internal/migrations/v2.5.0.go
@@ -7,9 +7,6 @@ import (
 )
 
 func V2_5_0(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf) error {
-	if _, err := db.Exec(`INSERT INTO settings (key, value) VALUES ('app.set_away_on_login', 'false'::jsonb) ON CONFLICT (key) DO NOTHING;`); err != nil {
-		return err
-	}
 	if _, err := db.Exec(`INSERT INTO settings (key, value) VALUES ('app.show_conversation_subject', 'true'::jsonb) ON CONFLICT (key) DO NOTHING;`); err != nil {
 		return err
 	}

--- a/internal/setting/models/models.go
+++ b/internal/setting/models/models.go
@@ -10,7 +10,6 @@ type General struct {
 	AllowedFileUploadExtensions []string `json:"app.allowed_file_upload_extensions"`
 	Timezone                    string   `json:"app.timezone"`
 	BusinessHoursID             string   `json:"app.business_hours_id"`
-	SetAwayOnLogin              bool     `json:"app.set_away_on_login"`
 	ShowConversationSubject     bool     `json:"app.show_conversation_subject"`
 }
 

--- a/schema.sql
+++ b/schema.sql
@@ -726,7 +726,6 @@ VALUES
     ('app.allowed_file_upload_extensions', '["*"]'::jsonb),
 	('app.timezone', '"Asia/Kolkata"'::jsonb),
 	('app.business_hours_id', '""'::jsonb),
-	('app.set_away_on_login', 'false'::jsonb),
 	('app.show_conversation_subject', 'true'::jsonb),
     ('notification.email.username', '"admin@yourcompany.com"'::jsonb),
     ('notification.email.host', '""'::jsonb),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a general setting to show conversation subjects.

- **Bug Fixes**
  - Login/OIDC sign-in now refreshes account/agent availability state via cache invalidation.
  - Conversation creation now normalizes contact email (trim/lowercase) and reuses existing contacts to reduce duplicates.
  - Away/default status indicators now use a clearer bordered gradient/appearance.

- **Chores**
  - Removed the obsolete “set away on login” setting from defaults, backend configuration, admin UI, schema, and English translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->