### PR TITLE
fix: reveal hover-gated controls on touch devices

### DIFF
--- a/frontend/apps/main/src/features/conversation/list/ConversationListItem.vue
+++ b/frontend/apps/main/src/features/conversation/list/ConversationListItem.vue
@@ -28,16 +28,22 @@
                 </AvatarFallback>
               </Avatar>
             </div>
+            <!-- Selection gates every bulk action, and a hover-only target is
+                 unreachable on touch. On touch the overlay is always live, so
+                 tapping the avatar selects; the checkbox itself only becomes
+                 visible once selection is under way, leaving the avatar
+                 readable until then. -->
             <div
               v-if="canBulkAct"
-              class="absolute inset-0 items-center justify-center"
-              :class="showCheckbox ? 'flex' : 'hidden group-hover:flex'"
+              class="absolute inset-0 items-center justify-center flex"
+              :class="showCheckbox ? '' : '[@media(hover:hover)]:hidden [@media(hover:hover)]:group-hover:flex'"
               @click.prevent.stop="handleCheckboxClick"
             >
               <Checkbox
                 :checked="isItemSelected"
                 :aria-label="t('conversation.bulkActions.selectConversation')"
                 class="w-5 h-5"
+                :class="showCheckbox ? '' : 'opacity-0 [@media(hover:hover)]:opacity-100'"
               />
             </div>
           </div>
@@ -279,7 +285,8 @@ const showCheckbox = computed(() => {
 
 const avatarOpacityClass = computed(() => {
   if (showCheckbox.value) return 'opacity-0'
-  if (canBulkAct.value) return 'opacity-100 group-hover:opacity-0'
+  // Only fade the avatar for the checkbox on devices that can actually hover.
+  if (canBulkAct.value) return 'opacity-100 [@media(hover:hover)]:group-hover:opacity-0'
   return 'opacity-100'
 })
 

--- a/frontend/apps/main/src/features/conversation/list/ConversationListItem.vue
+++ b/frontend/apps/main/src/features/conversation/list/ConversationListItem.vue
@@ -43,7 +43,11 @@
                 :checked="isItemSelected"
                 :aria-label="t('conversation.bulkActions.selectConversation')"
                 class="w-5 h-5"
-                :class="showCheckbox ? '' : 'opacity-0 [@media(hover:hover)]:opacity-100'"
+                :class="
+                  showCheckbox
+                    ? ''
+                    : 'opacity-0 focus-visible:opacity-100 [@media(hover:hover)]:opacity-100'
+                "
               />
             </div>
           </div>

--- a/frontend/apps/main/src/features/conversation/message/attachment/BubbleAttachmentItem.vue
+++ b/frontend/apps/main/src/features/conversation/message/attachment/BubbleAttachmentItem.vue
@@ -19,7 +19,7 @@
               @error="fallbackToOriginal($event, attachment.url)"
             />
             <div
-              class="absolute inset-x-0 top-0 flex items-start justify-between gap-2 px-2 pt-1.5 pb-5 bg-gradient-to-b from-black/75 via-black/40 to-transparent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none"
+              class="absolute inset-x-0 top-0 flex items-start justify-between gap-2 px-2 pt-1.5 pb-5 bg-gradient-to-b from-black/75 via-black/40 to-transparent transition-opacity pointer-events-none [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
             >
               <div class="min-w-0 flex-1 text-white image-meta">
                 <p class="font-medium text-xs truncate">{{ shortName(attachment.name) }}</p>
@@ -47,7 +47,7 @@
           <DownloadLink
             v-if="!isImage"
             :url="attachment.url"
-            class="absolute top-1.5 right-1.5 opacity-0 group-hover:opacity-100 transition-opacity"
+            class="absolute top-1.5 right-1.5 transition-opacity [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100"
           />
         </div>
       </PopoverTrigger>

--- a/frontend/apps/main/src/features/conversation/sidebar/CustomAttributes.vue
+++ b/frontend/apps/main/src/features/conversation/sidebar/CustomAttributes.vue
@@ -53,7 +53,7 @@
           <span class="sidebar-value break-all" v-if="attribute.data_type !== 'checkbox'">
             {{ customAttributes?.[attribute.key] ?? '-' }}
           </span>
-          <div class="flex items-center gap-0.5 opacity-0 group-hover/item:opacity-100 transition-opacity duration-200 flex-shrink-0">
+          <div class="flex items-center gap-0.5 transition-opacity duration-200 flex-shrink-0 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover/item:opacity-100">
             <button
               class="p-1 rounded-md hover:bg-muted cursor-pointer transition-colors"
               @click="startEditing(attribute)"


### PR DESCRIPTION
These controls are `opacity-0 group-hover:opacity-100`. Touch has no hover state, so they stay invisible while still being hit-testable — invisible targets rather than absent ones, and the action can't be performed at all:

- download an attachment, and its name/size
- edit or delete a custom attribute
- select a conversation, which gates every bulk action

Uses the `[@media(hover:hover)]` guard already used by `DataTable.vue`, so pointer devices are unaffected. For selection on touch the overlay is always live (tap the avatar to select) while the checkbox stays transparent until selection starts, so the avatar stays readable.

Independent of the layout work — applies to touch laptops and tablets today. Refs #470


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation selection on touch devices, keeping selection controls visible when tapping avatars.
  * Ensured attachment metadata and download controls remain visible on touch devices.
  * Kept attribute action controls accessible on devices without hover support.
  * Preserved existing hover interactions on desktop devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->