### PR TITLE
Fix live chat image thumbnails for S3 store.

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -688,9 +688,6 @@ func sendChatMessageResponse(app *App, r *fastglue.Request, messageUUID string) 
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, app.i18n.T("globals.messages.somethingWentWrong"), nil, envelope.GeneralError)
 	}
 
-	for i := range message.Attachments {
-		message.Attachments[i].URL = app.media.GetSignedURL(message.Attachments[i].UUID)
-	}
 	app.conversation.SignAvatarURL(&message.Author.AvatarURL)
 
 	// Strip agent email from widget responses.

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -66,11 +66,7 @@ func handleGetMessages(r *fastglue.Request) error {
 	rootURL, _ := app.setting.GetAppRootURL()
 	for i := range messages {
 		total = messages[i].Total
-		// Populate attachment URLs
-		for j := range messages[i].Attachments {
-			att := messages[i].Attachments[j]
-			messages[i].Attachments[j].URL = app.media.GetURL(att.UUID, att.ContentType, att.Name)
-		}
+		app.conversation.SignAttachmentURLs(messages[i].Attachments)
 		resolveQuotedCIDs(app, &messages[i])
 		resolveAttachmentCIDs(&messages[i], rootURL)
 	}
@@ -135,10 +131,7 @@ func handleGetMessage(r *fastglue.Request) error {
 	}
 
 	rootURL, _ := app.setting.GetAppRootURL()
-	for j := range message.Attachments {
-		att := message.Attachments[j]
-		message.Attachments[j].URL = app.media.GetURL(att.UUID, att.ContentType, att.Name)
-	}
+	app.conversation.SignAttachmentURLs(message.Attachments)
 	resolveQuotedCIDs(app, &message)
 	resolveAttachmentCIDs(&message, rootURL)
 

--- a/frontend/apps/main/src/features/conversation/message/attachment/BubbleAttachmentItem.vue
+++ b/frontend/apps/main/src/features/conversation/message/attachment/BubbleAttachmentItem.vue
@@ -13,9 +13,10 @@
         >
           <template v-if="isImage">
             <img
-              :src="getThumbFilepath(attachment.url)"
+              :src="attachment.thumbnail_url || getThumbFilepath(attachment.url)"
               :alt="attachment.name"
               class="w-full h-full object-cover"
+              @error="fallbackToOriginal($event, attachment.url)"
             />
             <div
               class="absolute inset-x-0 top-0 flex items-start justify-between gap-2 px-2 pt-1.5 pb-5 bg-gradient-to-b from-black/75 via-black/40 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
@@ -83,6 +84,12 @@ const emit = defineEmits(['preview'])
 const showAudio = ref(false)
 
 const shortName = (name) => (name || '').substring(0, 40)
+
+const fallbackToOriginal = (event, originalUrl) => {
+  if (event.target.dataset.originalFallback) return
+  event.target.dataset.originalFallback = 'true'
+  event.target.src = originalUrl
+}
 
 const isImage = computed(() => (props.attachment.content_type || '').startsWith('image/'))
 

--- a/frontend/apps/widget/src/components/MessageAttachment.vue
+++ b/frontend/apps/widget/src/components/MessageAttachment.vue
@@ -11,6 +11,7 @@
           :src="getThumbnailUrl(attachment)"
           :alt="attachment.name"
           class="max-w-48 max-h-32 rounded-lg object-cover"
+          @error="fallbackToOriginal($event, attachment.url)"
           @click="openImage(attachment.url)"
         />
       </div>
@@ -49,7 +50,13 @@ const isImage = (attachment) => {
 
 const getThumbnailUrl = (attachment) => {
   if (!isImage(attachment)) return attachment.url
-  return getThumbFilepath(attachment.url)
+  return attachment.thumbnail_url || getThumbFilepath(attachment.url)
+}
+
+const fallbackToOriginal = (event, originalUrl) => {
+  if (event.target.dataset.originalFallback) return
+  event.target.dataset.originalFallback = 'true'
+  event.target.src = originalUrl
 }
 
 const openImage = (url) => {

--- a/internal/attachment/attachment.go
+++ b/internal/attachment/attachment.go
@@ -13,15 +13,16 @@ const (
 
 // Attachment represents a file or blob attachment that can be sent or received on a message.
 type Attachment struct {
-	Name        string               `json:"name"`
-	Size        int                  `json:"size"`
-	Content     []byte               `json:"content"`
-	ContentID   string               `json:"content_id"`
-	ContentType string               `json:"content_type"`
-	Disposition string               `json:"disposition"`
-	UUID        string               `json:"uuid"`
-	URL         string               `json:"url"`
-	Header      textproto.MIMEHeader `json:"-"`
+	Name         string               `json:"name"`
+	Size         int                  `json:"size"`
+	Content      []byte               `json:"content"`
+	ContentID    string               `json:"content_id"`
+	ContentType  string               `json:"content_type"`
+	Disposition  string               `json:"disposition"`
+	UUID         string               `json:"uuid"`
+	URL          string               `json:"url"`
+	ThumbnailURL string               `json:"thumbnail_url"`
+	Header       textproto.MIMEHeader `json:"-"`
 }
 
 type Attachments []Attachment

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -1830,7 +1830,7 @@ func (m *Manager) BuildWidgetConversationResponse(conversation models.Conversati
 		for _, msg := range messages {
 			m.SignAvatarURL(&msg.Author.AvatarURL)
 			attachments := msg.Attachments
-			m.signAttachmentURLs(attachments)
+			m.SignAttachmentURLs(attachments)
 
 			// Strip agent email from widget responses.
 			author := msg.Author

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -168,6 +168,7 @@ type mediaStore interface {
 	GetBlob(name string) ([]byte, error)
 	GetURL(uuid, contentType, fileName string) string
 	GetSignedURL(name string) string
+	GetThumbnailURL(uuid string) string
 	Attach(id int, model string, modelID int) error
 	SetContentID(id int, contentID string) error
 	GetByModel(id int, model string) ([]mmodels.Media, error)
@@ -1829,9 +1830,7 @@ func (m *Manager) BuildWidgetConversationResponse(conversation models.Conversati
 		for _, msg := range messages {
 			m.SignAvatarURL(&msg.Author.AvatarURL)
 			attachments := msg.Attachments
-			for j := range attachments {
-				attachments[j].URL = m.mediaStore.GetSignedURL(attachments[j].UUID)
-			}
+			m.signAttachmentURLs(attachments)
 
 			// Strip agent email from widget responses.
 			author := msg.Author

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -392,11 +392,19 @@ func (m *Manager) GetMessage(uuid string) (models.Message, error) {
 	}
 
 	// Generate signed URLs for attachments.
-	for i := range message.Attachments {
-		message.Attachments[i].URL = m.mediaStore.GetSignedURL(message.Attachments[i].UUID)
-	}
+	m.signAttachmentURLs(message.Attachments)
 
 	return message, nil
+}
+
+// signAttachmentURLs adds access URLs for the original image and its thumbnail.
+func (m *Manager) signAttachmentURLs(attachments attachment.Attachments) {
+	for i := range attachments {
+		attachments[i].URL = m.mediaStore.GetSignedURL(attachments[i].UUID)
+		if strings.HasPrefix(attachments[i].ContentType, "image/") {
+			attachments[i].ThumbnailURL = m.mediaStore.GetThumbnailURL(attachments[i].UUID)
+		}
+	}
 }
 
 // UpdateMessageStatus updates the status of a message.
@@ -1449,6 +1457,7 @@ func (m *Manager) broadcastMessageToWidgetClients(message *models.Message) {
 		return
 	}
 
+	m.signAttachmentURLs(message.Attachments)
 	m.SignAvatarURL(&message.Author.AvatarURL)
 	liveChatInbox.BroadcastMessageToClients(message.ConversationUUID, conversation.ContactID, models.ChatMessage{
 		UUID:             message.UUID,

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -400,7 +400,7 @@ func (m *Manager) GetMessage(uuid string) (models.Message, error) {
 // signAttachmentURLs adds access URLs for the original image and its thumbnail.
 func (m *Manager) signAttachmentURLs(attachments attachment.Attachments) {
 	for i := range attachments {
-		attachments[i].URL = m.mediaStore.GetSignedURL(attachments[i].UUID)
+		attachments[i].URL = m.mediaStore.GetURL(attachments[i].UUID, attachments[i].ContentType, attachments[i].Name)
 		if strings.HasPrefix(attachments[i].ContentType, "image/") {
 			attachments[i].ThumbnailURL = m.mediaStore.GetThumbnailURL(attachments[i].UUID)
 		}

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -1322,7 +1322,10 @@ func (m *Manager) fetchMessageAttachments(messageID int) (attachment.Attachments
 			Content:     blob,
 			Size:        media.Size,
 			Header:      attachment.MakeHeader(media.ContentType, contentID, media.Filename, "base64", media.Disposition.String),
-			URL:         m.mediaStore.GetSignedURL(media.UUID),
+			URL:         m.mediaStore.GetURL(media.UUID, media.ContentType, media.Filename),
+		}
+		if strings.HasPrefix(media.ContentType, "image/") {
+			attachment.ThumbnailURL = m.mediaStore.GetThumbnailURL(media.UUID)
 		}
 		attachments = append(attachments, attachment)
 	}

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -392,13 +392,13 @@ func (m *Manager) GetMessage(uuid string) (models.Message, error) {
 	}
 
 	// Generate signed URLs for attachments.
-	m.signAttachmentURLs(message.Attachments)
+	m.SignAttachmentURLs(message.Attachments)
 
 	return message, nil
 }
 
-// signAttachmentURLs adds access URLs for the original image and its thumbnail.
-func (m *Manager) signAttachmentURLs(attachments attachment.Attachments) {
+// SignAttachmentURLs adds access URLs for the original image and its thumbnail.
+func (m *Manager) SignAttachmentURLs(attachments attachment.Attachments) {
 	for i := range attachments {
 		attachments[i].URL = m.mediaStore.GetURL(attachments[i].UUID, attachments[i].ContentType, attachments[i].Name)
 		if strings.HasPrefix(attachments[i].ContentType, "image/") {
@@ -1460,7 +1460,7 @@ func (m *Manager) broadcastMessageToWidgetClients(message *models.Message) {
 		return
 	}
 
-	m.signAttachmentURLs(message.Attachments)
+	m.SignAttachmentURLs(message.Attachments)
 	m.SignAvatarURL(&message.Author.AvatarURL)
 	liveChatInbox.BroadcastMessageToClients(message.ConversationUUID, conversation.ContactID, models.ChatMessage{
 		UUID:             message.UUID,

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -245,7 +245,7 @@ func (m *Manager) GetSignedURL(name string) string {
 // GetThumbnailURL returns the URL for an image thumbnail.
 // FS signs the original UUID; S3 signs the thumbnail object.
 func (m *Manager) GetThumbnailURL(uuid string) string {
-	if _, ok := m.store.(SignedURLStore); ok {
+	if m.store.Name() == "fs" {
 		// FS validates thumbnail requests with the original UUID signature.
 		u, err := url.Parse(m.GetSignedURL(uuid))
 		if err == nil {

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -243,7 +243,6 @@ func (m *Manager) GetSignedURL(name string) string {
 }
 
 // GetThumbnailURL returns the URL for an image thumbnail.
-// FS signs the original UUID; S3 signs the thumbnail object.
 func (m *Manager) GetThumbnailURL(uuid string) string {
 	if m.store.Name() == "fs" {
 		// FS validates thumbnail requests with the original UUID signature.

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -257,7 +257,7 @@ func (m *Manager) GetThumbnailURL(uuid string) string {
 			return u.String()
 		}
 	}
-	return m.GetSignedURL(image.ThumbPrefix + uuid)
+	return m.store.GetURL(image.ThumbPrefix+uuid, "inline", "")
 }
 
 // SignedURLValidator returns the store's signature validator if available.

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -239,6 +240,24 @@ func (m *Manager) GetSignedURL(name string) string {
 	}
 	// Fallback to regular URL if signed URLs not supported
 	return m.GetURL(name, "", "")
+}
+
+// GetThumbnailURL returns the URL for an image thumbnail.
+// FS signs the original UUID; S3 signs the thumbnail object.
+func (m *Manager) GetThumbnailURL(uuid string) string {
+	if _, ok := m.store.(SignedURLStore); ok {
+		// FS validates thumbnail requests with the original UUID signature.
+		u, err := url.Parse(m.GetSignedURL(uuid))
+		if err == nil {
+			if idx := strings.LastIndex(u.Path, "/"); idx >= 0 {
+				u.Path = u.Path[:idx+1] + image.ThumbPrefix + uuid
+			} else {
+				u.Path = image.ThumbPrefix + uuid
+			}
+			return u.String()
+		}
+	}
+	return m.GetSignedURL(image.ThumbPrefix + uuid)
 }
 
 // SignedURLValidator returns the store's signature validator if available.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image attachment previews now prefer per-attachment thumbnail URLs when available.
* **Bug Fixes**
  * If a thumbnail fails to load, the preview falls back to the original image.
  * Stops repeated fallback attempts after an image load error.
* **Refactor**
  * Centralized attachment URL/thumbnail signing and ensured both conversation responses and widget rendering use the same thumbnail/URL logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->