### PR TITLE
show attachment type in draft preview when there is no draft text

### DIFF
--- a/frontend/apps/main/src/features/conversation/list/ConversationListItem.vue
+++ b/frontend/apps/main/src/features/conversation/list/ConversationListItem.vue
@@ -244,10 +244,12 @@ const isTyping = computed(() => conversationStore.typingByUUID[props.conversatio
 
 const draftPreview = computed(() => {
   const draft = conversationStore.conversationDraftPreview(props.conversation.uuid)
-  if (!draft?.content) return ''
-  const text = draft.content.replace(/<[^>]*>/g, '').trim()
-  if (!text && /<img\b/i.test(draft.content)) return t('globals.terms.image', 1)
-  return text.length > 120 ? text.slice(0, 120) + '...' : text
+  if (!draft?.content && !draft?.meta?.attachments?.length) return ''
+  const text = (draft.content || '').replace(/<[^>]*>/g, '').trim()
+  if (text) return text.length > 120 ? text.slice(0, 120) + '...' : text
+  if (draft.meta?.attachments?.length) return conversationStore.getMediaPreview(draft.meta.attachments)
+  if (/<img\b/i.test(draft.content || '')) return t('globals.terms.image', 1)
+  return ''
 })
 
 const showSubject = computed(

--- a/frontend/apps/main/src/stores/conversation.js
+++ b/frontend/apps/main/src/stores/conversation.js
@@ -1216,6 +1216,7 @@ export const useConversationStore = defineStore('conversation', () => {
     deleteMessage,
     conversationHasDraft,
     conversationDraftPreview,
+    getMediaPreview,
     setSelectedDraftType,
     resolveDraftType,
     addPendingMessage,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation drafts now show richer preview text, including attachment-based previews and image indicators when applicable.
  * Drafts without text or attachments now appear blank instead of showing confusing content.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->