### PR TITLE
Optional original-sender header for IMAP inboxes (#348)

### DIFF
--- a/frontend/apps/main/src/features/admin/inbox/EmailInboxForm.vue
+++ b/frontend/apps/main/src/features/admin/inbox/EmailInboxForm.vue
@@ -295,6 +295,19 @@
           <FormMessage />
         </FormItem>
       </FormField>
+
+      <FormField v-slot="{ componentField }" name="imap.original_sender_header">
+        <FormItem>
+          <FormLabel>{{ $t('admin.inbox.originalSenderHeader') }}</FormLabel>
+          <FormControl>
+            <Input type="text" placeholder="X-Original-Sender" v-bind="componentField" />
+          </FormControl>
+          <FormDescription>
+            {{ $t('admin.inbox.originalSenderHeader.description') }}
+          </FormDescription>
+          <FormMessage />
+        </FormItem>
+      </FormField>
     </div>
 
     <!-- OAuth SMTP Configuration -->
@@ -490,6 +503,19 @@
           </FormControl>
           <FormDescription>
             {{ $t('admin.inbox.imapScanInboxSince.description') }}
+          </FormDescription>
+          <FormMessage />
+        </FormItem>
+      </FormField>
+
+      <FormField v-slot="{ componentField }" name="imap.original_sender_header">
+        <FormItem>
+          <FormLabel>{{ $t('admin.inbox.originalSenderHeader') }}</FormLabel>
+          <FormControl>
+            <Input type="text" placeholder="X-Original-Sender" v-bind="componentField" />
+          </FormControl>
+          <FormDescription>
+            {{ $t('admin.inbox.originalSenderHeader.description') }}
           </FormDescription>
           <FormMessage />
         </FormItem>
@@ -904,7 +930,8 @@ const form = useForm({
       tls_type: 'none',
       read_interval: '5m',
       scan_inbox_since: '48h',
-      tls_skip_verify: false
+      tls_skip_verify: false,
+      original_sender_header: ''
     },
     smtp: {
       host: 'smtp.gmail.com',

--- a/frontend/apps/main/src/features/admin/inbox/formSchema.js
+++ b/frontend/apps/main/src/features/admin/inbox/formSchema.js
@@ -47,7 +47,11 @@ export const createFormSchema = (t) => z.object({
     read_interval: z.string().min(1, t('globals.messages.required')).refine(isGoDuration, {
       message: t('validation.invalidDuration')
     }),
-    original_sender_header: z.string().optional()
+    original_sender_header: z
+      .string()
+      .trim()
+      .regex(/^[!-9;-~]*$/, { message: t('validation.invalidHeaderName') })
+      .optional()
   }),
   smtp: z.object({
     host: z.string().min(1, t('globals.messages.required')),

--- a/frontend/apps/main/src/features/admin/inbox/formSchema.js
+++ b/frontend/apps/main/src/features/admin/inbox/formSchema.js
@@ -46,7 +46,8 @@ export const createFormSchema = (t) => z.object({
     }),
     read_interval: z.string().min(1, t('globals.messages.required')).refine(isGoDuration, {
       message: t('validation.invalidDuration')
-    })
+    }),
+    original_sender_header: z.string().optional()
   }),
   smtp: z.object({
     host: z.string().min(1, t('globals.messages.required')),

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -1080,6 +1080,7 @@
   "validation.invalidDuration": "Invalid duration format. Please use a valid format (e.g. 30m, 1h, 48h).",
   "validation.invalidEmail": "Invalid email address",
   "validation.invalidFromAddress": "Invalid from email address format, make sure it's a valid email address in the format `Name <mail@example.com>`",
+  "validation.invalidHeaderName": "Invalid header name. Use a single header field name without spaces or colons (e.g. X-Original-Sender).",
   "validation.invalidIPOrCIDR": "Invalid IP address or CIDR range: {entry}",
   "validation.invalidInbox": "Invalid inbox",
   "validation.invalidKey": "Invalid key",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -147,6 +147,8 @@
   "admin.inbox.imapScanInboxSince.description": "To improve performance in large helpdesks with high email volume, this limits scans to emails received since the specified duration (e.g., `2h`, `48h`) by subtracting it from the current time.",
   "admin.inbox.imapScanInterval": "Scan Interval",
   "admin.inbox.imapScanInterval.description": "Interval to scan the inbox for new emails. Format: 120s, 1m, 1h",
+  "admin.inbox.originalSenderHeader": "Original sender header",
+  "admin.inbox.originalSenderHeader.description": "Optional. When set, the address in this header is used as the sender instead of the From header, falling back to From when it is absent. For Google Groups, set this to X-Original-Sender. Leave empty to keep the default behavior.",
   "admin.inbox.livechat.allowStartConversation": "Allow start conversation",
   "admin.inbox.livechat.allowStartConversation.users.description": "Allow users to start new conversations",
   "admin.inbox.livechat.allowStartConversation.visitors.description": "Allow visitors to start new conversations",

--- a/internal/inbox/channel/email/imap.go
+++ b/internal/inbox/channel/email/imap.go
@@ -171,6 +171,15 @@ func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.
 		return nil
 	}
 
+	// Validate and normalize the configured original-sender header name so a bad
+	// value (whitespace, control characters, etc.) can't malform the IMAP
+	// HEADER.FIELDS request. An invalid value is ignored, falling back to From.
+	originalSenderHeader := strings.TrimSpace(cfg.OriginalSenderHeader)
+	if originalSenderHeader != "" && !isValidHeaderName(originalSenderHeader) {
+		e.lo.Warn("ignoring invalid original_sender_header", "header", cfg.OriginalSenderHeader, "inbox_id", inboxID)
+		originalSenderHeader = ""
+	}
+
 	// Fetch envelope and headers needed for auto-reply detection.
 	headerFields := []string{
 		headerAutoSubmitted,
@@ -180,8 +189,8 @@ func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.
 	}
 	// Also fetch the configured original-sender header (e.g. X-Original-Sender)
 	// so the sender can be remapped below.
-	if cfg.OriginalSenderHeader != "" {
-		headerFields = append(headerFields, cfg.OriginalSenderHeader)
+	if originalSenderHeader != "" {
+		headerFields = append(headerFields, originalSenderHeader)
 	}
 	fetchOptions := &imap.FetchOptions{
 		Envelope: true,
@@ -274,8 +283,8 @@ func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.
 				extractedMessageID = extractMessageIDFromHeaders(envelope)
 
 				// Remap the sender from the configured header (e.g. X-Original-Sender).
-				if cfg.OriginalSenderHeader != "" {
-					overrideFromAddr, overrideFromName = extractSenderFromHeader(envelope, cfg.OriginalSenderHeader)
+				if originalSenderHeader != "" {
+					overrideFromAddr, overrideFromName = extractSenderFromHeader(envelope, originalSenderHeader)
 				}
 			}
 
@@ -420,6 +429,12 @@ func (e *Email) processEnvelope(ctx context.Context, client *imapclient.Client, 
 		if from.Addr() != "" {
 			fromAddr = append(fromAddr, strings.ToLower(from.Addr()))
 		}
+	}
+	// When the sender was remapped from the configured header, record the
+	// effective sender in meta so it stays consistent with the contact (and is
+	// not left empty when the envelope has no From).
+	if overrideFromAddr != "" {
+		fromAddr = []string{overrideFromAddr}
 	}
 
 	meta, err := json.Marshal(map[string]interface{}{
@@ -693,6 +708,21 @@ func extractSenderFromHeader(envelope *enmime.Envelope, headerName string) (addr
 		return strings.ToLower(parsed.Address), parsed.Name
 	}
 	return "", ""
+}
+
+// isValidHeaderName reports whether s is a valid RFC 5322 header field name
+// (printable US-ASCII, 33-126, excluding ':'), i.e. safe to place in an IMAP
+// HEADER.FIELDS request.
+func isValidHeaderName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < 33 || r > 126 || r == ':' {
+			return false
+		}
+	}
+	return true
 }
 
 // extractConversationUUIDFromRecipient extracts conversation UUID from plus-addressed recipient.

--- a/internal/inbox/channel/email/imap.go
+++ b/internal/inbox/channel/email/imap.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/mail"
 	"strings"
 	"time"
 
@@ -125,7 +126,7 @@ func (e *Email) processMailbox(ctx context.Context, scanInboxSince time.Duration
 		return fmt.Errorf("error searching messages: %w", err)
 	}
 
-	return e.fetchAndProcessMessages(ctx, client, searchResults, e.Identifier())
+	return e.fetchAndProcessMessages(ctx, client, searchResults, e.Identifier(), cfg)
 }
 
 // searchMessages searches for messages in the specified time range.
@@ -156,7 +157,7 @@ func (e *Email) searchMessages(client *imapclient.Client, since time.Time) (*ima
 }
 
 // fetchAndProcessMessages fetches and processes messages based on the search results.
-func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.Client, searchResults *imap.SearchData, inboxID int) error {
+func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.Client, searchResults *imap.SearchData, inboxID int, cfg imodels.IMAPConfig) error {
 	seqSet := imap.SeqSet{}
 	if searchResults.Min > 0 && searchResults.Max > 0 {
 		e.lo.Debug("using ESEARCH range", "min", searchResults.Min, "max", searchResults.Max, "inbox_id", inboxID)
@@ -171,17 +172,23 @@ func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.
 	}
 
 	// Fetch envelope and headers needed for auto-reply detection.
+	headerFields := []string{
+		headerAutoSubmitted,
+		headerAutoreply,
+		headerLibredeskLoopPrevention,
+		headerMessageID,
+	}
+	// Also fetch the configured original-sender header (e.g. X-Original-Sender)
+	// so the sender can be remapped below.
+	if cfg.OriginalSenderHeader != "" {
+		headerFields = append(headerFields, cfg.OriginalSenderHeader)
+	}
 	fetchOptions := &imap.FetchOptions{
 		Envelope: true,
 		BodySection: []*imap.FetchItemBodySection{
 			{
-				Specifier: imap.PartSpecifierHeader,
-				HeaderFields: []string{
-					headerAutoSubmitted,
-					headerAutoreply,
-					headerLibredeskLoopPrevention,
-					headerMessageID,
-				},
+				Specifier:    imap.PartSpecifierHeader,
+				HeaderFields: headerFields,
 			},
 		},
 	}
@@ -193,6 +200,8 @@ func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.
 		autoReply          bool
 		isLoop             bool
 		extractedMessageID string
+		overrideFromAddr   string
+		overrideFromName   string
 	}
 	var messages []msgData
 
@@ -228,6 +237,8 @@ func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.
 			autoReply          bool
 			isLoop             bool
 			extractedMessageID string
+			overrideFromAddr   string
+			overrideFromName   string
 		)
 		// Process all fetch items for the current message.
 		for {
@@ -261,6 +272,11 @@ func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.
 
 				// Extract Message-Id from raw headers as fallback for problematic Message IDs
 				extractedMessageID = extractMessageIDFromHeaders(envelope)
+
+				// Remap the sender from the configured header (e.g. X-Original-Sender).
+				if cfg.OriginalSenderHeader != "" {
+					overrideFromAddr, overrideFromName = extractSenderFromHeader(envelope, cfg.OriginalSenderHeader)
+				}
 			}
 
 			// Envelope.
@@ -275,7 +291,7 @@ func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.
 			continue
 		}
 
-		messages = append(messages, msgData{env: env, seqNum: msg.SeqNum, autoReply: autoReply, isLoop: isLoop, extractedMessageID: extractedMessageID})
+		messages = append(messages, msgData{env: env, seqNum: msg.SeqNum, autoReply: autoReply, isLoop: isLoop, extractedMessageID: extractedMessageID, overrideFromAddr: overrideFromAddr, overrideFromName: overrideFromName})
 	}
 
 	// Now process each collected message.
@@ -300,7 +316,7 @@ func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.
 		}
 
 		// Process the envelope.
-		if err := e.processEnvelope(ctx, client, msgData.env, msgData.seqNum, inboxID, msgData.extractedMessageID); err != nil && err != context.Canceled {
+		if err := e.processEnvelope(ctx, client, msgData.env, msgData.seqNum, inboxID, msgData.extractedMessageID, msgData.overrideFromAddr, msgData.overrideFromName); err != nil && err != context.Canceled {
 			e.lo.Error("error processing envelope", "error", err)
 		}
 	}
@@ -309,12 +325,23 @@ func (e *Email) fetchAndProcessMessages(ctx context.Context, client *imapclient.
 }
 
 // processEnvelope processes a single email envelope.
-func (e *Email) processEnvelope(ctx context.Context, client *imapclient.Client, env *imap.Envelope, seqNum uint32, inboxID int, extractedMessageID string) error {
-	if len(env.From) == 0 {
+//
+// overrideFromAddr/overrideFromName, when set, come from the inbox's configured
+// original-sender header (e.g. X-Original-Sender) and replace the envelope From
+// as the message sender. They are empty when the header is unset or invalid, in
+// which case the envelope From is used.
+func (e *Email) processEnvelope(ctx context.Context, client *imapclient.Client, env *imap.Envelope, seqNum uint32, inboxID int, extractedMessageID, overrideFromAddr, overrideFromName string) error {
+	if len(env.From) == 0 && overrideFromAddr == "" {
 		e.lo.Warn("no sender received for email", "message_id", env.MessageID)
 		return nil
 	}
-	var fromAddress = strings.ToLower(env.From[0].Addr())
+	var fromAddress string
+	if len(env.From) > 0 {
+		fromAddress = strings.ToLower(env.From[0].Addr())
+	}
+	if overrideFromAddr != "" {
+		fromAddress = overrideFromAddr
+	}
 
 	// Determine final Message ID - prefer IMAP-parsed, fallback to raw header extraction
 	messageID := env.MessageID
@@ -352,8 +379,17 @@ func (e *Email) processEnvelope(ctx context.Context, client *imapclient.Client, 
 
 	e.lo.Debug("processing new incoming message", "message_id", messageID, "subject", env.Subject, "from", fromAddress, "inbox_id", inboxID)
 
-	// Make contact.
-	firstName, lastName := getContactName(env.From[0])
+	// Make contact. When the sender was remapped from the configured header,
+	// derive the name from that header (its display name, else the local part).
+	var firstName, lastName string
+	if overrideFromAddr != "" {
+		firstName, lastName = stringutil.SplitName(overrideFromName)
+		if firstName == "" {
+			firstName, _, _ = strings.Cut(fromAddress, "@")
+		}
+	} else {
+		firstName, lastName = getContactName(env.From[0])
+	}
 	contact := models.IncomingContact{
 		FirstName: firstName,
 		LastName:  lastName,
@@ -637,6 +673,26 @@ func extractMessageIDFromHeaders(envelope *enmime.Envelope) string {
 		return strings.TrimSpace(strings.Trim(rawMessageID, "<>"))
 	}
 	return ""
+}
+
+// extractSenderFromHeader returns the lowercased address and display name from
+// the given header (e.g. "X-Original-Sender"). It returns empty strings when the
+// header is absent or cannot be parsed as an email address, so callers fall back
+// to the envelope From.
+func extractSenderFromHeader(envelope *enmime.Envelope, headerName string) (addr string, name string) {
+	raw := strings.TrimSpace(envelope.GetHeader(headerName))
+	if raw == "" {
+		return "", ""
+	}
+	// Prefer a full address list (handles an optional display name and any
+	// trailing addresses); fall back to a single-address parse.
+	if addrs, err := mail.ParseAddressList(raw); err == nil && len(addrs) > 0 {
+		return strings.ToLower(addrs[0].Address), addrs[0].Name
+	}
+	if parsed, err := mail.ParseAddress(raw); err == nil {
+		return strings.ToLower(parsed.Address), parsed.Name
+	}
+	return "", ""
 }
 
 // extractConversationUUIDFromRecipient extracts conversation UUID from plus-addressed recipient.

--- a/internal/inbox/channel/email/imap_original_sender_test.go
+++ b/internal/inbox/channel/email/imap_original_sender_test.go
@@ -1,0 +1,72 @@
+package email
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jhillyerd/enmime"
+)
+
+func TestExtractSenderFromHeader(t *testing.T) {
+	const header = "X-Original-Sender"
+
+	testCases := []struct {
+		name         string
+		rawEmail     string
+		headerName   string
+		expectedAddr string
+		expectedName string
+	}{
+		{
+			name:         "address with display name",
+			rawEmail:     "From: group@lists.example.com\r\nX-Original-Sender: Jane Doe <Jane.Doe@Example.com>\r\nSubject: hi\r\n\r\nbody",
+			headerName:   header,
+			expectedAddr: "jane.doe@example.com",
+			expectedName: "Jane Doe",
+		},
+		{
+			name:         "bare address is lowercased",
+			rawEmail:     "From: group@lists.example.com\r\nX-Original-Sender: USER@Example.com\r\nSubject: hi\r\n\r\nbody",
+			headerName:   header,
+			expectedAddr: "user@example.com",
+			expectedName: "",
+		},
+		{
+			name:         "header absent falls back to empty",
+			rawEmail:     "From: group@lists.example.com\r\nSubject: hi\r\n\r\nbody",
+			headerName:   header,
+			expectedAddr: "",
+			expectedName: "",
+		},
+		{
+			name:         "unparseable header falls back to empty",
+			rawEmail:     "From: group@lists.example.com\r\nX-Original-Sender: not-an-email\r\nSubject: hi\r\n\r\nbody",
+			headerName:   header,
+			expectedAddr: "",
+			expectedName: "",
+		},
+		{
+			name:         "empty header name is a no-op",
+			rawEmail:     "From: group@lists.example.com\r\nX-Original-Sender: user@example.com\r\nSubject: hi\r\n\r\nbody",
+			headerName:   "",
+			expectedAddr: "",
+			expectedName: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			env, err := enmime.ReadEnvelope(strings.NewReader(tc.rawEmail))
+			if err != nil {
+				t.Fatalf("reading envelope: %v", err)
+			}
+			addr, name := extractSenderFromHeader(env, tc.headerName)
+			if addr != tc.expectedAddr {
+				t.Errorf("addr = %q, want %q", addr, tc.expectedAddr)
+			}
+			if name != tc.expectedName {
+				t.Errorf("name = %q, want %q", name, tc.expectedName)
+			}
+		})
+	}
+}

--- a/internal/inbox/channel/email/imap_original_sender_test.go
+++ b/internal/inbox/channel/email/imap_original_sender_test.go
@@ -70,3 +70,26 @@ func TestExtractSenderFromHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestIsValidHeaderName(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		valid bool
+	}{
+		{"typical header", "X-Original-Sender", true},
+		{"simple token", "From", true},
+		{"empty", "", false},
+		{"contains space", "X Original Sender", false},
+		{"contains colon", "X-Original-Sender:", false},
+		{"contains control char", "X-Original\tSender", false},
+		{"non-ascii", "X-Originál-Sender", false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidHeaderName(tc.input); got != tc.valid {
+				t.Errorf("isValidHeaderName(%q) = %v, want %v", tc.input, got, tc.valid)
+			}
+		})
+	}
+}

--- a/internal/inbox/models/models.go
+++ b/internal/inbox/models/models.go
@@ -92,6 +92,10 @@ type IMAPConfig struct {
 	ScanInboxSince string `json:"scan_inbox_since"`
 	TLSType        string `json:"tls_type"`
 	TLSSkipVerify  bool   `json:"tls_skip_verify"`
+	// OriginalSenderHeader, when set, uses the address in this header as the
+	// message sender instead of the From header (e.g. "X-Original-Sender" for
+	// Google Groups). Falls back to From when the header is absent or invalid.
+	OriginalSenderHeader string `json:"original_sender_header"`
 }
 
 // ClearPasswords masks all config passwords


### PR DESCRIPTION
Implements #348.

Went with the generic approach you suggested rather than anything Google-specific: there's a new optional `original_sender_header` field on the IMAP inbox config. When it's set, we take the address from that header (e.g. `X-Original-Sender` for Google Groups) as the sender, and fall back to the normal `From` whenever the header isn't there. Left empty it changes nothing, so existing inboxes behave exactly as they do today.

I kept this to the `From`/sender side only since that's what actually fixes the Google Groups case. If a `to` remap turns out to be needed we can do it as a small follow-up with its own header field.

A few notes on how it works:

- The configured header name is threaded into the fetch so it's actually requested from the server, then parsed with `net/mail` — handles both a bare `user@example.com` and `Name <user@example.com>`. Anything that doesn't parse just falls back to `From` instead of dropping the message.
- The contact name uses the header's display name when there is one, otherwise the local part of the address.
- Added the field to the inbox form (both auth variants) with a hint pointing Google Groups users at `X-Original-Sender`, plus the en-US strings.

For testing I added a unit test around the header parsing (`extractSenderFromHeader`) covering the display-name, bare-address, missing-header and unparseable cases. `go build ./...` and `go vet ./internal/inbox/...` are clean and the email package tests pass. I didn't spin up the frontend locally, but the new field just mirrors the existing IMAP inputs.

Happy to move the field or adjust anything if you'd rather it sit elsewhere.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional IMAP setting to override the effective sender using a configurable original-sender header.
  * Available for both OAuth and manual IMAP inbox setup; when present and valid, emails use the header’s address and display name (otherwise they fall back to the standard sender).
  * Added localized labels, descriptions, and an `X-Original-Sender` example for Google Groups.

* **Bug Fixes**
  * Added validation to reject unsafe/invalid header names.

* **Tests**
  * Added unit coverage for header parsing and header-name validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->