### PR TITLE
Add CLI helper for decrypting crypto payloads

### DIFF
--- a/scripts/decrypt-payload/main.go
+++ b/scripts/decrypt-payload/main.go
@@ -1,0 +1,32 @@
+// Run with:
+//
+//	ENCRYPTION_KEY='32-character-key' go run ./scripts/decrypt-payload 'enc:...'
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/abhinavxd/libredesk/internal/crypto"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintln(os.Stderr, "usage: ENCRYPTION_KEY=<32-byte-key> go run ./scripts/decrypt-payload <encrypted-payload>")
+		os.Exit(2)
+	}
+
+	key, ok := os.LookupEnv("ENCRYPTION_KEY")
+	if !ok {
+		fmt.Fprintln(os.Stderr, "ENCRYPTION_KEY is required")
+		os.Exit(2)
+	}
+
+	plaintext, err := crypto.Decrypt(os.Args[1], key)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fmt.Print(plaintext)
+}

--- a/scripts/decrypt-payload/main.go
+++ b/scripts/decrypt-payload/main.go
@@ -21,6 +21,10 @@ func main() {
 		fmt.Fprintln(os.Stderr, "ENCRYPTION_KEY is required")
 		os.Exit(2)
 	}
+	if len(key) != 32 {
+		fmt.Fprintln(os.Stderr, "ENCRYPTION_KEY must be exactly 32 bytes")
+		os.Exit(2)
+	}
 
 	plaintext, err := crypto.Decrypt(os.Args[1], key)
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line utility for decrypting a single encrypted payload.
  * Supports configuration through the `ENCRYPTION_KEY` environment variable, requiring a 32-byte key.
  * Provides clear usage guidance and error reporting for invalid input, missing configuration, or decryption failures.
  * Returns distinct exit codes to help identify validation and decryption errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->