### PR TITLE
fix prechat field removal on enter key in livechat inbox form

### DIFF
--- a/frontend/apps/main/src/features/admin/inbox/PreChatFormConfig.vue
+++ b/frontend/apps/main/src/features/admin/inbox/PreChatFormConfig.vue
@@ -56,6 +56,7 @@
                     <Switch v-model:checked="field.enabled" />
                     <Button
                       v-if="!field.is_default"
+                      type="button"
                       variant="ghost"
                       size="sm"
                       @click="removeField(index)"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the pre-chat form configuration’s delete button from unintentionally submitting the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->