### PR TITLE
speed up releases with parallel goreleaser builds and fix windows bin name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --parallelism 1 --clean
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_ORG: libredesk

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,7 +28,7 @@ builds:
     goarm:
       - 6
       - 7
-    binary: 'libredesk{{ if eq .Os "windows" }}.exe{{ end }}'
+    binary: libredesk
     ldflags:
       - -s -w -X "main.buildString={{ .Tag }} ({{ .ShortCommit }} {{ .Date }}, {{ .Os }}/{{ .Arch }})" -X "main.versionString={{ .Tag }}"
     hooks:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Improved the release build process for cleaner artifact generation.
  * Standardized the universal build binary name as `libredesk` across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->