### PR TITLE
link message media in one query inside the insert transaction

### DIFF
--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -169,8 +169,7 @@ type mediaStore interface {
 	GetURL(uuid, contentType, fileName string) string
 	GetSignedURL(name string) string
 	GetThumbnailURL(uuid string) string
-	Attach(id int, model string, modelID int) error
-	SetContentID(id int, contentID string) error
+	LinkMessageMediaTx(tx *sqlx.Tx, messageID int, media []mmodels.Media, inlineUUIDs []string) error
 	GetByModel(id int, model string) ([]mmodels.Media, error)
 	GetByContentIDs(contentIDs []string, conversationUUID string) ([]mmodels.Media, error)
 	ContentIDExists(contentID, conversationUUID string) (bool, string, error)

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -584,7 +584,6 @@ func (m *Manager) InsertMessage(message *models.Message) error {
 		message.ContentType = models.ContentTypeText
 	}
 
-	// Extract inline media UUIDs for linking after message insertion.
 	inlineUUIDs := extractInlineImageUUIDs(message.Content)
 
 	// Rewrite inline image URLs to cid:ldsk-<uuid>. The read API resolves them back to signed URLs.
@@ -597,20 +596,27 @@ func (m *Manager) InsertMessage(message *models.Message) error {
 		message.TextContent = stringutil.HTML2Text(message.Content)
 	}
 
-	// Insert Message.
-	if err := m.q.InsertMessage.Get(message, message.Type, message.Status, message.ConversationID, message.ConversationUUID, message.Content, message.TextContent, message.SenderID, message.SenderType,
+	tx, err := m.db.Beginx()
+	if err != nil {
+		m.lo.Error("error beginning message insert transaction", "error", err)
+		return envelope.NewError(envelope.GeneralError, m.i18n.T("globals.messages.somethingWentWrong"), nil)
+	}
+	defer tx.Rollback()
+
+	if err := tx.Stmtx(m.q.InsertMessage).Get(message, message.Type, message.Status, message.ConversationID, message.ConversationUUID, message.Content, message.TextContent, message.SenderID, message.SenderType,
 		message.Private, message.ContentType, message.SourceID, message.Meta); err != nil {
 		m.lo.Error("error inserting message in db", "error", err)
 		return envelope.NewError(envelope.GeneralError, m.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
 
-	// Attach just inserted message to the media.
-	for _, media := range message.Media {
-		m.mediaStore.Attach(media.ID, mmodels.ModelMessages, message.ID)
+	if err := m.mediaStore.LinkMessageMediaTx(tx, message.ID, message.Media, inlineUUIDs); err != nil {
+		return envelope.NewError(envelope.GeneralError, m.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
 
-	// Link inline media and stamp content_id so the cid: form just persisted resolves on read.
-	m.linkInlineMediaToMessage(inlineUUIDs, message.ID)
+	if err := tx.Commit(); err != nil {
+		m.lo.Error("error committing message insert transaction", "error", err)
+		return envelope.NewError(envelope.GeneralError, m.i18n.T("globals.messages.somethingWentWrong"), nil)
+	}
 
 	// Add this user as a participant if not already present.
 	m.addConversationParticipant(message.SenderID, message.ConversationUUID)
@@ -1107,39 +1113,6 @@ func rewriteInlineImagesToCID(content string) string {
 	})
 }
 
-// linkInlineMediaToMessage attaches each inline-image media row to this
-// message (so it isn't garbage-collected as an orphan) and stamps a stable
-// content_id so cid:ldsk-<uuid> in the saved body resolves on read.
-func (m *Manager) linkInlineMediaToMessage(uuids []string, messageID int) {
-	for _, uuid := range uuids {
-		media, err := m.mediaStore.Get(0, uuid)
-		if err != nil {
-			continue
-		}
-		if media.Model.Valid && media.Model.String != mmodels.ModelMessages {
-			continue
-		}
-		// Linked to a different message already, leave it.
-		if media.ModelID.Valid && media.ModelID.Int != messageID {
-			continue
-		}
-
-		// Attach.
-		if !media.ModelID.Valid {
-			if err := m.mediaStore.Attach(media.ID, mmodels.ModelMessages, messageID); err != nil {
-				m.lo.Warn("error linking inline media to message", "uuid", uuid, "message_id", messageID, "error", err)
-			}
-		}
-
-		// Set content_id if not already set.
-		if media.ContentID == "" {
-			if err := m.mediaStore.SetContentID(media.ID, inlineContentID(uuid)); err != nil {
-				m.lo.Warn("error setting media content_id", "uuid", uuid, "message_id", messageID, "error", err)
-			}
-		}
-	}
-}
-
 // uploadMessageAttachments uploads all attachments for a message.
 func (m *Manager) uploadMessageAttachments(message *models.Message) error {
 	if len(message.Attachments) == 0 {
@@ -1490,8 +1463,9 @@ func (m *Manager) getMediaPreview(media mmodels.Media) string {
 	}
 }
 
+// inlineContentID lowercases the uuid to match the content_id the DB stamps from uuid::TEXT.
 func inlineContentID(uuid string) string {
-	return "ldsk-" + uuid
+	return "ldsk-" + strings.ToLower(uuid)
 }
 
 // findExistingMedia resolves an inbound cid to its stored form: ldsk-* is left as-is, others are namespaced by conversation to avoid cross-conversation collisions.

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -86,12 +86,11 @@ type queries struct {
 	Get                     *sqlx.Stmt `query:"get-media"`
 	GetByUUID               *sqlx.Stmt `query:"get-media-by-uuid"`
 	Delete                  *sqlx.Stmt `query:"delete-media"`
-	Attach                  *sqlx.Stmt `query:"attach-to-model"`
+	LinkMessageMedia        *sqlx.Stmt `query:"link-message-media"`
 	GetByModel              *sqlx.Stmt `query:"get-model-media"`
 	GetUnlinkedMessageMedia *sqlx.Stmt `query:"get-unlinked-message-media"`
 	ContentIDExists         *sqlx.Stmt `query:"content-id-exists"`
 	GetByContentIDs         *sqlx.Stmt `query:"get-media-by-content-ids"`
-	SetContentID            *sqlx.Stmt `query:"set-media-content-id"`
 }
 
 // UploadAndInsert uploads file on storage and inserts an entry in db.
@@ -170,15 +169,6 @@ func (m *Manager) Get(id int, uuid string) (models.Media, error) {
 	}
 	media.URL = m.GetURL(media.UUID, media.ContentType, media.Filename)
 	return media, nil
-}
-
-// SetContentID stamps a content_id onto a media row if one isn't already set.
-func (m *Manager) SetContentID(id int, contentID string) error {
-	if _, err := m.queries.SetContentID.Exec(id, contentID); err != nil {
-		m.lo.Error("error setting media content_id", "id", id, "content_id", contentID, "error", err)
-		return fmt.Errorf("setting media content_id: %w", err)
-	}
-	return nil
 }
 
 // ContentIDExists reports whether a media row with the given content_id is linked to a message in the given conversation. Scoped this way so an orphan media row (e.g., from a partial failure) doesn't short-circuit a retry into skipping the upload.
@@ -265,11 +255,18 @@ func (m *Manager) SignedURLValidator() func(name, sig string, exp int64) bool {
 	return m.store.SignedURLValidator()
 }
 
-// Attach associates a media file with a specific model by its ID and model name.
-func (m *Manager) Attach(id int, model string, modelID int) error {
-	if _, err := m.queries.Attach.Exec(id, model, modelID); err != nil {
-		m.lo.Error("error attaching media to model", "model", model, "model_id", modelID, "media_id", id, "error", err)
-		return fmt.Errorf("attaching media;%d to model:%s model_id:%d: %w", id, model, modelID, err)
+// LinkMessageMediaTx links a message's attachments and inline images to it within the given transaction, stamping a content_id on the inline ones.
+func (m *Manager) LinkMessageMediaTx(tx *sqlx.Tx, messageID int, media []models.Media, inlineUUIDs []string) error {
+	if len(media) == 0 && len(inlineUUIDs) == 0 {
+		return nil
+	}
+	ids := make([]int, 0, len(media))
+	for _, med := range media {
+		ids = append(ids, med.ID)
+	}
+	if _, err := tx.Stmtx(m.queries.LinkMessageMedia).Exec(messageID, pq.Array(ids), pq.Array(inlineUUIDs)); err != nil {
+		m.lo.Error("error linking media to message", "message_id", messageID, "error", err)
+		return fmt.Errorf("linking media to message:%d: %w", messageID, err)
 	}
 	return nil
 }

--- a/internal/media/queries.sql
+++ b/internal/media/queries.sql
@@ -31,11 +31,17 @@ WHERE uuid = $1;
 DELETE FROM media
 WHERE uuid = $1;
 
--- name: attach-to-model
+-- name: link-message-media
 UPDATE media
-SET model_type = $2,
-    model_id = $3
-WHERE id = $1;
+SET model_type = 'messages',
+    model_id = $1,
+    content_id = CASE
+        WHEN uuid = ANY($3::uuid[]) THEN COALESCE(NULLIF(content_id, ''), 'ldsk-' || uuid::TEXT)
+        ELSE content_id
+    END
+WHERE (id = ANY($2::INT[]) OR uuid = ANY($3::uuid[]))
+  AND COALESCE(model_type, 'messages') = 'messages'
+  AND COALESCE(model_id, 0) = 0;
 
 -- name: get-model-media
 SELECT id, created_at, updated_at, "uuid", store, filename, content_type, content_id, model_id, model_type, disposition, "size", meta
@@ -65,9 +71,3 @@ INNER JOIN conversation_messages cm ON cm.id = m.model_id
 WHERE m.model_type = 'messages'
   AND m.content_id = ANY($1)
   AND cm.conversation_id = (SELECT id FROM conversations WHERE uuid = $2::uuid LIMIT 1);
-
--- name: set-media-content-id
-UPDATE media
-SET content_id = $2
-WHERE id = $1
-  AND (content_id IS NULL OR content_id = '');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when attaching uploaded media and inline images to messages.
  * Ensured message creation and media linking complete together, preventing partial updates.
  * Improved inline image reference handling, including consistent content identifiers.
  * Prevented already-linked media from being reassigned unintentionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->