### PR TITLE
count macro usage for content-only macros

### DIFF
--- a/cmd/macro.go
+++ b/cmd/macro.go
@@ -199,7 +199,7 @@ func handleApplyMacro(r *fastglue.Request) error {
 		}
 	}
 
-	if successCount == 0 {
+	if len(incomingActions) > 0 && successCount == 0 {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, app.i18n.T("macro.couldNotApply"), nil, envelope.GeneralError)
 	}
 

--- a/frontend/apps/main/src/composables/useDraftManager.js
+++ b/frontend/apps/main/src/composables/useDraftManager.js
@@ -36,6 +36,7 @@ const draftKey = (uuid, type) => `${uuid}::${type}`
 
 const metaSignature = (meta) =>
   JSON.stringify({
+    macro_id: meta?.macro_id || 0,
     macro_actions: meta?.macro_actions || [],
     attachments: (meta?.attachments || []).map(a => a.uuid)
   })
@@ -52,6 +53,7 @@ export function useDraftManager (conversationUUID, messageType, uploadedFiles = 
   const isLoading = ref(false)
   const loadedAttachments = ref([])
   const loadedMacroActions = ref([])
+  const loadedMacroID = ref(0)
 
   // Live-key guard: the editor is transiently empty during open/switch and must not clobber a stored draft.
   const loadedKey = ref(null)
@@ -59,7 +61,9 @@ export function useDraftManager (conversationUUID, messageType, uploadedFiles = 
 
   const buildDraft = () => {
     const meta = {}
-    const macroActions = conversationStore.getMacro(MACRO_CONTEXT.REPLY)?.actions || []
+    const macro = conversationStore.getMacro(MACRO_CONTEXT.REPLY)
+    const macroActions = macro?.actions || []
+    if (macro?.id > 0) meta.macro_id = macro.id
     if (macroActions.length > 0) meta.macro_actions = macroActions
     if (uploadedFiles?.value?.length > 0) {
       meta.attachments = uploadedFiles.value.map(file => ({
@@ -80,6 +84,7 @@ export function useDraftManager (conversationUUID, messageType, uploadedFiles = 
     textContent.value = ''
     loadedAttachments.value = validateAttachments(draft?.meta?.attachments)
     loadedMacroActions.value = validateMacroActions(draft?.meta?.macro_actions)
+    loadedMacroID.value = Number(draft?.meta?.macro_id) > 0 ? Number(draft.meta.macro_id) : 0
   }
 
   const load = async (uuid, type) => {
@@ -168,6 +173,7 @@ export function useDraftManager (conversationUUID, messageType, uploadedFiles = 
     isLoading,
     clearDraft,
     loadedAttachments,
-    loadedMacroActions
+    loadedMacroActions,
+    loadedMacroID
   }
 }

--- a/frontend/apps/main/src/features/conversation/CreateConversation.vue
+++ b/frontend/apps/main/src/features/conversation/CreateConversation.vue
@@ -478,7 +478,7 @@ const createConversation = form.handleSubmit(async (values) => {
 
     // Get macro from context, and set if any actions are available.
     const macro = conversationStore.getMacro(MACRO_CONTEXT.NEW_CONVERSATION)
-    if (conversationUUID !== '' && macro?.id && macro?.actions?.length > 0) {
+    if (conversationUUID !== '' && macro?.id) {
       try {
         await api.applyMacro(conversationUUID, macro.id, macro.actions)
       } catch (error) {
@@ -506,10 +506,8 @@ const createConversation = form.handleSubmit(async (values) => {
 watch(
   () => conversationStore.getMacro(MACRO_CONTEXT.NEW_CONVERSATION).id,
   () => {
-    form.setFieldValue(
-      'content',
-      conversationStore.getMacro(MACRO_CONTEXT.NEW_CONVERSATION).message_content
-    )
+    const content = conversationStore.getMacro(MACRO_CONTEXT.NEW_CONVERSATION).message_content
+    if (content) form.setFieldValue('content', content)
   },
   { deep: true }
 )

--- a/frontend/apps/main/src/features/conversation/ReplyBox.vue
+++ b/frontend/apps/main/src/features/conversation/ReplyBox.vue
@@ -190,7 +190,8 @@ const {
   isLoading: isDraftLoading,
   clearDraft,
   loadedAttachments,
-  loadedMacroActions
+  loadedMacroActions,
+  loadedMacroID
 } = useDraftManager(currentConversationUUID, messageType, mediaFiles)
 
 // Rest of existing state
@@ -401,7 +402,7 @@ const processSend = async (skipContactEmailCheck = false, skipMissingTagsCheck =
   if (!hasMessageSendingErrored) {
     const macroID = conversationStore.getMacro(MACRO_CONTEXT.REPLY)?.id
     const macroActions = conversationStore.getMacro(MACRO_CONTEXT.REPLY)?.actions || []
-    if (macroID > 0 && macroActions.length > 0) {
+    if (macroID > 0) {
       try {
         await api.applyMacro(convUUID, macroID, macroActions)
       } catch (error) {
@@ -444,12 +445,13 @@ watch(
   { deep: true }
 )
 
-// Reset first so a loaded draft never inherits the previous conversation's macro id/message_content (drafts store only actions).
+// Reset first so a loaded draft never inherits the previous conversation's macro (drafts store no message_content).
 watch(
-  loadedMacroActions,
-  (actions) => {
+  [loadedMacroID, loadedMacroActions],
+  ([id, actions]) => {
     conversationStore.resetMacro(MACRO_CONTEXT.REPLY)
-    if (actions.length) conversationStore.setMacroActions([...toRaw(actions)], MACRO_CONTEXT.REPLY)
+    if (id > 0) conversationStore.setMacro({ id, actions: [...toRaw(actions)] }, MACRO_CONTEXT.REPLY)
+    else if (actions.length) conversationStore.setMacroActions([...toRaw(actions)], MACRO_CONTEXT.REPLY)
   },
   { deep: true }
 )


### PR DESCRIPTION
Macros with no actions never hit the apply endpoint, so their usage count stayed at zero. The frontend now calls apply whenever a macro was picked, and drafts store the macro id so a macro survives switching conversations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macro application for macros without actions.
  * Preserved existing message content when a macro does not provide replacement text.
  * Corrected draft restoration so saved reply macros and their actions are recovered reliably.

* **Improvements**
  * Drafts now retain the selected reply macro, allowing macro settings to persist when saving and reopening drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->