### PR TITLE
Security: Unvalidated `order` and `order_by` parameters in activity logs query

### DIFF
--- a/cmd/actvity_log.go
+++ b/cmd/actvity_log.go
@@ -14,6 +14,22 @@ func handleGetActivityLogs(r *fastglue.Request) error {
 		filters = string(r.RequestCtx.QueryArgs().Peek("filters"))
 		total   = 0
 	)
+
+	allowedOrderBy := map[string]bool{
+		"id":          true,
+		"created_at":  true,
+		"updated_at":  true,
+		"user_id":     true,
+		"action":      true,
+		"entity_type": true,
+		"entity_id":   true,
+	}
+	if !allowedOrderBy[orderBy] {
+		orderBy = "id"
+	}
+	if order != "asc" && order != "desc" {
+		order = "desc"
+	}
 	page, pageSize := getPagination(r)
 	logs, err := app.activityLog.GetAll(order, orderBy, filters, page, pageSize, app.setting.GetAppTimezone())
 	if err != nil {


### PR DESCRIPTION
## Summary

Security: Unvalidated `order` and `order_by` parameters in activity logs query

## Problem

**Severity**: `High` | **File**: `cmd/actvity_log.go:L11`

The `handleGetActivityLogs` function passes user-controlled `order` and `orderBy` query parameters directly to `app.activityLog.GetAll`. If these values are used to construct SQL queries without proper sanitization or whitelist validation, it could lead to SQL Injection, allowing an attacker to manipulate query logic or access unauthorized data.

## Solution

Ensure `order` and `orderBy` are validated against a strict whitelist of allowed column names and sort directions (e.g., 'ASC', 'DESC') before being used in any database query.

## Changes

- `cmd/actvity_log.go` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity log sorting by validating requested sort fields and directions.
  * Invalid sorting parameters now fall back to safe defaults, ensuring reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->