### PR TITLE
shortlist tags with embeddings before asking the LLM to suggest them

### DIFF
--- a/cmd/ai.go
+++ b/cmd/ai.go
@@ -348,25 +348,12 @@ func handleAISuggestTags(r *fastglue.Request) error {
 		return sendErrorEnvelope(r, err)
 	}
 
-	tags, err := app.tag.GetAll()
-	if err != nil {
-		return sendErrorEnvelope(r, err)
-	}
-	if len(tags) == 0 {
-		return sendErrorEnvelope(r, envelope.NewError(envelope.InputError, app.i18n.T("ai.noTagsConfigured"), nil))
-	}
-
 	transcript := conversationTranscript(app, req.ConversationUUID)
 	if strings.TrimSpace(transcript) == "" {
 		return sendErrorEnvelope(r, envelope.NewError(envelope.InputError, app.i18n.T("ai.tagSuggestEmptyConversation"), nil))
 	}
 
-	names := make([]string, 0, len(tags))
-	for _, t := range tags {
-		names = append(names, t.Name)
-	}
-
-	suggestions, err := app.ai.SuggestTags(r.RequestCtx, transcript, names)
+	suggestions, err := app.ai.SuggestTags(r.RequestCtx, transcript)
 	if err != nil {
 		return sendErrorEnvelope(r, err)
 	}

--- a/internal/ai/ai.go
+++ b/internal/ai/ai.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/abhinavxd/libredesk/internal/ai/models"
@@ -54,6 +55,8 @@ type Manager struct {
 	reconcileMu  sync.Mutex
 	snippetGenMu sync.Mutex
 	snippetGen   map[int]uint64
+	// tagGen is bumped on every tag vector purge; an in-flight tag reindex only commits if its gen is still current.
+	tagGen atomic.Uint64
 	// embedSem caps concurrent background snippet embeds.
 	embedSem           chan struct{}
 	httpClient         *http.Client
@@ -81,30 +84,33 @@ type ProviderConfigView struct {
 }
 
 type queries struct {
-	GetProviderByType           *sqlx.Stmt `query:"get-provider-by-type"`
-	UpdateProviderConfig        *sqlx.Stmt `query:"update-provider-config"`
-	GetPrompt                   *sqlx.Stmt `query:"get-prompt"`
-	GetPrompts                  *sqlx.Stmt `query:"get-prompts"`
-	GetKnowledgeBaseItems       *sqlx.Stmt `query:"get-knowledge-base-items"`
-	GetKnowledgeBaseItem        *sqlx.Stmt `query:"get-knowledge-base-item"`
-	KnowledgeBaseItemExists     *sqlx.Stmt `query:"knowledge-base-item-exists"`
-	InsertKnowledgeBaseItem     *sqlx.Stmt `query:"insert-knowledge-base-item"`
-	UpdateKnowledgeBaseItem     *sqlx.Stmt `query:"update-knowledge-base-item"`
-	DeleteKnowledgeBaseItem     *sqlx.Stmt `query:"delete-knowledge-base-item"`
-	SetKnowledgeBaseFingerprint *sqlx.Stmt `query:"set-knowledge-base-embedded-fingerprint"`
-	InsertEmbedding             *sqlx.Stmt `query:"insert-embedding"`
-	DeleteEmbeddingsBySource    *sqlx.Stmt `query:"delete-embeddings-by-source"`
-	GetAllEmbeddings            *sqlx.Stmt `query:"get-all-embeddings"`
-	GetTools                    *sqlx.Stmt `query:"get-tools"`
-	GetTool                     *sqlx.Stmt `query:"get-tool"`
-	GetEnabledToolsByIDs        *sqlx.Stmt `query:"get-enabled-tools-by-ids"`
-	GetToolAuth                 *sqlx.Stmt `query:"get-tool-auth"`
-	InsertTool                  *sqlx.Stmt `query:"insert-tool"`
-	UpdateTool                  *sqlx.Stmt `query:"update-tool"`
-	DeleteTool                  *sqlx.Stmt `query:"delete-tool"`
-	GetCopilotMessages          *sqlx.Stmt `query:"get-copilot-messages"`
-	InsertCopilotMessage        *sqlx.Stmt `query:"insert-copilot-message"`
-	DeleteCopilotMessages       *sqlx.Stmt `query:"delete-copilot-messages"`
+	GetProviderByType            *sqlx.Stmt `query:"get-provider-by-type"`
+	UpdateProviderConfig         *sqlx.Stmt `query:"update-provider-config"`
+	GetPrompt                    *sqlx.Stmt `query:"get-prompt"`
+	GetPrompts                   *sqlx.Stmt `query:"get-prompts"`
+	GetKnowledgeBaseItems        *sqlx.Stmt `query:"get-knowledge-base-items"`
+	GetKnowledgeBaseItem         *sqlx.Stmt `query:"get-knowledge-base-item"`
+	KnowledgeBaseItemExists      *sqlx.Stmt `query:"knowledge-base-item-exists"`
+	InsertKnowledgeBaseItem      *sqlx.Stmt `query:"insert-knowledge-base-item"`
+	UpdateKnowledgeBaseItem      *sqlx.Stmt `query:"update-knowledge-base-item"`
+	DeleteKnowledgeBaseItem      *sqlx.Stmt `query:"delete-knowledge-base-item"`
+	SetKnowledgeBaseFingerprint  *sqlx.Stmt `query:"set-knowledge-base-embedded-fingerprint"`
+	InsertEmbedding              *sqlx.Stmt `query:"insert-embedding"`
+	DeleteEmbeddingsBySource     *sqlx.Stmt `query:"delete-embeddings-by-source"`
+	DeleteEmbeddingsBySourceIDs  *sqlx.Stmt `query:"delete-embeddings-by-source-ids"`
+	DeleteEmbeddingsBySourceType *sqlx.Stmt `query:"delete-embeddings-by-source-type"`
+	GetAllEmbeddings             *sqlx.Stmt `query:"get-all-embeddings"`
+	GetTags                      *sqlx.Stmt `query:"get-tags"`
+	GetTools                     *sqlx.Stmt `query:"get-tools"`
+	GetTool                      *sqlx.Stmt `query:"get-tool"`
+	GetEnabledToolsByIDs         *sqlx.Stmt `query:"get-enabled-tools-by-ids"`
+	GetToolAuth                  *sqlx.Stmt `query:"get-tool-auth"`
+	InsertTool                   *sqlx.Stmt `query:"insert-tool"`
+	UpdateTool                   *sqlx.Stmt `query:"update-tool"`
+	DeleteTool                   *sqlx.Stmt `query:"delete-tool"`
+	GetCopilotMessages           *sqlx.Stmt `query:"get-copilot-messages"`
+	InsertCopilotMessage         *sqlx.Stmt `query:"insert-copilot-message"`
+	DeleteCopilotMessages        *sqlx.Stmt `query:"delete-copilot-messages"`
 }
 
 // New creates and returns a new instance of the Manager.
@@ -288,6 +294,7 @@ func (m *Manager) UpdateProviderConfig(providerType string, in models.ProviderCo
 	// A changed embedding model, dimension count, or backend URL produces vectors incomparable to the stored ones.
 	if providerType == models.ProviderTypeEmbedding && (existing.Model != cfg.Model || existing.Dimensions != cfg.Dimensions || existing.BaseURL != cfg.BaseURL) {
 		m.lo.Info("embedding provider changed, reindexing knowledge base", "old_model", existing.Model, "new_model", cfg.Model, "old_base_url", existing.BaseURL, "new_base_url", cfg.BaseURL)
+		m.purgeTagEmbeddings()
 		m.ReindexAll()
 	}
 	return nil

--- a/internal/ai/copilot.go
+++ b/internal/ai/copilot.go
@@ -13,8 +13,8 @@ import (
 // maxSuggestTagsList bounds how many tag names are sent to the LLM for a tag suggestion.
 const maxSuggestTagsList = 300
 
-// maxTagQueryChars bounds the transcript embedded to retrieve tag candidates.
-const maxTagQueryChars = 4000
+// maxTagQueryTokens bounds the transcript embedded to retrieve tag candidates; a longer transcript averages every topic in the thread into one vector and retrieves worse.
+const maxTagQueryTokens = 1000
 
 // maxSuggestedTags caps how many tags a suggestion returns, whatever the model replies with.
 const maxSuggestedTags = 3
@@ -117,7 +117,7 @@ func (m *Manager) tagShortlist(ctx context.Context, transcript string, tags []mo
 		return names
 	}
 
-	candidates, err := m.tagCandidates(ctx, trimToRuneBoundary(transcript, maxTagQueryChars), maxSuggestTagsList, tags)
+	candidates, err := m.tagCandidates(ctx, capToTokens(transcript, maxTagQueryTokens), maxSuggestTagsList, tags)
 	if err != nil {
 		m.lo.Warn("error retrieving tag candidates for ai tag suggestion", "error", err, "total", len(names))
 	} else if len(candidates) > 0 {

--- a/internal/ai/copilot.go
+++ b/internal/ai/copilot.go
@@ -13,6 +13,9 @@ import (
 // maxSuggestTagsList bounds how many tag names are sent to the LLM for a tag suggestion.
 const maxSuggestTagsList = 300
 
+// maxTagQueryChars bounds the transcript embedded to retrieve tag candidates.
+const maxTagQueryChars = 4000
+
 // maxSuggestedTags caps how many tags a suggestion returns, whatever the model replies with.
 const maxSuggestedTags = 3
 
@@ -83,12 +86,17 @@ func (m *Manager) Summarize(ctx context.Context, transcript string) (string, err
 	return m.CompletionRaw(ctx, summarizeSystemPrompt, "Conversation:\n"+transcript)
 }
 
-// SuggestTags picks up to 3 allowed tags that fit the transcript; empty (never nil) when none fit or the reply is unparseable.
-func (m *Manager) SuggestTags(ctx context.Context, transcript string, allowed []string) ([]string, error) {
-	if len(allowed) > maxSuggestTagsList {
-		m.lo.Warn("tag list truncated for ai tag suggestion", "total", len(allowed), "cap", maxSuggestTagsList)
-		allowed = allowed[:maxSuggestTagsList]
+// SuggestTags picks up to 3 existing tags that fit the transcript; empty (never nil) when none fit or the reply is unparseable.
+func (m *Manager) SuggestTags(ctx context.Context, transcript string) ([]string, error) {
+	tags, err := m.getTags()
+	if err != nil {
+		return nil, envelope.NewError(envelope.GeneralError, m.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
+	if len(tags) == 0 {
+		return nil, envelope.NewError(envelope.InputError, m.i18n.T("ai.noTagsConfigured"), nil)
+	}
+
+	allowed := m.tagShortlist(ctx, transcript, tags)
 	userPrompt := "Allowed tags:\n" + strings.Join(allowed, "\n") + "\n\nConversation:\n" + transcript
 	resp, err := m.CompletionRaw(ctx, suggestTagsSystemPrompt, userPrompt)
 	if err != nil {
@@ -100,6 +108,24 @@ func (m *Manager) SuggestTags(ctx context.Context, transcript string, allowed []
 		return []string{}, nil
 	}
 	return suggestions, nil
+}
+
+// tagShortlist narrows the tag list to the tags most similar to the transcript, or a truncated list when the tag index is unavailable.
+func (m *Manager) tagShortlist(ctx context.Context, transcript string, tags []models.TagRef) []string {
+	names := tagNames(tags)
+	if len(names) <= maxSuggestTagsList {
+		return names
+	}
+
+	candidates, err := m.tagCandidates(ctx, trimToRuneBoundary(transcript, maxTagQueryChars), maxSuggestTagsList, tags)
+	if err != nil {
+		m.lo.Warn("error retrieving tag candidates for ai tag suggestion", "error", err, "total", len(names))
+	} else if len(candidates) > 0 {
+		return candidates
+	}
+
+	m.lo.Warn("tag list truncated for ai tag suggestion", "total", len(names), "cap", maxSuggestTagsList)
+	return names[:maxSuggestTagsList]
 }
 
 // parseSuggestedTags extracts the model's JSON tag array, keeping only allowed names; nil means unparseable (vs none fit).

--- a/internal/ai/embedding.go
+++ b/internal/ai/embedding.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/abhinavxd/libredesk/internal/ai/models"
 	"github.com/abhinavxd/libredesk/internal/stringutil"
+	"github.com/lib/pq"
 )
 
 // reconcileInterval is how often knowledge base content that failed to embed is retried.
@@ -45,12 +46,13 @@ func (ix *embeddingIndex) replaceAll(chunks []indexedChunk) {
 	ix.chunks = chunks
 }
 
-func (ix *embeddingIndex) replaceSource(sourceType string, sourceID int, chunks []indexedChunk) {
+// replaceWhere drops every chunk matching drop, then appends chunks.
+func (ix *embeddingIndex) replaceWhere(drop func(indexedChunk) bool, chunks []indexedChunk) {
 	ix.mu.Lock()
 	defer ix.mu.Unlock()
 	kept := ix.chunks[:0:0]
 	for _, c := range ix.chunks {
-		if c.sourceType == sourceType && c.sourceID == sourceID {
+		if drop(c) {
 			continue
 		}
 		kept = append(kept, c)
@@ -58,12 +60,38 @@ func (ix *embeddingIndex) replaceSource(sourceType string, sourceID int, chunks 
 	ix.chunks = append(kept, chunks...)
 }
 
-func (ix *embeddingIndex) removeSource(sourceType string, sourceID int) {
-	ix.replaceSource(sourceType, sourceID, nil)
+// replaceSourceIDs drops every chunk of a source type whose id is in ids, then appends chunks.
+func (ix *embeddingIndex) replaceSourceIDs(sourceType string, ids []int, chunks []indexedChunk) {
+	drop := make(map[int]bool, len(ids))
+	for _, id := range ids {
+		drop[id] = true
+	}
+	ix.replaceWhere(func(c indexedChunk) bool { return c.sourceType == sourceType && drop[c.sourceID] }, chunks)
 }
 
-// search returns the top-k matches and the count of chunks skipped for mismatched vector dimensions.
-func (ix *embeddingIndex) search(query []float32, k int) ([]models.SearchResult, int) {
+func (ix *embeddingIndex) removeSource(sourceType string, sourceID int) {
+	ix.replaceSourceIDs(sourceType, []int{sourceID}, nil)
+}
+
+func (ix *embeddingIndex) removeSourceType(sourceType string) {
+	ix.replaceWhere(func(c indexedChunk) bool { return c.sourceType == sourceType }, nil)
+}
+
+// chunksBySourceID returns a source type's chunks keyed by source id; only valid for one-chunk-per-source types.
+func (ix *embeddingIndex) chunksBySourceID(sourceType string) map[int]indexedChunk {
+	ix.mu.RLock()
+	defer ix.mu.RUnlock()
+	out := make(map[int]indexedChunk)
+	for _, c := range ix.chunks {
+		if c.sourceType == sourceType {
+			out[c.sourceID] = c
+		}
+	}
+	return out
+}
+
+// search returns the top-k matches within one source type and the count of chunks skipped for mismatched vector dimensions.
+func (ix *embeddingIndex) search(query []float32, k int, sourceType string) ([]models.SearchResult, int) {
 	ix.mu.RLock()
 	defer ix.mu.RUnlock()
 
@@ -75,6 +103,9 @@ func (ix *embeddingIndex) search(query []float32, k int) ([]models.SearchResult,
 	dimMismatch := 0
 	results := make([]models.SearchResult, 0, len(ix.chunks))
 	for _, c := range ix.chunks {
+		if c.sourceType != sourceType {
+			continue
+		}
 		if len(c.vec) != len(query) {
 			dimMismatch++
 			continue
@@ -98,8 +129,12 @@ func (ix *embeddingIndex) search(query []float32, k int) ([]models.SearchResult,
 	return results, dimMismatch
 }
 
-// Search embeds the query and returns the top-k most similar chunks across the whole index.
+// Search embeds the query and returns the top-k most similar knowledge base chunks.
 func (m *Manager) Search(ctx context.Context, query string, k int) ([]models.SearchResult, error) {
+	return m.searchSource(ctx, query, k, models.SourceSnippet)
+}
+
+func (m *Manager) searchSource(ctx context.Context, query string, k int, sourceType string) ([]models.SearchResult, error) {
 	// A run arriving right after boot must not search the index before it has loaded.
 	select {
 	case <-m.indexReady:
@@ -110,11 +145,11 @@ func (m *Manager) Search(ctx context.Context, query string, k int) ([]models.Sea
 	if err != nil {
 		return nil, err
 	}
-	results, dimMismatch := m.index.search(qvec, k)
+	results, dimMismatch := m.index.search(qvec, k, sourceType)
 	if dimMismatch > 0 {
-		m.lo.Warn("skipped stale embeddings with mismatched dimensions; reindex the knowledge base after changing the embedding model", "count", dimMismatch, "query_dimensions", len(qvec))
+		m.lo.Warn("skipped stale embeddings with mismatched dimensions; reindex after changing the embedding model", "source_type", sourceType, "count", dimMismatch, "query_dimensions", len(qvec))
 	}
-	m.lo.Debug("rag search", "query_len", len(query), "hits", len(results))
+	m.lo.Debug("rag search", "source_type", sourceType, "query_len", len(query), "hits", len(results))
 	for i, r := range results {
 		m.lo.Debug("rag fetched chunk", "rank", i+1, "score", r.Score, "source_type", r.SourceType, "source_id", r.SourceID, "chunk_len", len(r.ChunkText))
 	}
@@ -129,7 +164,7 @@ func (m *Manager) Reindex(sourceType string, sourceID int, title, htmlContent st
 	}
 	m.reindexMu.Lock()
 	defer m.reindexMu.Unlock()
-	return m.commitEmbeddings(sourceType, sourceID, indexed)
+	return m.commitEmbeddings(sourceType, []int{sourceID}, indexed)
 }
 
 // embedSource chunks and embeds content without touching stored state, so it can run before taking reindexMu.
@@ -165,8 +200,8 @@ func (m *Manager) embedSource(ctx context.Context, sourceType string, sourceID i
 	return indexed, nil
 }
 
-// commitEmbeddings replaces a source's stored and in-memory vectors. Caller must hold reindexMu.
-func (m *Manager) commitEmbeddings(sourceType string, sourceID int, indexed []indexedChunk) error {
+// commitEmbeddings replaces the stored and in-memory vectors of the given source ids. Caller must hold reindexMu.
+func (m *Manager) commitEmbeddings(sourceType string, sourceIDs []int, indexed []indexedChunk) error {
 	tx, err := m.db.BeginTxx(context.Background(), &sql.TxOptions{})
 	if err != nil {
 		m.lo.Error("error beginning reindex transaction", "error", err)
@@ -176,14 +211,14 @@ func (m *Manager) commitEmbeddings(sourceType string, sourceID int, indexed []in
 		_ = tx.Rollback()
 	}()
 
-	if _, err := tx.Stmtx(m.q.DeleteEmbeddingsBySource).Exec(sourceType, sourceID); err != nil {
+	if _, err := tx.Stmtx(m.q.DeleteEmbeddingsBySourceIDs).Exec(sourceType, pq.Array(sourceIDs)); err != nil {
 		m.lo.Error("error clearing old embeddings", "error", err)
 		return err
 	}
 	insert := tx.Stmtx(m.q.InsertEmbedding)
 	for _, c := range indexed {
-		if _, err := insert.Exec(sourceType, sourceID, c.chunkText, serializeEmbedding(c.vec), len(c.vec)); err != nil {
-			m.lo.Error("error inserting embedding", "error", err)
+		if _, err := insert.Exec(sourceType, c.sourceID, c.chunkText, serializeEmbedding(c.vec), len(c.vec)); err != nil {
+			m.lo.Error("error inserting embedding", "error", err, "source_id", c.sourceID)
 			return err
 		}
 	}
@@ -192,7 +227,7 @@ func (m *Manager) commitEmbeddings(sourceType string, sourceID int, indexed []in
 		return err
 	}
 
-	m.index.replaceSource(sourceType, sourceID, indexed)
+	m.index.replaceSourceIDs(sourceType, sourceIDs, indexed)
 	return nil
 }
 
@@ -276,7 +311,7 @@ func (m *Manager) reconcileLoop(ctx context.Context) {
 	}
 }
 
-// reconcile re-embeds every enabled snippet whose stored fingerprint no longer matches its content and the active model.
+// reconcile brings the knowledge base and tag embeddings back in line with the active embedding provider.
 func (m *Manager) reconcile(ctx context.Context) {
 	if !m.reconcileMu.TryLock() {
 		return
@@ -291,12 +326,18 @@ func (m *Manager) reconcile(ctx context.Context) {
 	if cfg.APIKey == "" {
 		return
 	}
+	m.reconcileSnippets(ctx, cfg)
+	m.reconcileTags(ctx)
+}
+
+// reconcileSnippets re-embeds every enabled snippet whose stored fingerprint no longer matches its content and the active model.
+func (m *Manager) reconcileSnippets(ctx context.Context, cfg models.ProviderConfig) {
 	items, err := m.GetKnowledgeBaseItems()
 	if err != nil {
 		return
 	}
 
-	reindexed := 0
+	var reindexed, dropped int
 	for _, item := range items {
 		if ctx.Err() != nil {
 			return
@@ -305,6 +346,7 @@ func (m *Manager) reconcile(ctx context.Context) {
 			// A disabled item should carry no embeddings; clean up any left behind.
 			if item.EmbeddedFingerprint != "" {
 				m.reindexSnippetWith(ctx, item, cfg.BaseURL, cfg.Model, cfg.Dimensions, m.nextSnippetGen(item.ID))
+				dropped++
 			}
 			continue
 		}
@@ -314,8 +356,8 @@ func (m *Manager) reconcile(ctx context.Context) {
 		m.reindexSnippetWith(ctx, item, cfg.BaseURL, cfg.Model, cfg.Dimensions, m.nextSnippetGen(item.ID))
 		reindexed++
 	}
-	if reindexed > 0 {
-		m.lo.Info("reconciled knowledge base embeddings", "reindexed", reindexed)
+	if reindexed > 0 || dropped > 0 {
+		m.lo.Info("reconciled knowledge base embeddings", "reindexed", reindexed, "dropped", dropped, "total", len(items))
 	}
 }
 

--- a/internal/ai/knowledgebase.go
+++ b/internal/ai/knowledgebase.go
@@ -153,7 +153,7 @@ func (m *Manager) reindexSnippetWith(ctx context.Context, item models.KnowledgeB
 	if !m.canCommitSnippet(item.ID, gen) {
 		return
 	}
-	if err := m.commitEmbeddings(models.SourceSnippet, item.ID, indexed); err != nil {
+	if err := m.commitEmbeddings(models.SourceSnippet, []int{item.ID}, indexed); err != nil {
 		m.lo.Error("error indexing snippet", "error", err, "id", item.ID)
 		return
 	}

--- a/internal/ai/models/models.go
+++ b/internal/ai/models/models.go
@@ -23,6 +23,7 @@ const (
 
 	// Source types for embeddings.
 	SourceSnippet = "snippet"
+	SourceTag     = "tag"
 
 	// ai_knowledge_base.source values.
 	KnowledgeSourceManual       = "manual"
@@ -122,6 +123,12 @@ type Embedding struct {
 	ChunkText  string `db:"chunk_text"`
 	Embedding  []byte `db:"embedding"`
 	Dimensions int    `db:"dimensions"`
+}
+
+// TagRef is a tag id and name.
+type TagRef struct {
+	ID   int    `db:"id"`
+	Name string `db:"name"`
 }
 
 // SearchResult is one hit from the in-memory embedding search.

--- a/internal/ai/queries.sql
+++ b/internal/ai/queries.sql
@@ -37,6 +37,15 @@ INSERT INTO embeddings (source_type, source_id, chunk_text, embedding, dimension
 -- name: delete-embeddings-by-source
 DELETE FROM embeddings WHERE source_type = $1 AND source_id = $2;
 
+-- name: delete-embeddings-by-source-ids
+DELETE FROM embeddings WHERE source_type = $1 AND source_id = ANY($2);
+
+-- name: delete-embeddings-by-source-type
+DELETE FROM embeddings WHERE source_type = $1;
+
+-- name: get-tags
+SELECT id, name FROM tags ORDER BY id;
+
 -- name: get-all-embeddings
 SELECT id, source_type, source_id, chunk_text, embedding, dimensions FROM embeddings;
 

--- a/internal/ai/tagindex.go
+++ b/internal/ai/tagindex.go
@@ -1,0 +1,131 @@
+package ai
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/abhinavxd/libredesk/internal/ai/models"
+)
+
+// reconcileTags embeds tags missing from the index, re-embeds renamed ones and drops the vectors of deleted tags.
+func (m *Manager) reconcileTags(ctx context.Context) {
+	tags, err := m.getTags()
+	if err != nil {
+		return
+	}
+
+	// Before the boot load finishes every tag reads as unindexed, which would re-embed the whole list.
+	select {
+	case <-m.indexReady:
+	case <-ctx.Done():
+		return
+	}
+
+	gen := m.tagGen.Load()
+	stale, removed := diffTagIndex(tags, m.index.chunksBySourceID(models.SourceTag))
+	if len(stale) == 0 && len(removed) == 0 {
+		return
+	}
+
+	touched := slices.Clone(removed)
+	chunks := make([]indexedChunk, 0, len(stale))
+	if len(stale) > 0 {
+		names := tagNames(stale)
+		vecs, err := m.GetEmbeddingsBatch(ctx, names)
+		if err != nil {
+			m.lo.Error("error embedding tags", "error", err, "count", len(names))
+			return
+		}
+		for i, t := range stale {
+			touched = append(touched, t.ID)
+			chunks = append(chunks, indexedChunk{
+				sourceType: models.SourceTag,
+				sourceID:   t.ID,
+				chunkText:  t.Name,
+				vec:        vecs[i],
+				norm:       norm(vecs[i]),
+			})
+		}
+	}
+
+	m.reindexMu.Lock()
+	defer m.reindexMu.Unlock()
+	if m.tagGen.Load() != gen {
+		return
+	}
+	if err := m.commitEmbeddings(models.SourceTag, touched, chunks); err != nil {
+		return
+	}
+	m.lo.Info("reconciled tag embeddings", "embedded", len(chunks), "removed", len(removed), "total", len(tags))
+}
+
+// purgeTagEmbeddings drops every tag vector so the next reconcile re-embeds the list with the current provider.
+func (m *Manager) purgeTagEmbeddings() {
+	m.reindexMu.Lock()
+	defer m.reindexMu.Unlock()
+	m.tagGen.Add(1)
+	if _, err := m.q.DeleteEmbeddingsBySourceType.Exec(models.SourceTag); err != nil {
+		m.lo.Error("error deleting tag embeddings", "error", err)
+		return
+	}
+	m.index.removeSourceType(models.SourceTag)
+}
+
+// tagCandidates returns the current names of the tags most similar to text, most similar first; a name only the index still knows is dropped.
+func (m *Manager) tagCandidates(ctx context.Context, text string, k int, tags []models.TagRef) ([]string, error) {
+	results, err := m.searchSource(ctx, text, k, models.SourceTag)
+	if err != nil {
+		return nil, err
+	}
+	byID := make(map[int]string, len(tags))
+	for _, t := range tags {
+		byID[t.ID] = t.Name
+	}
+	names := make([]string, 0, len(results))
+	for _, r := range results {
+		if name, ok := byID[r.SourceID]; ok {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+func (m *Manager) getTags() ([]models.TagRef, error) {
+	tags := make([]models.TagRef, 0)
+	if err := m.q.GetTags.Select(&tags); err != nil {
+		m.lo.Error("error fetching tags", "error", err)
+		return nil, err
+	}
+	return tags, nil
+}
+
+func tagNames(tags []models.TagRef) []string {
+	names := make([]string, 0, len(tags))
+	for _, t := range tags {
+		names = append(names, t.Name)
+	}
+	return names
+}
+
+// diffTagIndex reports which tags need embedding and which indexed source ids no longer belong; a blank name is dropped, not embedded.
+func diffTagIndex(tags []models.TagRef, indexed map[int]indexedChunk) (stale []models.TagRef, removed []int) {
+	live := make(map[int]bool, len(tags))
+	for _, t := range tags {
+		if strings.TrimSpace(t.Name) == "" {
+			continue
+		}
+		live[t.ID] = true
+		if c, ok := indexed[t.ID]; ok && c.chunkText == t.Name {
+			continue
+		}
+		stale = append(stale, t)
+	}
+	for id := range indexed {
+		if !live[id] {
+			removed = append(removed, id)
+		}
+	}
+	slices.Sort(removed)
+	return stale, removed
+}

--- a/internal/ai/tagindex.go
+++ b/internal/ai/tagindex.go
@@ -65,11 +65,11 @@ func (m *Manager) purgeTagEmbeddings() {
 	m.reindexMu.Lock()
 	defer m.reindexMu.Unlock()
 	m.tagGen.Add(1)
+	// Clearing the index even on a failed delete keeps this self-healing: the next reconcile re-embeds every tag and overwrites the rows left behind.
+	m.index.removeSourceType(models.SourceTag)
 	if _, err := m.q.DeleteEmbeddingsBySourceType.Exec(models.SourceTag); err != nil {
 		m.lo.Error("error deleting tag embeddings", "error", err)
-		return
 	}
-	m.index.removeSourceType(models.SourceTag)
 }
 
 // tagCandidates returns the current names of the tags most similar to text, most similar first; a name only the index still knows is dropped.

--- a/internal/ai/tagindex_test.go
+++ b/internal/ai/tagindex_test.go
@@ -1,0 +1,70 @@
+package ai
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/abhinavxd/libredesk/internal/ai/models"
+)
+
+func TestDiffTagIndex(t *testing.T) {
+	indexed := map[int]indexedChunk{
+		1: {sourceType: models.SourceTag, sourceID: 1, chunkText: "billing", vec: []float32{1, 0}},
+		2: {sourceType: models.SourceTag, sourceID: 2, chunkText: "old-name", vec: []float32{0, 1}},
+		3: {sourceType: models.SourceTag, sourceID: 3, chunkText: "deleted", vec: []float32{1, 1}},
+		4: {sourceType: models.SourceTag, sourceID: 4, chunkText: "blanked", vec: []float32{1, 1}},
+	}
+	tags := []models.TagRef{
+		{ID: 1, Name: "billing"},
+		{ID: 2, Name: "new-name"},
+		{ID: 4, Name: "  "},
+		{ID: 6, Name: "kyc"},
+	}
+
+	stale, removed := diffTagIndex(tags, indexed)
+
+	wantStale := []models.TagRef{{ID: 2, Name: "new-name"}, {ID: 6, Name: "kyc"}}
+	if !reflect.DeepEqual(stale, wantStale) {
+		t.Errorf("stale = %v, want %v", stale, wantStale)
+	}
+	if want := []int{3, 4}; !reflect.DeepEqual(removed, want) {
+		t.Errorf("removed = %v, want %v", removed, want)
+	}
+}
+
+func TestIndexSearchFiltersBySourceType(t *testing.T) {
+	ix := newEmbeddingIndex()
+	ix.replaceAll([]indexedChunk{
+		{sourceType: models.SourceSnippet, sourceID: 1, chunkText: "snippet", vec: []float32{1, 0}, norm: 1},
+		{sourceType: models.SourceTag, sourceID: 2, chunkText: "tag", vec: []float32{1, 0}, norm: 1},
+	})
+
+	results, _ := ix.search([]float32{1, 0}, 10, models.SourceTag)
+	if len(results) != 1 || results[0].ChunkText != "tag" {
+		t.Fatalf("results = %v, want only the tag chunk", results)
+	}
+}
+
+func TestIndexReplaceSourceIDs(t *testing.T) {
+	ix := newEmbeddingIndex()
+	ix.replaceAll([]indexedChunk{
+		{sourceType: models.SourceSnippet, sourceID: 1, chunkText: "snippet"},
+		{sourceType: models.SourceTag, sourceID: 1, chunkText: "keep"},
+		{sourceType: models.SourceTag, sourceID: 2, chunkText: "drop"},
+		{sourceType: models.SourceTag, sourceID: 3, chunkText: "rename"},
+	})
+
+	ix.replaceSourceIDs(models.SourceTag, []int{2, 3}, []indexedChunk{
+		{sourceType: models.SourceTag, sourceID: 3, chunkText: "renamed"},
+	})
+
+	got := map[string]string{}
+	for _, c := range ix.chunks {
+		got[fmt.Sprintf("%s:%d", c.sourceType, c.sourceID)] = c.chunkText
+	}
+	want := map[string]string{"snippet:1": "snippet", "tag:1": "keep", "tag:3": "renamed"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("chunks = %v, want %v", got, want)
+	}
+}

--- a/internal/tag/queries.sql
+++ b/internal/tag/queries.sql
@@ -5,7 +5,9 @@ select
     updated_at,
     name
 from
-    tags;
+    tags
+order by
+    name;
 
 -- name: insert-tag
 INSERT into


### PR DESCRIPTION
Tag suggestion used to send the first 300 tags to the model, so anything past that was invisible. Tags are now embedded into the same index as the knowledge base, and only the tags most similar to the conversation get sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI tag suggestions now derive candidates from conversation content using a token-bound shortlist and only return up to the configured maximum.
  * Tag embeddings are now managed with batch/index replacement and source-aware search for more accurate matching.

* **Bug Fixes**
  * Embeddings are purged and rebuilt when embedding provider settings change, including tag embeddings.
  * Tag list results are consistently ordered alphabetically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->