### PR TITLE
fix AI agent OTP verification flow

### DIFF
--- a/internal/aiagent/prompt.go
+++ b/internal/aiagent/prompt.go
@@ -53,6 +53,7 @@ const verificationNote = `This customer is not verified yet. Some tools need a v
 - Call send_email_verification to email them a one-time code, then tell them you have sent a code and ask them to reply with it. Never ask for or accept the code by any other means, and never state the code yourself.
 - If the customer gives a different email from the one the code went to (for example after their account could not be located), call set_contact_email with the new email, then send_email_verification again.
 - When they reply with the code, call check_email_verification with it. Once it succeeds, retry the tool you needed.
+- Call check_email_verification for every code the customer sends, including after an earlier code was rejected. Never tell them a code is wrong unless that tool just said so.
 Do not claim the customer is verified until check_email_verification has succeeded.`
 
 var toneClauses = map[string]string{

--- a/internal/aiagent/tools.go
+++ b/internal/aiagent/tools.go
@@ -288,7 +288,7 @@ func (t *sendEmailVerificationTool) Execute(ctx context.Context, args string) (s
 		t.m.lo.Error("error recording verification send count", "conversation_uuid", t.conv.UUID, "error", err)
 	}
 	t.m.lo.Debug("ai agent sent verification code", "conversation_uuid", t.conv.UUID, "email", email)
-	return "A verification code has been emailed to the customer. Tell them you have sent a code to their email and ask them to reply with it.", nil
+	return fmt.Sprintf("A verification code has been emailed to %s. Tell them you have sent a code to that address, quoting it exactly, and ask them to reply with the code, checking their spam folder if it is not in the inbox.", email), nil
 }
 
 // checkEmailVerificationTool verifies the code the customer entered against the pending one.

--- a/internal/aiagent/worker.go
+++ b/internal/aiagent/worker.go
@@ -303,7 +303,8 @@ func (m *Manager) handle(ctx context.Context, convID int) {
 	// verified: the 30-min window can expire mid-run and a blocked tool then points the model at
 	// them. set_contact_email is visitor-only, so a self-claimed email can be corrected in chat; a
 	// known contact's email is never swappable this way.
-	if conv.InboxChannel == channelEmail || conv.Contact.Type != umodels.UserTypeContact {
+	needsVerification := m.assistantHasVerifiedTool(assistant)
+	if needsVerification && (conv.InboxChannel == channelEmail || conv.Contact.Type != umodels.UserTypeContact) {
 		offerSetEmail := conv.Contact.Type == umodels.UserTypeVisitor
 		tools = append(tools, &sendEmailVerificationTool{m: m, conv: &conv})
 		tools = append(tools, &checkEmailVerificationTool{m: m, conv: &conv})
@@ -312,7 +313,7 @@ func (m *Manager) handle(ctx context.Context, convID int) {
 		}
 		m.lo.Debug("ai agent offering verification tools", "conversation_uuid", conv.UUID, "set_contact_email_offered", offerSetEmail)
 	}
-	if !runVerified {
+	if needsVerification && !runVerified {
 		systemPrompt += "\n\n" + verificationNote
 	}
 
@@ -630,6 +631,25 @@ func (m *Manager) recentContactConversations(conv cmodels.Conversation, verified
 		return nil
 	}
 	return recent
+}
+
+// assistantHasVerifiedTool reports whether any tool attached to the assistant is verification-gated;
+// it fails open so a lookup error keeps the verification flow available.
+func (m *Manager) assistantHasVerifiedTool(a models.Assistant) bool {
+	if len(a.ToolIDs) == 0 {
+		return false
+	}
+	tools, err := m.ai.GetEnabledToolsByIDs(a.ToolIDs)
+	if err != nil {
+		m.lo.Error("error fetching assistant tools for verification check", "assistant_id", a.ID, "error", err)
+		return true
+	}
+	for _, t := range tools {
+		if t.RequiresVerification {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Manager) encodeAttachmentImage(att attachment.Attachment) (aimodels.ChatImage, bool) {


### PR DESCRIPTION
The verification tools and OTP prompt block loaded for every unverified customer, so an assistant with no account-acting tools still asked people for an email code it had no use for. The worker now checks the assistant's tools first and skips both unless one is flagged requires_verification. A lookup error fails open and keeps the flow.

The send tool's result did not say which address it mailed, so the model filled one in from chat history. After a sibling conversation rebound the contact's email, it named the old address while the mail went to the new one. The result now names the address and mentions the spam folder.

The prompt did not say to check every code the customer sends, so after one rejection the model declared the next code wrong without calling the tool and handed off to a human.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Verification now checks every customer-provided code, including codes submitted after an earlier rejection.
  * Email verification confirmations now include the recipient’s email address and remind customers to check their spam folder.
  * Verification prompts and tools are shown only when required for the available assistant capabilities, while verification remains active if capability details cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->