### PR TITLE
 fix(email): render inline images from clients that omit Content-Disposition

### DIFF
--- a/internal/inbox/channel/email/imap.go
+++ b/internal/inbox/channel/email/imap.go
@@ -503,34 +503,7 @@ func (e *Email) processFullMessage(item imapclient.FetchItemDataBodySection, inc
 			"message_id", incomingMsg.SourceID.String)
 	}
 
-	// Process attachments
-	for _, att := range envelope.Attachments {
-		incomingMsg.Attachments = append(incomingMsg.Attachments, attachment.Attachment{
-			Name:        att.FileName,
-			Content:     att.Content,
-			ContentType: att.ContentType,
-			ContentID:   att.ContentID,
-			Size:        len(att.Content),
-			Disposition: attachment.DispositionAttachment,
-		})
-	}
-
-	// Process inlines - treat ones without ContentID as regular attachments
-	for _, inline := range envelope.Inlines {
-		disposition := attachment.DispositionInline
-		if inline.ContentID == "" {
-			disposition = attachment.DispositionAttachment
-		}
-
-		incomingMsg.Attachments = append(incomingMsg.Attachments, attachment.Attachment{
-			Name:        inline.FileName,
-			Content:     inline.Content,
-			ContentType: inline.ContentType,
-			ContentID:   inline.ContentID,
-			Size:        len(inline.Content),
-			Disposition: disposition,
-		})
-	}
+	incomingMsg.Attachments = collectAttachments(envelope)
 
 	incomingMsg.Content = stringutil.SanitizeUTF8(incomingMsg.Content)
 	incomingMsg.Subject = stringutil.SanitizeUTF8(incomingMsg.Subject)
@@ -544,6 +517,43 @@ func (e *Email) processFullMessage(item imapclient.FetchItemDataBodySection, inc
 		return err
 	}
 	return nil
+}
+
+// collectAttachments gathers all attachment and inline parts from an email
+// envelope into a single list of attachments.
+func collectAttachments(envelope *enmime.Envelope) []attachment.Attachment {
+	attachments := make([]attachment.Attachment, 0, len(envelope.Attachments)+len(envelope.Inlines))
+
+	// Attachments always use the attachment disposition.
+	for _, att := range envelope.Attachments {
+		attachments = append(attachments, attachment.Attachment{
+			Name:        att.FileName,
+			Content:     att.Content,
+			ContentType: att.ContentType,
+			ContentID:   att.ContentID,
+			Size:        len(att.Content),
+			Disposition: attachment.DispositionAttachment,
+		})
+	}
+
+	// Inlines are inline when they carry a ContentID, otherwise they are
+	// treated as regular attachments.
+	for _, inline := range envelope.Inlines {
+		disposition := attachment.DispositionInline
+		if inline.ContentID == "" {
+			disposition = attachment.DispositionAttachment
+		}
+		attachments = append(attachments, attachment.Attachment{
+			Name:        inline.FileName,
+			Content:     inline.Content,
+			ContentType: inline.ContentType,
+			ContentID:   inline.ContentID,
+			Size:        len(inline.Content),
+			Disposition: disposition,
+		})
+	}
+
+	return attachments
 }
 
 // getContactName extracts the contact's first and last name from the IMAP address.

--- a/internal/inbox/channel/email/imap.go
+++ b/internal/inbox/channel/email/imap.go
@@ -511,7 +511,8 @@ func (e *Email) processFullMessage(item imapclient.FetchItemDataBodySection, inc
 	incomingMsg.Contact.LastName = stringutil.SanitizeUTF8(incomingMsg.Contact.LastName)
 
 	e.lo.Debug("enqueuing incoming email message", "message_id", incomingMsg.SourceID.String,
-		"attachments", len(envelope.Attachments), "inline_attachments", len(envelope.Inlines))
+		"attachments", len(envelope.Attachments), "inline_attachments", len(envelope.Inlines),
+		"other_parts", len(envelope.OtherParts))
 
 	if err := e.messageStore.EnqueueIncoming(incomingMsg); err != nil {
 		return err
@@ -522,7 +523,7 @@ func (e *Email) processFullMessage(item imapclient.FetchItemDataBodySection, inc
 // collectAttachments gathers all attachment and inline parts from an email
 // envelope into a single list of attachments.
 func collectAttachments(envelope *enmime.Envelope) []attachment.Attachment {
-	attachments := make([]attachment.Attachment, 0, len(envelope.Attachments)+len(envelope.Inlines))
+	attachments := make([]attachment.Attachment, 0, len(envelope.Attachments)+len(envelope.Inlines)+len(envelope.OtherParts))
 
 	// Attachments always use the attachment disposition.
 	for _, att := range envelope.Attachments {
@@ -536,19 +537,19 @@ func collectAttachments(envelope *enmime.Envelope) []attachment.Attachment {
 		})
 	}
 
-	// Inlines are inline when they carry a ContentID, otherwise they are
-	// treated as regular attachments.
-	for _, inline := range envelope.Inlines {
+	// Inlines and other (unclassified) parts are inline when they carry a
+	// ContentID, otherwise they are treated as regular attachments.
+	for _, part := range append(append([]*enmime.Part{}, envelope.Inlines...), envelope.OtherParts...) {
 		disposition := attachment.DispositionInline
-		if inline.ContentID == "" {
+		if part.ContentID == "" {
 			disposition = attachment.DispositionAttachment
 		}
 		attachments = append(attachments, attachment.Attachment{
-			Name:        inline.FileName,
-			Content:     inline.Content,
-			ContentType: inline.ContentType,
-			ContentID:   inline.ContentID,
-			Size:        len(inline.Content),
+			Name:        part.FileName,
+			Content:     part.Content,
+			ContentType: part.ContentType,
+			ContentID:   part.ContentID,
+			Size:        len(part.Content),
 			Disposition: disposition,
 		})
 	}

--- a/internal/inbox/channel/email/imap_test.go
+++ b/internal/inbox/channel/email/imap_test.go
@@ -1,9 +1,12 @@
 package email
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/abhinavxd/libredesk/internal/attachment"
 	"github.com/emersion/go-message/mail"
 	"github.com/jhillyerd/enmime"
 )
@@ -130,6 +133,105 @@ func TestGoIMAPMessageIDParsing(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestCollectAttachments_OutlookInlineImages verifies that inline images embedded
+// with a Content-ID but no Content-Disposition header (as Outlook does) are collected
+// as inline attachments so their cid: references resolve in the message body. enmime
+// routes such parts to envelope.OtherParts, which must not be dropped.
+//
+// The fixture testdata/outlook-inline-images.eml is a synthetic message that
+// reproduces the exact MIME structure Outlook produces.
+func TestCollectAttachments_OutlookInlineImages(t *testing.T) {
+	const wantCID = "report-chart@example.com"
+
+	f, err := os.Open(filepath.Join("testdata", "outlook-inline-images.eml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	envelope, err := enmime.ReadEnvelope(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sanity: enmime puts the image in OtherParts, not Inlines/Attachments,
+	// because it carries no Content-Disposition header.
+	if len(envelope.Inlines) != 0 || len(envelope.Attachments) != 0 {
+		t.Fatalf("expected image to be unclassified by enmime, got inlines=%d attachments=%d",
+			len(envelope.Inlines), len(envelope.Attachments))
+	}
+	if len(envelope.OtherParts) != 1 {
+		t.Fatalf("expected 1 other part, got %d", len(envelope.OtherParts))
+	}
+
+	// The HTML body references the image via cid:.
+	if !strings.Contains(envelope.HTML, "cid:"+wantCID) {
+		t.Fatalf("fixture HTML does not reference cid:%s", wantCID)
+	}
+
+	got := collectAttachments(envelope)
+
+	// The cid referenced in the HTML must resolve to a collected, non-empty inline attachment.
+	var att *attachment.Attachment
+	for i := range got {
+		if got[i].ContentID == wantCID {
+			att = &got[i]
+			break
+		}
+	}
+	if att == nil {
+		t.Fatalf("cid:%s referenced in HTML but not collected as an attachment (got %d attachments)", wantCID, len(got))
+	}
+	if att.Disposition != attachment.DispositionInline {
+		t.Errorf("expected inline disposition, got %q", att.Disposition)
+	}
+	if att.ContentType != "image/png" {
+		t.Errorf("expected content type image/png, got %q", att.ContentType)
+	}
+	if att.Size == 0 || len(att.Content) == 0 {
+		t.Errorf("expected non-empty attachment content, got size=%d len=%d", att.Size, len(att.Content))
+	}
+}
+
+// TestCollectAttachments_Dispositions verifies disposition handling across the three
+// enmime buckets: real attachments, inline parts, and inline-less other parts.
+func TestCollectAttachments_Dispositions(t *testing.T) {
+	env := &enmime.Envelope{
+		Attachments: []*enmime.Part{
+			{FileName: "doc.pdf", ContentType: "application/pdf", ContentID: "", Content: []byte("x")},
+		},
+		Inlines: []*enmime.Part{
+			{FileName: "logo.png", ContentType: "image/png", ContentID: "logo@id", Content: []byte("x")},
+		},
+		OtherParts: []*enmime.Part{
+			{FileName: "inline.png", ContentType: "image/png", ContentID: "inline@id", Content: []byte("x")},
+			{FileName: "noid.png", ContentType: "image/png", ContentID: "", Content: []byte("x")},
+		},
+	}
+
+	got := collectAttachments(env)
+	if len(got) != 4 {
+		t.Fatalf("expected 4 attachments, got %d", len(got))
+	}
+
+	byName := map[string]attachment.Attachment{}
+	for _, a := range got {
+		byName[a.Name] = a
+	}
+
+	cases := map[string]string{
+		"doc.pdf":    attachment.DispositionAttachment, // real attachment
+		"logo.png":   attachment.DispositionInline,     // inline w/ cid
+		"inline.png": attachment.DispositionInline,     // other part w/ cid -> inline
+		"noid.png":   attachment.DispositionAttachment, // other part w/o cid -> attachment
+	}
+	for name, want := range cases {
+		if got := byName[name].Disposition; got != want {
+			t.Errorf("%s: expected disposition %q, got %q", name, want, got)
+		}
 	}
 }
 

--- a/internal/inbox/channel/email/testdata/outlook-inline-images.eml
+++ b/internal/inbox/channel/email/testdata/outlook-inline-images.eml
@@ -1,0 +1,28 @@
+From: Emma Johnson <emma.johnson@example.com>
+To: support@example.org
+Subject: FW: Quarterly report
+Message-ID: <outlook-inline-test@example.com>
+Date: Wed, 15 Jul 2026 14:56:44 +0200
+MIME-Version: 1.0
+Content-Type: multipart/related; boundary="----=_Outer_ABC"
+X-Mailer: Microsoft Outlook 16.0
+
+------=_Outer_ABC
+Content-Type: multipart/alternative; boundary="----=_Inner_DEF"
+
+------=_Inner_DEF
+Content-Type: text/plain; charset="utf-8"
+
+See the chart below.
+------=_Inner_DEF
+Content-Type: text/html; charset="utf-8"
+
+<html><body><p>See the chart below.</p><img src="cid:report-chart@example.com"></body></html>
+------=_Inner_DEF--
+------=_Outer_ABC
+Content-Type: image/png; name="chart.png"
+Content-Transfer-Encoding: base64
+Content-ID: <report-chart@example.com>
+
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==
+------=_Outer_ABC--


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email attachment handling, including Outlook-style inline images.
  * Preserved inline image references and correctly classified email parts as inline content or downloadable attachments.
  * Sanitized incoming email text and contact names to prevent invalid characters from affecting processing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->