### PR TITLE
fix(log): don't drop the error detail in unsnoozeAll log call

### DIFF
--- a/internal/conversation/unsnoozer.go
+++ b/internal/conversation/unsnoozer.go
@@ -24,7 +24,7 @@ func (c *Manager) RunUnsnoozer(ctx context.Context, unsnoozeInterval time.Durati
 func (c *Manager) unsnoozeAll(ctx context.Context) {
 	res, err := c.q.UnsnoozeAll.ExecContext(ctx)
 	if err != nil {
-		c.lo.Error("error unsnoozing all conversations", err)
+		c.lo.Error("error unsnoozing all conversations", "error", err)
 		return
 	}
 	rows, _ := res.RowsAffected()


### PR DESCRIPTION
Small correctness fix in the unsnoozer.

`unsnoozeAll` logged its error with the error passed as a positional argument and no key:

```go
c.lo.Error("error unsnoozing all conversations", err)
```

logf treats variadic fields as key/value pairs and drops the last one when the count is odd (`handleLog`: *"If there are odd number of fields, ignore the last"*). With a single `err` field that's an odd count, so the error was silently discarded — when the unsnooze query fails the log line ended up with no diagnostic detail at all, which makes that background worker hard to debug.

Passed it as an `"error"` key/value, matching the convention used everywhere else in the codebase.

`go build` and `go vet` on the package are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error log formatting when restoring snoozed conversations, making troubleshooting details clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->