### PR TITLE
increase default http write timeout to 60s

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -25,7 +25,7 @@ disable_secure_cookies = false
 session_lifetime = "9h"
 # Request read and write timeouts.
 read_timeout = "8s"
-write_timeout = "8s"
+write_timeout = "60s"
 # Maximum request body size in bytes (100MB)
 # If you are using proxy, you may need to configure them to allow larger request bodies.
 max_body_size = 104857600


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the sample HTTP server’s write timeout to 60 seconds, improving support for longer-running responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->