### PR TITLE
fix: track media uploader to prevent cross-agent file theft

### DIFF
--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -852,7 +852,8 @@ func handleCreateConversation(r *fastglue.Request) error {
 	}
 
 	// Get media for the attachment ids, skip any already associated with a model.
-	media, err := getUnassociatedMedia(app, req.Attachments)
+	// Only return media uploaded by the current user to prevent cross-agent IDOR.
+	media, err := getUnassociatedMedia(app, req.Attachments, auser.ID)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, app.i18n.T("globals.messages.somethingWentWrong"), nil, envelope.GeneralError)
 	}

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -852,7 +852,6 @@ func handleCreateConversation(r *fastglue.Request) error {
 	}
 
 	// Get media for the attachment ids, skip any already associated with a model.
-	// Only return media uploaded by the current user to prevent cross-agent IDOR.
 	media, err := getUnassociatedMedia(app, req.Attachments, auser.ID)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, app.i18n.T("globals.messages.somethingWentWrong"), nil, envelope.GeneralError)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/abhinavxd/libredesk/internal/colorlog"
 	"github.com/abhinavxd/libredesk/internal/dbutil"
+	"github.com/abhinavxd/libredesk/internal/migrations"
 	"github.com/abhinavxd/libredesk/internal/user"
 	"github.com/jmoiron/sqlx"
 	"github.com/knadh/stuffbin"
@@ -56,6 +57,11 @@ func install(ctx context.Context, db *sqlx.DB, fs stuffbin.FileSystem, idempoten
 	// Install schema.
 	if err := installSchema(db, fs); err != nil {
 		log.Fatalf("error installing schema: %v", err)
+	}
+
+	// Run post-schema migrations so fresh installs include columns not yet in schema.sql.
+	if err := migrations.V2_7_0(db, fs, ko); err != nil {
+		log.Fatalf("error running v2.7.0 migration: %v", err)
 	}
 
 	log.Println("database schema installed successfully")

--- a/cmd/media.go
+++ b/cmd/media.go
@@ -69,7 +69,6 @@ func handleMediaUpload(r *fastglue.Request) error {
 
 	// Only agents who manage the help center may upload publicly served media.
 	if mmodels.IsPublicModel(linkedModel) {
-		auser := r.RequestCtx.UserValue("user").(amodels.User)
 		agent, err := app.user.GetAgentCachedOrLoad(auser.ID)
 		if err != nil {
 			return sendErrorEnvelope(r, err)
@@ -291,7 +290,6 @@ func bytesToMegabytes(bytes int64) float64 {
 }
 
 // getUnassociatedMedia fetches media by IDs that are owned by uploaderID and not yet attached to any message.
-// Only media uploaded by the requesting user is returned, preventing cross-agent file theft via sequential ID enumeration.
 func getUnassociatedMedia(app *App, ids []int, uploaderID int) ([]mmodels.Media, error) {
 	all, err := app.media.GetManyByUploader(ids, uploaderID)
 	if err != nil {

--- a/cmd/media.go
+++ b/cmd/media.go
@@ -30,6 +30,7 @@ const mediaCacheTTL = 24 * time.Hour
 func handleMediaUpload(r *fastglue.Request) error {
 	var (
 		app     = r.Context.(*App)
+		auser   = r.RequestCtx.UserValue("user").(amodels.User)
 		cleanUp = false
 	)
 
@@ -159,8 +160,8 @@ func handleMediaUpload(r *fastglue.Request) error {
 		return sendErrorEnvelope(r, err)
 	}
 
-	// Insert in DB.
-	media, err := app.media.Insert(disposition, srcFileName, srcContentType, "" /**content_id**/, null.NewString(linkedModel, linkedModel != ""), uuid.String(), null.Int{} /**model_id**/, int(srcFileSize), meta, !mmodels.IsPublicModel(linkedModel))
+	// Insert in DB — record the uploading agent's ID for ownership enforcement.
+	media, err := app.media.Insert(disposition, srcFileName, srcContentType, "" /**content_id**/, null.NewString(linkedModel, linkedModel != ""), uuid.String(), null.Int{} /**model_id**/, int(srcFileSize), meta, !mmodels.IsPublicModel(linkedModel), auser.ID)
 	if err != nil {
 		cleanUp = true
 		app.lo.Error("error inserting metadata into database", "error", err)
@@ -289,9 +290,10 @@ func bytesToMegabytes(bytes int64) float64 {
 	return float64(bytes) / 1024 / 1024
 }
 
-// getUnassociatedMedia fetches media by IDs, skipping any already associated with a model.
-func getUnassociatedMedia(app *App, ids []int) ([]mmodels.Media, error) {
-	all, err := app.media.GetMany(ids)
+// getUnassociatedMedia fetches media by IDs that are owned by uploaderID and not yet attached to any message.
+// Only media uploaded by the requesting user is returned, preventing cross-agent file theft via sequential ID enumeration.
+func getUnassociatedMedia(app *App, ids []int, uploaderID int) ([]mmodels.Media, error) {
+	all, err := app.media.GetManyByUploader(ids, uploaderID)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -234,7 +234,6 @@ func handleSendMessage(r *fastglue.Request) error {
 	}
 
 	// Get media for all attachments, skip any already associated with a model.
-	// Only return media uploaded by the current user to prevent cross-agent IDOR.
 	media, err := getUnassociatedMedia(app, req.Attachments, auser.ID)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, app.i18n.T("globals.messages.somethingWentWrong"), nil, envelope.GeneralError)

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -234,7 +234,8 @@ func handleSendMessage(r *fastglue.Request) error {
 	}
 
 	// Get media for all attachments, skip any already associated with a model.
-	media, err := getUnassociatedMedia(app, req.Attachments)
+	// Only return media uploaded by the current user to prevent cross-agent IDOR.
+	media, err := getUnassociatedMedia(app, req.Attachments, auser.ID)
 	if err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, app.i18n.T("globals.messages.somethingWentWrong"), nil, envelope.GeneralError)
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -46,6 +46,7 @@ var migList = []migFunc{
 	{"v2.4.0", migrations.V2_4_0},
 	{"v2.5.0", migrations.V2_5_0},
 	{"v2.6.0", migrations.V2_6_0},
+	{"v2.7.0", migrations.V2_7_0},
 	{"v2.8.0", migrations.V2_8_0},
 }
 

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -528,7 +528,7 @@ func uploadUserAvatar(r *fastglue.Request, user models.User, files []*multipart.
 	meta := []byte("{}")
 	// Agent and AI assistant avatars are public: both appear as authors on the help center.
 	private := user.Type != models.UserTypeAgent && user.Type != models.UserTypeAIAssistant
-	media, err := app.media.UploadAndInsert(srcFileName, srcContentType, contentID, linkedModel, linkedID, resized, srcFileSize, disposition, meta, private)
+	media, err := app.media.UploadAndInsert(srcFileName, srcContentType, contentID, linkedModel, linkedID, resized, srcFileSize, disposition, meta, private, user.ID)
 	if err != nil {
 		app.lo.Error("error uploading file", "user_id", user.ID, "error", err)
 		return envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.errorUploadingFile"), nil)

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -182,7 +182,7 @@ type mediaStore interface {
 	GetDraftInlineMedia(uuid string, conversationID int) (mmodels.Media, error)
 	ContentIDExists(contentID, conversationUUID string) (bool, string, error)
 	Upload(fileName, contentType string, content io.ReadSeeker) (string, string, error)
-	UploadAndInsert(fileName, contentType, contentID string, modelType null.String, modelID null.Int, content io.ReadSeeker, fileSize int, disposition null.String, meta []byte, private bool) (mmodels.Media, error)
+	UploadAndInsert(fileName, contentType, contentID string, modelType null.String, modelID null.Int, content io.ReadSeeker, fileSize int, disposition null.String, meta []byte, private bool, uploaderID int) (mmodels.Media, error)
 }
 
 type inboxStore interface {

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -1,4 +1,3 @@
-// Package conversation manages conversations and messages.
 package conversation
 
 import (
@@ -2267,3 +2266,4 @@ func renderTagFilter(operator, value string, paramIndex int) (string, []any, err
 		return "", nil, fmt.Errorf("invalid operator for tags: %s", operator)
 	}
 }
+

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -1549,3 +1549,4 @@ func (m *Manager) emailFromAddress(inb inbox.Inbox, message models.Message) stri
 	addr.Name = name
 	return addr.String()
 }
+

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -1163,7 +1163,8 @@ func (m *Manager) uploadMessageAttachments(message *models.Message) error {
 			attachment.Size,
 			null.StringFrom(attachment.Disposition),
 			[]byte("{}"), /** meta **/
-			true,          /** private **/
+			true, /** private **/
+			0,    /** uploaderID: 0 = system/email-ingested, stored as NULL **/
 		)
 		if err != nil {
 			m.lo.Error("failed to upload attachment", "name", attachment.Name, "content_type", attachment.ContentType, "size", attachment.Size, "content_id", contentID, "disposition", attachment.Disposition, "conversation_uuid", message.ConversationUUID, "message_source_id", message.SourceID.String, "error", err)

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -94,6 +94,7 @@ func New(opt Opts) (*Manager, error) {
 type queries struct {
 	Insert                      *sqlx.Stmt `query:"insert-media"`
 	Get                         *sqlx.Stmt `query:"get-media"`
+	GetByUploader               *sqlx.Stmt `query:"get-media-uploaded-by"`
 	GetByUUID                   *sqlx.Stmt `query:"get-media-by-uuid"`
 	Delete                      *sqlx.Stmt `query:"delete-media"`
 	LinkMessageMedia            *sqlx.Stmt `query:"link-message-media"`
@@ -108,7 +109,7 @@ type queries struct {
 }
 
 // UploadAndInsert uploads file on storage and inserts an entry in db.
-func (m *Manager) UploadAndInsert(srcFilename, contentType, contentID string, modelType null.String, modelID null.Int, content io.ReadSeeker, fileSize int, disposition null.String, meta []byte, private bool) (models.Media, error) {
+func (m *Manager) UploadAndInsert(srcFilename, contentType, contentID string, modelType null.String, modelID null.Int, content io.ReadSeeker, fileSize int, disposition null.String, meta []byte, private bool, uploaderID int) (models.Media, error) {
 	var (
 		uuid = uuid.New()
 		err  error
@@ -120,7 +121,7 @@ func (m *Manager) UploadAndInsert(srcFilename, contentType, contentID string, mo
 		return models.Media{}, err
 	}
 
-	media, err := m.Insert(disposition, srcFilename, contentType, contentID, modelType, uuid.String(), modelID, fileSize, meta, private)
+	media, err := m.Insert(disposition, srcFilename, contentType, contentID, modelType, uuid.String(), modelID, fileSize, meta, private, uploaderID)
 	if err != nil {
 		m.store.Delete(uuid.String())
 		return models.Media{}, err
@@ -149,9 +150,9 @@ func (m *Manager) Upload(fileName, contentType string, content io.ReadSeeker) (s
 }
 
 // Insert inserts media details into the database and returns the inserted media record.
-func (m *Manager) Insert(disposition null.String, fileName, contentType, contentID string, modelType null.String, uuid string, modelID null.Int, fileSize int, meta []byte, private bool) (models.Media, error) {
+func (m *Manager) Insert(disposition null.String, fileName, contentType, contentID string, modelType null.String, uuid string, modelID null.Int, fileSize int, meta []byte, private bool, uploaderID int) (models.Media, error) {
 	var id int
-	if err := m.queries.Insert.QueryRow(m.store.Name(), fileName, contentType, fileSize, meta, modelID, modelType, disposition, contentID, uuid, private).Scan(&id); err != nil {
+	if err := m.queries.Insert.QueryRow(m.store.Name(), fileName, contentType, fileSize, meta, modelID, modelType, disposition, contentID, uuid, private, uploaderID).Scan(&id); err != nil {
 		m.lo.Error("error inserting media", "error", err, "file_name", fileName, "content_type", contentType, "store", m.store.Name())
 		return models.Media{}, envelope.NewError(envelope.GeneralError, m.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
@@ -164,6 +165,25 @@ func (m *Manager) GetMany(ids []int) ([]models.Media, error) {
 	for _, id := range ids {
 		med, err := m.Get(id, "")
 		if err != nil {
+			return nil, err
+		}
+		out = append(out, med)
+	}
+	return out, nil
+}
+
+// GetManyByUploader fetches media records by IDs, returning only those uploaded by the given user.
+// Records with NULL uploaded_by (e.g. system/email-ingested media) are also returned to preserve
+// backward compatibility with existing messages.
+func (m *Manager) GetManyByUploader(ids []int, uploaderID int) ([]models.Media, error) {
+	out := make([]models.Media, 0, len(ids))
+	for _, id := range ids {
+		var med models.Media
+		if err := m.queries.GetByUploader.Get(&med, id, uploaderID); err != nil {
+			if err == sql.ErrNoRows {
+				m.lo.Warn("media not found or not owned by uploader, skipping", "media_id", id, "uploader_id", uploaderID)
+				continue
+			}
 			return nil, err
 		}
 		out = append(out, med)

--- a/internal/media/media.go
+++ b/internal/media/media.go
@@ -172,6 +172,7 @@ func (m *Manager) GetMany(ids []int) ([]models.Media, error) {
 	return out, nil
 }
 
+
 // GetManyByUploader fetches media records by IDs, returning only those uploaded by the given user.
 // Records with NULL uploaded_by (e.g. system/email-ingested media) are also returned to preserve
 // backward compatibility with existing messages.

--- a/internal/media/models/models.go
+++ b/internal/media/models/models.go
@@ -37,6 +37,7 @@ type Media struct {
 	Size        int             `db:"size" json:"size"`
 	Meta        json.RawMessage `db:"meta" json:"meta"`
 	Private     bool            `db:"private" json:"private"`
+	UploadedBy  null.Int        `db:"uploaded_by" json:"-"`
 
 	// Pseudo fields
 	URL     string `json:"url"`

--- a/internal/media/queries.sql
+++ b/internal/media/queries.sql
@@ -25,7 +25,7 @@ WHERE
    ($2 != '' AND uuid = NULLIF($2, '')::uuid)
 
 -- name: get-media-uploaded-by
-SELECT id, created_at, updated_at, "uuid", store, filename, content_type, content_id, model_id, model_type, disposition, "size", meta, uploaded_by
+SELECT id, created_at, updated_at, "uuid", store, filename, content_type, content_id, model_id, model_type, disposition, "size", meta, private, uploaded_by
 FROM media
 WHERE id = $1
   AND (uploaded_by = $2 OR uploaded_by IS NULL)

--- a/internal/media/queries.sql
+++ b/internal/media/queries.sql
@@ -1,5 +1,5 @@
 -- name: insert-media
-INSERT INTO media (store, filename, content_type, size, meta, model_id, model_type, disposition, content_id, uuid, private)
+INSERT INTO media (store, filename, content_type, size, meta, model_id, model_type, disposition, content_id, uuid, private, uploaded_by)
 VALUES(
   $1,
   $2,
@@ -11,20 +11,27 @@ VALUES(
   $8,
   $9,
   $10,
-  $11
+  $11,
+  NULLIF($12, 0)
 )
 RETURNING id;
 
 -- name: get-media
-SELECT id, created_at, updated_at, "uuid", store, filename, content_type, content_id, model_id, model_type, disposition, "size", meta, private
+SELECT id, created_at, updated_at, "uuid", store, filename, content_type, content_id, model_id, model_type, disposition, "size", meta, private, uploaded_by
 FROM media
 WHERE
    ($1 > 0 AND id = $1)
    OR
    ($2 != '' AND uuid = NULLIF($2, '')::uuid)
 
+-- name: get-media-uploaded-by
+SELECT id, created_at, updated_at, "uuid", store, filename, content_type, content_id, model_id, model_type, disposition, "size", meta, uploaded_by
+FROM media
+WHERE id = $1
+  AND (uploaded_by = $2 OR uploaded_by IS NULL)
+
 -- name: get-media-by-uuid
-SELECT id, created_at, updated_at, "uuid", store, filename, content_type, content_id, model_id, model_type, disposition, "size", meta, private
+SELECT id, created_at, updated_at, "uuid", store, filename, content_type, content_id, model_id, model_type, disposition, "size", meta, private, uploaded_by
 FROM media
 WHERE uuid = $1;
 

--- a/internal/migrations/v2.7.0.go
+++ b/internal/migrations/v2.7.0.go
@@ -7,8 +7,6 @@ import (
 )
 
 func V2_7_0(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf) error {
-	// Add uploaded_by column to media table to track which user uploaded each file.
-	// This is used to prevent cross-agent media theft via sequential ID enumeration (IDOR).
 	if _, err := db.Exec(`
 		ALTER TABLE media ADD COLUMN IF NOT EXISTS uploaded_by INT NULL REFERENCES users(id) ON DELETE SET NULL;
 	`); err != nil {

--- a/internal/migrations/v2.7.0.go
+++ b/internal/migrations/v2.7.0.go
@@ -1,0 +1,25 @@
+package migrations
+
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/knadh/koanf/v2"
+	"github.com/knadh/stuffbin"
+)
+
+func V2_7_0(db *sqlx.DB, fs stuffbin.FileSystem, ko *koanf.Koanf) error {
+	// Add uploaded_by column to media table to track which user uploaded each file.
+	// This is used to prevent cross-agent media theft via sequential ID enumeration (IDOR).
+	if _, err := db.Exec(`
+		ALTER TABLE media ADD COLUMN IF NOT EXISTS uploaded_by INT NULL REFERENCES users(id) ON DELETE SET NULL;
+	`); err != nil {
+		return err
+	}
+
+	if _, err := db.Exec(`
+		CREATE INDEX IF NOT EXISTS index_media_on_uploaded_by ON media(uploaded_by);
+	`); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
## What

Uploaded attachments had no ownership column on the `media` table. Any authenticated agent could reference another agent's unattached media ID in their own conversation request, claiming the file before the original uploader hit send. Sequential `SERIAL` primary keys made IDs trivially enumerable.

## Root cause

`getUnassociatedMedia()` in `cmd/media.go` checked only `model_id == 0` (file not yet attached), with no check for who uploaded the file.

## Fix

- Add `uploaded_by INT NULL REFERENCES users(id)` column to the `media` table (migration `v2.7.0`)
- Store the uploading agent's user ID on every upload in `handleMediaUpload`
- Add `GetManyByUploader()` to the media manager — returns only records owned by the requesting user, or records with `uploaded_by IS NULL` (system/email-ingested media, for backward compatibility)
- Update `getUnassociatedMedia()` to call `GetManyByUploader()` instead of `GetMany()`
- Thread `uploaderID` through `Insert()` and `UploadAndInsert()` signatures; system-ingested attachments pass `0` (stored as `NULL`)

## Verification

Tested locally against a running instance:

**Before fix** — attacker (user B) can steal agent A's unattached file using sequential ID:
```
POST /api/v1/conversations  {"attachments": [6]}   # ID 6 uploaded by agent A
→ 200 OK, file claimed by attacker
GET  /uploads/<uuid>?sig=...  → file contents returned
```

**After fix** — same request silently drops the attachment:
```
POST /api/v1/conversations  {"attachments": [6]}
→ 200 OK, conversation created, attachments: []   ← file not attached
```

Agent A can still send their own files normally (no regression).

## Files changed

| File | Change |
|---|---|
| `internal/migrations/v2.7.0.go` | New migration — `uploaded_by` column + index |
| `cmd/upgrade.go` | Register `v2.7.0` |
| `internal/media/models/models.go` | Add `UploadedBy null.Int` field |
| `internal/media/queries.sql` | Add `uploaded_by` to INSERT; new `get-media-uploaded-by` query |
| `internal/media/media.go` | Add `GetManyByUploader()`; update `Insert()`/`UploadAndInsert()` signatures |
| `internal/conversation/conversation.go` | Update `mediaStore` interface |
| `internal/conversation/message.go` | Pass `uploaderID=0` for system-ingested attachments |
| `cmd/media.go` | Pass `auser.ID` to `Insert()`; `getUnassociatedMedia` uses ownership check |
| `cmd/messages.go` | Pass `auser.ID` to `getUnassociatedMedia` |
| `cmd/conversation.go` | Pass `auser.ID` to `getUnassociatedMedia` |
| `cmd/users.go` | Pass `user.ID` to `UploadAndInsert` for avatar uploads |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Restricted private attachments and unattached media to their uploader.
  * Improved authorization for public, signed, and authenticated media access.
  * Added privacy and uploader tracking for uploaded media.

* **New Features**
  * Added contact reuse and permission-aware contact synchronization.
  * Improved media access controls and safer download handling.

* **Maintenance**
  * Added database migrations and automatic setup for media uploader data.
  * Improved media handling for fresh installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->