### PR TITLE
clarify phone_number comment in JWT payload example

### DIFF
--- a/frontend/apps/main/src/features/admin/inbox/LivechatInboxForm.vue
+++ b/frontend/apps/main/src/features/admin/inbox/LivechatInboxForm.vue
@@ -1119,7 +1119,7 @@ const jwtPayloadExample = computed(() => {
   "email": "user@example.com",                // Required: User's email
   "first_name": "John",                       // Required: User's first name
   "last_name": "Doe",                         // Optional: User's last name
-  "phone_number": "9876543210",                // Optional: User's phone number (no country calling code)
+  "phone_number": "9876543210",                // Optional: User's phone number (e.g. "199999999999")
   "phone_number_country_code": "IN",          // Optional: ISO 3166-1 alpha-2 country code (e.g. "IN", "US")
   "exp": 1735689600,                          // Required: Expiration time (Unix timestamp in seconds)
   "contact_custom_attributes": {              // Optional: Contact-level attributes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example text for the phone number field to clarify that it’s optional and include a sample value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->