### PR TITLE
seed default business hours and SLA policy on install

### DIFF
--- a/internal/migrations/v2.5.0.go
+++ b/internal/migrations/v2.5.0.go
@@ -31,39 +31,5 @@ func V2_5_0(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf) error {
 	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS index_uniq_conversation_drafts_on_conversation_id_and_user_id_and_type ON conversation_drafts (conversation_id, user_id, type);`); err != nil {
 		return err
 	}
-
-// Seed default business hours and SLA policy. mirrors the INSERTs at the tail of schema.sql.
-// guarded on emptiness, not name, so configured installs aren't given a stray row.
-
-
-	if _, err := db.Exec(`
-		INSERT INTO business_hours ("name", description, is_always_open, hours, holidays)
-		SELECT
-			'Default',
-			'Default business hours, Monday to Friday, 09:00 to 17:00.',
-			false,
-			'{"Monday": {"open": "09:00", "close": "17:00"}, "Tuesday": {"open": "09:00", "close": "17:00"}, "Wednesday": {"open": "09:00", "close": "17:00"}, "Thursday": {"open": "09:00", "close": "17:00"}, "Friday": {"open": "09:00", "close": "17:00"}}'::jsonb,
-			'[]'::jsonb
-		WHERE NOT EXISTS (
-			SELECT 1 FROM business_hours
-		);
-	`); err != nil {
-		return err
-	}
-	if _, err := db.Exec(`
-		INSERT INTO sla_policies ("name", description, first_response_time, resolution_time, next_response_time, notifications)
-		SELECT
-			'Default',
-			'Default SLA policy, first response within 1 hour and resolution within 24 hours.',
-			'1h',
-			'24h',
-			NULL::text,
-			'[]'::jsonb
-		WHERE NOT EXISTS (
-			SELECT 1 FROM sla_policies
-		);
-	`); err != nil {
-		return err
-	}
 	return nil
 }

--- a/internal/migrations/v2.5.0.go
+++ b/internal/migrations/v2.5.0.go
@@ -31,5 +31,39 @@ func V2_5_0(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf) error {
 	if _, err := db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS index_uniq_conversation_drafts_on_conversation_id_and_user_id_and_type ON conversation_drafts (conversation_id, user_id, type);`); err != nil {
 		return err
 	}
+
+// Seed default business hours and SLA policy. mirrors the INSERTs at the tail of schema.sql.
+// guarded on emptiness, not name, so configured installs aren't given a stray row.
+
+
+	if _, err := db.Exec(`
+		INSERT INTO business_hours ("name", description, is_always_open, hours, holidays)
+		SELECT
+			'Default',
+			'Default business hours, Monday to Friday, 09:00 to 17:00.',
+			false,
+			'{"Monday": {"open": "09:00", "close": "17:00"}, "Tuesday": {"open": "09:00", "close": "17:00"}, "Wednesday": {"open": "09:00", "close": "17:00"}, "Thursday": {"open": "09:00", "close": "17:00"}, "Friday": {"open": "09:00", "close": "17:00"}}'::jsonb,
+			'[]'::jsonb
+		WHERE NOT EXISTS (
+			SELECT 1 FROM business_hours
+		);
+	`); err != nil {
+		return err
+	}
+	if _, err := db.Exec(`
+		INSERT INTO sla_policies ("name", description, first_response_time, resolution_time, next_response_time, notifications)
+		SELECT
+			'Default',
+			'Default SLA policy, first response within 1 hour and resolution within 24 hours.',
+			'1h',
+			'24h',
+			NULL::text,
+			'[]'::jsonb
+		WHERE NOT EXISTS (
+			SELECT 1 FROM sla_policies
+		);
+	`); err != nil {
+		return err
+	}
 	return nil
 }

--- a/schema.sql
+++ b/schema.sql
@@ -939,3 +939,11 @@ VALUES (
   '',
   true
 );
+
+-- Default business hours
+INSERT INTO business_hours ("name", description, is_always_open, hours, holidays) VALUES
+('Default', 'Default business hours, Monday to Friday, 09:00 to 17:00.', false, '{"Monday": {"open": "09:00", "close": "17:00"}, "Tuesday": {"open": "09:00", "close": "17:00"}, "Wednesday": {"open": "09:00", "close": "17:00"}, "Thursday": {"open": "09:00", "close": "17:00"}, "Friday": {"open": "09:00", "close": "17:00"}}'::jsonb, '[]'::jsonb);
+
+-- Default SLA policy
+INSERT INTO sla_policies ("name", description, first_response_time, resolution_time, next_response_time, notifications) VALUES
+('Default', 'Default SLA policy, first response within 1 hour and resolution within 24 hours.', '1h', '24h', NULL, '[]'::jsonb);


### PR DESCRIPTION
Closes #420.

Seeds one default business hours entry (Mon–Fri, 09:00–17:00) and one default
SLA policy (1h first response, 24h resolution).

Follows the existing pattern of a `schema.sql` insert plus a guarded copy in the
current migration. The migration guards on table emptiness rather than name, so
a configured install won't get a stray row and a deleted default won't be
resurrected.

Tested: fresh `--install` + `--upgrade` yields exactly one row in each table.
Rows render and are editable in the admin UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default business hours with standard weekday operating times.
  * Added a default SLA policy with first-response and resolution targets.
* **Bug Fixes**
  * Prevented duplicate default records when applying migrations to existing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->