### PR TITLE
hide assign-to-me nudge when agent lacks assignee permission

### DIFF
--- a/frontend/apps/main/src/features/conversation/message/MessageList.vue
+++ b/frontend/apps/main/src/features/conversation/message/MessageList.vue
@@ -97,6 +97,7 @@ import { isSameDay } from 'date-fns'
 import AssignSelfNudge from './AssignSelfNudge.vue'
 import { useEmitter } from '@main/composables/useEmitter'
 import { EMITTER_EVENTS } from '@main/constants/emitterEvents'
+import { useBulkActionPermissions } from '@main/composables/useBulkActionPermissions'
 import MessagesSkeleton from './MessagesSkeleton.vue'
 import { TypingIndicator } from '@shared-ui/components/TypingIndicator'
 import { useStickyScroll } from '@shared-ui/composables'
@@ -115,6 +116,7 @@ const contentEl = ref(null)
 const emitter = useEmitter()
 const unReadMessages = ref(0)
 const showAssignNudge = ref(false)
+const { canAssignAgent } = useBulkActionPermissions()
 let currentConversationUUID = ''
 let openScrollDone = false
 
@@ -164,7 +166,12 @@ const newMessageHandler = (data) => {
   const message = data.message
   if (message?.sender_id === userStore.userID) {
     hasUserScrolled.value = false
-    if (message.type === 'outgoing' && !message.private && !conversationStore.current.assigned_user_id) {
+    if (
+      message.type === 'outgoing' &&
+      !message.private &&
+      !conversationStore.current.assigned_user_id &&
+      canAssignAgent.value
+    ) {
       showAssignNudge.value = true
     }
     return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The self-assign prompt now appears only for users who are allowed to assign agents.
  * This prompt is also limited to outgoing, non-private messages in unassigned conversations, reducing unnecessary or inappropriate nudges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->