### PR TITLE
fix create conversation API ignoring external_user_id for existing contacts

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: "1.24.3"
+          go-version: "1.25.0"
 
       - name: Set up Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.3"
+          go-version: "1.25.0"
 
       - name: Install dependencies
         run: go get -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.3"
+          go-version: "1.25.0"
           cache: true
 
       - name: Set up Node.js

--- a/Makefile
+++ b/Makefile
@@ -102,10 +102,21 @@ demo-build:
 	@echo "→ Building in demo mode..."
 	@export VITE_DEMO_BUILD="true" && $(MAKE) build
 
-# Run tests.
+# Run tests. Integration tests need a Postgres; start one with `make test-db` first, else they skip.
 .PHONY: test
 test:
 	@echo "→ Running Go tests..."
 	go test -count=1 ./...
 	@echo "→ Running frontend tests..."
 	cd ${FRONTEND_DIR} && npx pnpm install --frozen-lockfile && npx pnpm test:run
+
+# Start a throwaway Postgres for integration tests. Remove it with `make test-db-down`.
+.PHONY: test-db
+test-db:
+	docker run -d --name libredesk-test-db -p 127.0.0.1:5433:5432 \
+		-e POSTGRES_USER=libredesk -e POSTGRES_PASSWORD=libredesk -e POSTGRES_DB=libredesk \
+		postgres:17-alpine
+
+.PHONY: test-db-down
+test-db-down:
+	docker rm -f libredesk-test-db

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -899,7 +899,7 @@ func resolveUserFromClaims(app *App, claims Claims) (umodels.User, error) {
 	case claims.UserID > 0:
 		user, err = app.user.Get(claims.UserID, "", []string{umodels.UserTypeContact, umodels.UserTypeVisitor})
 	case claims.ExternalUserID != "":
-		user, err = app.user.GetByExternalID(claims.ExternalUserID)
+		user, err = app.user.GetContactByExternalID(claims.ExternalUserID)
 	default:
 		return umodels.User{}, errors.New("error fetching user")
 	}

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -795,7 +795,7 @@ func resolveOrCreateExternalContact(app *App, claims Claims) (int, error) {
 			ExternalUserID:         null.NewString(claims.ExternalUserID, true),
 			CustomAttributes:       marshalCustomAttributes(claims.ContactCustomAttributes, app),
 		}
-		if err := app.user.CreateContact(&user); err != nil {
+		if err := app.user.ResolveContact(&user, umodels.ContactSync); err != nil {
 			return 0, err
 		}
 		return user.ID, nil

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -821,19 +821,16 @@ func handleCreateConversation(r *fastglue.Request) error {
 		app.lo.Error("error checking permission", "error", err)
 		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
 	}
+	policy := umodels.ContactReuse
 	if canWriteContacts {
-		if err := app.user.CreateContact(&contact); err != nil {
-			return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
-		}
-	} else {
-		// Matches by external_user_id when provided - one email can map to multiple external IDs.
-		if err := app.user.GetOrCreateContact(&contact); err != nil {
-			return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
-		}
-		// A contact matched by external ID keeps its stored email as the recipient.
-		if contact.Email.String != "" {
-			to = []string{contact.Email.String}
-		}
+		policy = umodels.ContactSync
+	}
+	if err := app.user.ResolveContact(&contact, policy); err != nil {
+		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
+	}
+	// A contact matched by external ID keeps its stored email as the recipient.
+	if policy == umodels.ContactReuse && contact.Email.String != "" {
+		to = []string{contact.Email.String}
 	}
 
 	// Create conversation first.

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -52,6 +52,7 @@ type createConversationRequest struct {
 	FirstName        string         `json:"first_name"`
 	LastName         string         `json:"last_name"`
 	ExternalUserID   string         `json:"external_user_id"`
+	ReuseContact     bool           `json:"reuse_contact"`
 	Subject          string         `json:"subject"`
 	Content          string         `json:"content"`
 	Attachments      []int          `json:"attachments"`
@@ -815,14 +816,13 @@ func handleCreateConversation(r *fastglue.Request) error {
 		ExternalUserID:   null.NewString(req.ExternalUserID, req.ExternalUserID != ""),
 		CustomAttributes: json.RawMessage(`{}`),
 	}
-	// Only contacts:write callers may change a contact's name/email; others must reuse the contact untouched.
 	canWriteContacts, err := app.authz.Enforce(user, "contacts", "write")
 	if err != nil {
 		app.lo.Error("error checking permission", "error", err)
 		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
 	}
 	policy := umodels.ContactReuse
-	if canWriteContacts {
+	if canWriteContacts && !req.ReuseContact {
 		policy = umodels.ContactSync
 	}
 	if err := app.user.ResolveContact(&contact, policy); err != nil {

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -816,8 +816,7 @@ func handleCreateConversation(r *fastglue.Request) error {
 		ExternalUserID:   null.NewString(req.ExternalUserID, req.ExternalUserID != ""),
 		CustomAttributes: json.RawMessage(`{}`),
 	}
-	// Callers with contacts:write may update the contact's name/email via the CreateContact upsert;
-	// others only reuse the existing contact as-is.
+	// Only contacts:write callers may change a contact's name/email; others must reuse the contact untouched.
 	canWriteContacts, err := app.authz.Enforce(user, "contacts", "write")
 	if err != nil {
 		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -817,7 +817,13 @@ func handleCreateConversation(r *fastglue.Request) error {
 		CustomAttributes: json.RawMessage(`{}`),
 	}
 	// Reuse an existing contact as-is; this endpoint is gated only on conversations:write and must never rename a contact.
-	existing, err := app.user.GetContactByEmail(email)
+	// Match by external_user_id when provided - one email can map to multiple external IDs.
+	var existing umodels.User
+	if req.ExternalUserID != "" {
+		existing, err = app.user.GetByExternalID(req.ExternalUserID)
+	} else {
+		existing, err = app.user.GetContactByEmail(email)
+	}
 	if err != nil {
 		if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError {
 			return sendErrorEnvelope(r, err)

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -797,7 +797,6 @@ func handleCreateConversation(r *fastglue.Request) error {
 
 	req.Email = strings.ToLower(strings.TrimSpace(req.Email))
 
-	// Validate the request
 	if err := validateCreateConversationRequest(req, app); err != nil {
 		return sendErrorEnvelope(r, err)
 	}
@@ -819,6 +818,7 @@ func handleCreateConversation(r *fastglue.Request) error {
 	// Only contacts:write callers may change a contact's name/email; others must reuse the contact untouched.
 	canWriteContacts, err := app.authz.Enforce(user, "contacts", "write")
 	if err != nil {
+		app.lo.Error("error checking permission", "error", err)
 		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
 	}
 	if canWriteContacts {
@@ -900,7 +900,6 @@ func handleCreateConversation(r *fastglue.Request) error {
 	return r.SendEnvelope(conversation)
 }
 
-// validateCreateConversationRequest validates the create conversation request fields.
 func validateCreateConversationRequest(req createConversationRequest, app *App) error {
 	if req.InboxID <= 0 {
 		return envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.required", "name", "`inbox_id`"), nil)

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -826,22 +826,9 @@ func handleCreateConversation(r *fastglue.Request) error {
 			return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
 		}
 	} else {
-		// Match by external_user_id when provided - one email can map to multiple external IDs.
-		var existing umodels.User
-		if req.ExternalUserID != "" {
-			existing, err = app.user.GetByExternalID(req.ExternalUserID)
-		} else {
-			existing, err = app.user.GetContactByEmail(email)
-		}
-		if err != nil {
-			if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError {
-				return sendErrorEnvelope(r, err)
-			}
-			if err := app.user.CreateContact(&contact); err != nil {
-				return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
-			}
-		} else {
-			contact.ID = existing.ID
+		// Matches by external_user_id when provided - one email can map to multiple external IDs.
+		if err := app.user.GetOrCreateContact(&contact); err != nil {
+			return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
 		}
 	}
 

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -816,23 +816,34 @@ func handleCreateConversation(r *fastglue.Request) error {
 		ExternalUserID:   null.NewString(req.ExternalUserID, req.ExternalUserID != ""),
 		CustomAttributes: json.RawMessage(`{}`),
 	}
-	// Reuse an existing contact as-is; this endpoint is gated only on conversations:write and must never rename a contact.
-	// Match by external_user_id when provided - one email can map to multiple external IDs.
-	var existing umodels.User
-	if req.ExternalUserID != "" {
-		existing, err = app.user.GetByExternalID(req.ExternalUserID)
-	} else {
-		existing, err = app.user.GetContactByEmail(email)
-	}
+	// Callers with contacts:write may update the contact's name/email via the CreateContact upsert;
+	// others only reuse the existing contact as-is.
+	canWriteContacts, err := app.authz.Enforce(user, "contacts", "write")
 	if err != nil {
-		if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError {
-			return sendErrorEnvelope(r, err)
-		}
+		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
+	}
+	if canWriteContacts {
 		if err := app.user.CreateContact(&contact); err != nil {
 			return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
 		}
 	} else {
-		contact.ID = existing.ID
+		// Match by external_user_id when provided - one email can map to multiple external IDs.
+		var existing umodels.User
+		if req.ExternalUserID != "" {
+			existing, err = app.user.GetByExternalID(req.ExternalUserID)
+		} else {
+			existing, err = app.user.GetContactByEmail(email)
+		}
+		if err != nil {
+			if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError {
+				return sendErrorEnvelope(r, err)
+			}
+			if err := app.user.CreateContact(&contact); err != nil {
+				return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
+			}
+		} else {
+			contact.ID = existing.ID
+		}
 	}
 
 	// Create conversation first.

--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -830,6 +830,10 @@ func handleCreateConversation(r *fastglue.Request) error {
 		if err := app.user.GetOrCreateContact(&contact); err != nil {
 			return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
 		}
+		// A contact matched by external ID keeps its stored email as the recipient.
+		if contact.Email.String != "" {
+			to = []string{contact.Email.String}
+		}
 	}
 
 	// Create conversation first.

--- a/frontend/apps/main/src/features/conversation/CreateConversation.vue
+++ b/frontend/apps/main/src/features/conversation/CreateConversation.vue
@@ -471,6 +471,9 @@ const createConversation = form.handleSubmit(async (values) => {
     values.agent_id = values.agent_id ? Number(values.agent_id) : null
     // Array of attachment ids.
     values.attachments = mediaFiles.value.map((file) => file.id)
+    if (selectedContact.value?.external_user_id) {
+      values.external_user_id = selectedContact.value.external_user_id
+    }
     // Initiator of this conversation is always agent
     values.initiator = UserTypeAgent
     const conversation = await api.createConversation(values)

--- a/frontend/apps/main/src/features/conversation/CreateConversation.vue
+++ b/frontend/apps/main/src/features/conversation/CreateConversation.vue
@@ -474,6 +474,8 @@ const createConversation = form.handleSubmit(async (values) => {
     if (selectedContact.value?.external_user_id) {
       values.external_user_id = selectedContact.value.external_user_id
     }
+    // Form data is a snapshot from search; never let it overwrite the stored contact.
+    values.reuse_contact = true
     // Initiator of this conversation is always agent
     values.initiator = UserTypeAgent
     const conversation = await api.createConversation(values)

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -165,7 +165,7 @@ type userStore interface {
 	GetAgent(int, string) (umodels.User, error)
 	GetAgentCachedOrLoad(int) (umodels.User, error)
 	GetSystemUser() (umodels.User, error)
-	CreateContact(user *umodels.User) error
+	ResolveContact(user *umodels.User, policy umodels.ContactPolicy) error
 	UpgradeVisitorToContact(visitorID int) error
 }
 

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -811,7 +811,7 @@ func (m *Manager) ProcessIncomingMessage(in models.IncomingMessage) (models.Mess
 			Email:     in.Contact.Email,
 			Type:      umodels.UserTypeContact,
 		}
-		if err := m.userStore.CreateContact(&user); err != nil {
+		if err := m.userStore.ResolveContact(&user, umodels.ContactSync); err != nil {
 			m.lo.Error("error creating contact for incoming message", "message_source_id", in.SourceID.String, "error", err)
 			return models.Message{}, fmt.Errorf("creating contact: %w", err)
 		}
@@ -912,7 +912,7 @@ func (m *Manager) resolveByPlusAddress(in *models.IncomingMessage) (senderID, co
 	conversationUUID = conversation.UUID
 	senderID = conversation.Contact.ID
 
-	// Already a contact - if same email, return as sender. If different email, let CreateContact resolve actual sender.
+	// Already a contact - if same email, return as sender. If different email, let contact resolution find the actual sender.
 	if conversation.Contact.Type == umodels.UserTypeContact {
 		if !strings.EqualFold(conversation.Contact.Email.String, in.Contact.Email.String) {
 			return 0, conversationID, conversationUUID, nil
@@ -930,7 +930,7 @@ func (m *Manager) resolveByPlusAddress(in *models.IncomingMessage) (senderID, co
 	if contactErr == nil {
 		m.lo.Debug("a contact already exists with the same email as visitor; not upgrading visitor", "conversation_uuid", conversation.UUID, "contact_email", in.Contact.Email.String, "contact_user_id", user.ID)
 		// A contact with this email already exists; don't upgrade visitor.
-		// Let CreateContact resolve the correct sender ID.
+		// Let contact resolution find the correct sender ID.
 		return 0, conversationID, conversationUUID, nil
 	}
 

--- a/internal/conversation/transcript_test.go
+++ b/internal/conversation/transcript_test.go
@@ -1,32 +1,18 @@
 package conversation
 
 import (
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/abhinavxd/libredesk/internal/attachment"
 	"github.com/abhinavxd/libredesk/internal/conversation/models"
-	"github.com/knadh/go-i18n"
+	"github.com/abhinavxd/libredesk/internal/testutil"
 	"github.com/volatiletech/null/v9"
 )
 
-func newTestI18n(t *testing.T) *i18n.I18n {
-	t.Helper()
-	b, err := os.ReadFile("../../i18n/en-US.json")
-	if err != nil {
-		t.Fatalf("reading i18n file: %v", err)
-	}
-	in, err := i18n.New(b)
-	if err != nil {
-		t.Fatalf("loading i18n: %v", err)
-	}
-	return in
-}
-
 func TestBuildTranscript(t *testing.T) {
-	m := &Manager{i18n: newTestI18n(t)}
+	m := &Manager{i18n: testutil.NewI18n(t)}
 
 	created := time.Date(2026, time.May, 11, 10, 0, 0, 0, time.UTC)
 	downloaded := time.Date(2026, time.June, 2, 16, 10, 0, 0, time.UTC)

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,6 +1,4 @@
-// Package testutil provides a Postgres test harness for integration tests.
-// Start a database with `make test-db` (or point LIBREDESK_TEST_DB_DSN at any
-// Postgres superuser); tests skip when none is reachable.
+// Package testutil provides a Postgres test harness for integration tests: start one with `make test-db` or set LIBREDESK_TEST_DB_DSN, else tests skip.
 package testutil
 
 import (
@@ -12,7 +10,6 @@ import (
 
 	"github.com/jmoiron/sqlx"
 	"github.com/knadh/go-i18n"
-	"github.com/zerodha/logf"
 
 	_ "github.com/lib/pq"
 )
@@ -70,13 +67,6 @@ func NewI18n(t *testing.T) *i18n.I18n {
 		t.Fatalf("loading i18n: %v", err)
 	}
 	return mgr
-}
-
-// NewLogger returns a logger for constructing managers in tests.
-func NewLogger(t *testing.T) *logf.Logger {
-	t.Helper()
-	lo := logf.New(logf.Opts{})
-	return &lo
 }
 
 // repoRoot walks up from the working directory to the go.mod directory.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,99 @@
+// Package testutil provides a Postgres test harness for integration tests.
+// Start a database with `make test-db` (or point LIBREDESK_TEST_DB_DSN at any
+// Postgres superuser); tests skip when none is reachable.
+package testutil
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/knadh/go-i18n"
+	"github.com/zerodha/logf"
+
+	_ "github.com/lib/pq"
+)
+
+const (
+	dbDSNEnv     = "LIBREDESK_TEST_DB_DSN"
+	dbDefaultDSN = "postgres://libredesk:libredesk@127.0.0.1:5433/libredesk?sslmode=disable&connect_timeout=3"
+)
+
+// NewDB provisions a fresh database named libredesk_test_<name> with schema.sql applied, skipping the test if Postgres is unreachable.
+func NewDB(t *testing.T, name string) *sqlx.DB {
+	t.Helper()
+
+	dsn := os.Getenv(dbDSNEnv)
+	if dsn == "" {
+		dsn = dbDefaultDSN
+	}
+	admin, err := sqlx.Connect("postgres", dsn)
+	if err != nil {
+		t.Skipf("test database unreachable, set %s or start the dev postgres: %v", dbDSNEnv, err)
+	}
+	defer admin.Close()
+
+	dbName := "libredesk_test_" + name
+	admin.MustExec(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1`, dbName)
+	admin.MustExec(fmt.Sprintf(`DROP DATABASE IF EXISTS %s`, dbName))
+	admin.MustExec(fmt.Sprintf(`CREATE DATABASE %s`, dbName))
+
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parsing test DSN: %v", err)
+	}
+	u.Path = "/" + dbName
+	db, err := sqlx.Connect("postgres", u.String())
+	if err != nil {
+		t.Fatalf("connecting to test database: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	schema, err := os.ReadFile(filepath.Join(repoRoot(t), "schema.sql"))
+	if err != nil {
+		t.Fatalf("reading schema.sql: %v", err)
+	}
+	if _, err := db.Exec(string(schema)); err != nil {
+		t.Fatalf("applying schema.sql: %v", err)
+	}
+	return db
+}
+
+// NewI18n loads the en-US translations.
+func NewI18n(t *testing.T) *i18n.I18n {
+	t.Helper()
+	mgr, err := i18n.NewFromFile(filepath.Join(repoRoot(t), "i18n", "en-US.json"))
+	if err != nil {
+		t.Fatalf("loading i18n: %v", err)
+	}
+	return mgr
+}
+
+// NewLogger returns a logger for constructing managers in tests.
+func NewLogger(t *testing.T) *logf.Logger {
+	t.Helper()
+	lo := logf.New(logf.Opts{})
+	return &lo
+}
+
+// repoRoot walks up from the working directory to the go.mod directory.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getting working directory: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found in any parent directory")
+		}
+		dir = parent
+	}
+}

--- a/internal/user/contact.go
+++ b/internal/user/contact.go
@@ -45,7 +45,6 @@ func (u *Manager) UpdateContact(id int, user models.User) error {
 	return nil
 }
 
-// GetAllContacts returns a list of all contacts.
 func (u *Manager) GetContacts(page, pageSize int, order, orderBy string, filtersJSON, location string) ([]models.UserCompact, error) {
 	if pageSize > maxListPageSize {
 		pageSize = maxListPageSize
@@ -61,9 +60,13 @@ func (u *Manager) GetContacts(page, pageSize int, order, orderBy string, filters
 
 // reuseContact resolves to an existing contact without ever updating it, inserting one only if absent.
 func (u *Manager) reuseContact(user *models.User) error {
+	// An unknown ext_id falls back to the email lookup, else a duplicate contact with the same email gets inserted.
 	lookup := func() (models.User, error) {
 		if user.ExternalUserID.String != "" {
-			return u.GetContactByExternalID(user.ExternalUserID.String)
+			existing, err := u.GetContactByExternalID(user.ExternalUserID.String)
+			if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError || user.Email.String == "" {
+				return existing, err
+			}
 		}
 		return u.GetContactByEmail(user.Email.String)
 	}
@@ -84,10 +87,9 @@ func (u *Manager) reuseContact(user *models.User) error {
 		return err
 	}
 
-	password, err := u.generatePassword()
+	password, err := u.newContactPassword()
 	if err != nil {
-		u.lo.Error("generating password", "error", err)
-		return fmt.Errorf("generating password: %w", err)
+		return err
 	}
 
 	err = u.q.InsertContactIfAbsent.QueryRow(user.Email, user.FirstName, user.LastName, password, user.AvatarURL, user.ExternalUserID, user.CustomAttributes).Scan(&user.ID)
@@ -132,10 +134,9 @@ func (u *Manager) syncContact(user *models.User) error {
 			}
 		}
 
-		password, err := u.generatePassword()
+		password, err := u.newContactPassword()
 		if err != nil {
-			u.lo.Error("generating password", "error", err)
-			return fmt.Errorf("generating password: %w", err)
+			return err
 		}
 
 		// Upsert by ext_id - creates new or updates email/name on ext_id conflict.
@@ -162,10 +163,9 @@ func (u *Manager) syncContact(user *models.User) error {
 		}
 	}
 
-	password, err := u.generatePassword()
+	password, err := u.newContactPassword()
 	if err != nil {
-		u.lo.Error("generating password", "error", err)
-		return fmt.Errorf("generating password: %w", err)
+		return err
 	}
 
 	// No ext_id contact for this email - insert new, or update the existing no-ext-id contact's name.
@@ -174,4 +174,13 @@ func (u *Manager) syncContact(user *models.User) error {
 		return fmt.Errorf("insert contact: %w", err)
 	}
 	return nil
+}
+
+func (u *Manager) newContactPassword() ([]byte, error) {
+	password, err := u.generatePassword()
+	if err != nil {
+		u.lo.Error("generating password", "error", err)
+		return nil, fmt.Errorf("generating password: %w", err)
+	}
+	return password, nil
 }

--- a/internal/user/contact.go
+++ b/internal/user/contact.go
@@ -11,14 +11,56 @@ import (
 	"github.com/volatiletech/null/v9"
 )
 
-// GetOrCreateContact resolves user.ID to an existing contact, inserting one only if absent, never updating an existing row.
-func (u *Manager) GetOrCreateContact(user *models.User) error {
+// ResolveContact resolves user.ID to a contact by external_user_id or email, creating one if absent; policy decides if a matched contact may be updated.
+func (u *Manager) ResolveContact(user *models.User, policy models.ContactPolicy) error {
 	if len(user.CustomAttributes) == 0 {
 		user.CustomAttributes = []byte("{}")
 	}
 
 	user.Email = null.NewString(strings.ToLower(strings.TrimSpace(user.Email.String)), user.Email.Valid)
 
+	if policy == models.ContactSync {
+		return u.syncContact(user)
+	}
+	return u.reuseContact(user)
+}
+
+// UpdateContactBasicInfo updates only the name, email and phone of a contact.
+func (u *Manager) UpdateContactBasicInfo(id int, firstName, lastName, email, phoneNumber, phoneNumberCountryCode string) error {
+	if _, err := u.q.UpdateContactBasicInfo.Exec(id, firstName, lastName, strings.ToLower(strings.TrimSpace(email)), phoneNumber, phoneNumberCountryCode); err != nil {
+		u.lo.Error("error updating contact basic info", "error", err)
+		return fmt.Errorf("updating contact basic info: %w", err)
+	}
+	return nil
+}
+
+func (u *Manager) UpdateContact(id int, user models.User) error {
+	if _, err := u.q.UpdateContact.Exec(id, user.FirstName, user.LastName, user.Email, user.AvatarURL, user.PhoneNumber, user.PhoneNumberCountryCode, user.Country); err != nil {
+		if dbutil.IsUniqueViolationError(err) {
+			return envelope.NewError(envelope.InputError, u.i18n.T("contact.alreadyExistsWithEmail"), nil)
+		}
+		u.lo.Error("error updating user", "error", err)
+		return envelope.NewError(envelope.GeneralError, u.i18n.T("globals.messages.somethingWentWrong"), nil)
+	}
+	return nil
+}
+
+// GetAllContacts returns a list of all contacts.
+func (u *Manager) GetContacts(page, pageSize int, order, orderBy string, filtersJSON, location string) ([]models.UserCompact, error) {
+	if pageSize > maxListPageSize {
+		pageSize = maxListPageSize
+	}
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 {
+		pageSize = 10
+	}
+	return u.GetAllUsers(page, pageSize, []string{models.UserTypeContact, models.UserTypeVisitor}, order, orderBy, filtersJSON, location)
+}
+
+// reuseContact resolves to an existing contact without ever updating it, inserting one only if absent.
+func (u *Manager) reuseContact(user *models.User) error {
 	lookup := func() (models.User, error) {
 		if user.ExternalUserID.String != "" {
 			return u.GetContactByExternalID(user.ExternalUserID.String)
@@ -66,20 +108,8 @@ func (u *Manager) GetOrCreateContact(user *models.User) error {
 	return nil
 }
 
-func (u *Manager) CreateContact(user *models.User) error {
-	password, err := u.generatePassword()
-	if err != nil {
-		u.lo.Error("generating password", "error", err)
-		return fmt.Errorf("generating password: %w", err)
-	}
-
-	if len(user.CustomAttributes) == 0 {
-		user.CustomAttributes = []byte("{}")
-	}
-
-	// Normalize.
-	user.Email = null.NewString(strings.ToLower(strings.TrimSpace(user.Email.String)), user.Email.Valid)
-
+// syncContact resolves to an existing contact and updates its name/email, enriching external_user_id, inserting one if absent.
+func (u *Manager) syncContact(user *models.User) error {
 	// Check if email matches an existing contact without ext_id - enrich it.
 	if user.ExternalUserID.String != "" {
 		if user.Email.Valid && user.Email.String != "" {
@@ -100,6 +130,12 @@ func (u *Manager) CreateContact(user *models.User) error {
 				// ext_id already belongs to another contact, or the contact was deleted mid-flight - fall through to upsert.
 				u.lo.Info("skipping contact enrichment, falling back to upsert", "contact_id", existing.ID, "ext_id", user.ExternalUserID.String)
 			}
+		}
+
+		password, err := u.generatePassword()
+		if err != nil {
+			u.lo.Error("generating password", "error", err)
+			return fmt.Errorf("generating password: %w", err)
 		}
 
 		// Upsert by ext_id - creates new or updates email/name on ext_id conflict.
@@ -126,44 +162,16 @@ func (u *Manager) CreateContact(user *models.User) error {
 		}
 	}
 
+	password, err := u.generatePassword()
+	if err != nil {
+		u.lo.Error("generating password", "error", err)
+		return fmt.Errorf("generating password: %w", err)
+	}
+
 	// No ext_id contact for this email - insert new, or update the existing no-ext-id contact's name.
 	if err := u.q.InsertContactNoExtID.QueryRow(user.Email, user.FirstName, user.LastName, password, user.AvatarURL).Scan(&user.ID); err != nil {
 		u.lo.Error("error inserting contact", "error", err)
 		return fmt.Errorf("insert contact: %w", err)
 	}
 	return nil
-}
-
-// UpdateContactBasicInfo updates only the name, email and phone of a contact.
-func (u *Manager) UpdateContactBasicInfo(id int, firstName, lastName, email, phoneNumber, phoneNumberCountryCode string) error {
-	if _, err := u.q.UpdateContactBasicInfo.Exec(id, firstName, lastName, strings.ToLower(strings.TrimSpace(email)), phoneNumber, phoneNumberCountryCode); err != nil {
-		u.lo.Error("error updating contact basic info", "error", err)
-		return fmt.Errorf("updating contact basic info: %w", err)
-	}
-	return nil
-}
-
-func (u *Manager) UpdateContact(id int, user models.User) error {
-	if _, err := u.q.UpdateContact.Exec(id, user.FirstName, user.LastName, user.Email, user.AvatarURL, user.PhoneNumber, user.PhoneNumberCountryCode, user.Country); err != nil {
-		if dbutil.IsUniqueViolationError(err) {
-			return envelope.NewError(envelope.InputError, u.i18n.T("contact.alreadyExistsWithEmail"), nil)
-		}
-		u.lo.Error("error updating user", "error", err)
-		return envelope.NewError(envelope.GeneralError, u.i18n.T("globals.messages.somethingWentWrong"), nil)
-	}
-	return nil
-}
-
-// GetAllContacts returns a list of all contacts.
-func (u *Manager) GetContacts(page, pageSize int, order, orderBy string, filtersJSON, location string) ([]models.UserCompact, error) {
-	if pageSize > maxListPageSize {
-		pageSize = maxListPageSize
-	}
-	if page < 1 {
-		page = 1
-	}
-	if pageSize < 1 {
-		pageSize = 10
-	}
-	return u.GetAllUsers(page, pageSize, []string{models.UserTypeContact, models.UserTypeVisitor}, order, orderBy, filtersJSON, location)
 }

--- a/internal/user/contact.go
+++ b/internal/user/contact.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,54 @@ import (
 	"github.com/abhinavxd/libredesk/internal/user/models"
 	"github.com/volatiletech/null/v9"
 )
+
+// GetOrCreateContact resolves user.ID to an existing contact, inserting one only if absent, never updating an existing row.
+func (u *Manager) GetOrCreateContact(user *models.User) error {
+	password, err := u.generatePassword()
+	if err != nil {
+		u.lo.Error("generating password", "error", err)
+		return fmt.Errorf("generating password: %w", err)
+	}
+
+	if len(user.CustomAttributes) == 0 {
+		user.CustomAttributes = []byte("{}")
+	}
+
+	user.Email = null.NewString(strings.ToLower(strings.TrimSpace(user.Email.String)), user.Email.Valid)
+
+	lookup := func() (models.User, error) {
+		if user.ExternalUserID.String != "" {
+			return u.GetByExternalID(user.ExternalUserID.String)
+		}
+		return u.GetContactByEmail(user.Email.String)
+	}
+
+	existing, err := lookup()
+	if err == nil {
+		user.ID = existing.ID
+		return nil
+	}
+	if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError {
+		return err
+	}
+
+	err = u.q.InsertContactIfAbsent.QueryRow(user.Email, user.FirstName, user.LastName, password, user.AvatarURL, user.ExternalUserID, user.CustomAttributes).Scan(&user.ID)
+	if err == nil {
+		return nil
+	}
+	if err != sql.ErrNoRows {
+		u.lo.Error("error inserting contact", "error", err)
+		return fmt.Errorf("insert contact: %w", err)
+	}
+
+	// No returned row means a concurrent request inserted the contact - reuse it.
+	existing, err = lookup()
+	if err != nil {
+		return err
+	}
+	user.ID = existing.ID
+	return nil
+}
 
 func (u *Manager) CreateContact(user *models.User) error {
 	password, err := u.generatePassword()

--- a/internal/user/contact.go
+++ b/internal/user/contact.go
@@ -32,9 +32,16 @@ func (u *Manager) GetOrCreateContact(user *models.User) error {
 		return u.GetContactByEmail(user.Email.String)
 	}
 
+	reuse := func(existing models.User) {
+		user.ID = existing.ID
+		if existing.Email.String != "" {
+			user.Email = existing.Email
+		}
+	}
+
 	existing, err := lookup()
 	if err == nil {
-		user.ID = existing.ID
+		reuse(existing)
 		return nil
 	}
 	if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError {
@@ -55,7 +62,7 @@ func (u *Manager) GetOrCreateContact(user *models.User) error {
 	if err != nil {
 		return err
 	}
-	user.ID = existing.ID
+	reuse(existing)
 	return nil
 }
 

--- a/internal/user/contact.go
+++ b/internal/user/contact.go
@@ -21,7 +21,7 @@ func (u *Manager) GetOrCreateContact(user *models.User) error {
 
 	lookup := func() (models.User, error) {
 		if user.ExternalUserID.String != "" {
-			return u.GetByExternalID(user.ExternalUserID.String)
+			return u.GetContactByExternalID(user.ExternalUserID.String)
 		}
 		return u.GetContactByEmail(user.Email.String)
 	}

--- a/internal/user/contact.go
+++ b/internal/user/contact.go
@@ -13,12 +13,6 @@ import (
 
 // GetOrCreateContact resolves user.ID to an existing contact, inserting one only if absent, never updating an existing row.
 func (u *Manager) GetOrCreateContact(user *models.User) error {
-	password, err := u.generatePassword()
-	if err != nil {
-		u.lo.Error("generating password", "error", err)
-		return fmt.Errorf("generating password: %w", err)
-	}
-
 	if len(user.CustomAttributes) == 0 {
 		user.CustomAttributes = []byte("{}")
 	}
@@ -46,6 +40,12 @@ func (u *Manager) GetOrCreateContact(user *models.User) error {
 	}
 	if envErr, ok := err.(envelope.Error); !ok || envErr.ErrorType != envelope.NotFoundError {
 		return err
+	}
+
+	password, err := u.generatePassword()
+	if err != nil {
+		u.lo.Error("generating password", "error", err)
+		return fmt.Errorf("generating password: %w", err)
 	}
 
 	err = u.q.InsertContactIfAbsent.QueryRow(user.Email, user.FirstName, user.LastName, password, user.AvatarURL, user.ExternalUserID, user.CustomAttributes).Scan(&user.ID)

--- a/internal/user/contact_test.go
+++ b/internal/user/contact_test.go
@@ -1,0 +1,348 @@
+package user
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/abhinavxd/libredesk/internal/user/models"
+	"github.com/jmoiron/sqlx"
+	"github.com/knadh/go-i18n"
+	"github.com/volatiletech/null/v9"
+	"github.com/zerodha/logf"
+
+	_ "github.com/lib/pq"
+)
+
+const (
+	testDBDSNEnv     = "LIBREDESK_TEST_DB_DSN"
+	testDBDefaultDSN = "postgres://libredesk:libredesk@127.0.0.1:5432/libredesk?sslmode=disable&connect_timeout=3"
+	testDBName       = "libredesk_contact_test"
+)
+
+type userRow struct {
+	FirstName string
+	LastName  string
+	Email     string
+	ExtID     string
+	Type      string
+}
+
+// newTestManager provisions a fresh test database with schema.sql applied and returns a Manager on it.
+func newTestManager(t *testing.T) (*Manager, *sqlx.DB) {
+	t.Helper()
+
+	dsn := os.Getenv(testDBDSNEnv)
+	if dsn == "" {
+		dsn = testDBDefaultDSN
+	}
+	admin, err := sqlx.Connect("postgres", dsn)
+	if err != nil {
+		t.Skipf("test database unreachable, set %s or start the dev postgres: %v", testDBDSNEnv, err)
+	}
+	defer admin.Close()
+
+	admin.MustExec(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1`, testDBName)
+	admin.MustExec(fmt.Sprintf(`DROP DATABASE IF EXISTS %s`, testDBName))
+	admin.MustExec(fmt.Sprintf(`CREATE DATABASE %s`, testDBName))
+
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("parsing test DSN: %v", err)
+	}
+	u.Path = "/" + testDBName
+	db, err := sqlx.Connect("postgres", u.String())
+	if err != nil {
+		t.Fatalf("connecting to test database: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	schema, err := os.ReadFile("../../schema.sql")
+	if err != nil {
+		t.Fatalf("reading schema.sql: %v", err)
+	}
+	if _, err := db.Exec(string(schema)); err != nil {
+		t.Fatalf("applying schema.sql: %v", err)
+	}
+
+	i18nMgr, err := i18n.NewFromFile("../../i18n/en-US.json")
+	if err != nil {
+		t.Fatalf("loading i18n: %v", err)
+	}
+	lo := logf.New(logf.Opts{})
+	mgr, err := New(i18nMgr, Opts{DB: db, Lo: &lo})
+	if err != nil {
+		t.Fatalf("creating user manager: %v", err)
+	}
+	return mgr, db
+}
+
+func newContact(email, extID, firstName, lastName string) *models.User {
+	return &models.User{
+		Email:          null.NewString(email, email != ""),
+		ExternalUserID: null.NewString(extID, extID != ""),
+		FirstName:      firstName,
+		LastName:       lastName,
+	}
+}
+
+func resolve(t *testing.T, u *Manager, c *models.User, policy models.ContactPolicy) {
+	t.Helper()
+	if err := u.ResolveContact(c, policy); err != nil {
+		t.Fatalf("ResolveContact: %v", err)
+	}
+	if c.ID <= 0 {
+		t.Fatalf("ResolveContact returned no ID")
+	}
+}
+
+func fetchRow(t *testing.T, db *sqlx.DB, id int) userRow {
+	t.Helper()
+	var r userRow
+	err := db.QueryRow(`SELECT first_name, COALESCE(last_name, ''), COALESCE(email, ''), COALESCE(external_user_id, ''), type FROM users WHERE id = $1`,
+		id).Scan(&r.FirstName, &r.LastName, &r.Email, &r.ExtID, &r.Type)
+	if err != nil {
+		t.Fatalf("fetching user %d: %v", id, err)
+	}
+	return r
+}
+
+func countByEmail(t *testing.T, db *sqlx.DB, email string) int {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM users WHERE email = $1 AND deleted_at IS NULL`, email).Scan(&n); err != nil {
+		t.Fatalf("counting users with email %s: %v", email, err)
+	}
+	return n
+}
+
+func insertAgent(t *testing.T, db *sqlx.DB, email, extID string) int {
+	t.Helper()
+	var id int
+	err := db.QueryRow(`INSERT INTO users (type, email, first_name, "password", external_user_id) VALUES ('agent', $1, 'Agent', 'x', $2) RETURNING id`,
+		email, null.NewString(extID, extID != "")).Scan(&id)
+	if err != nil {
+		t.Fatalf("inserting agent: %v", err)
+	}
+	return id
+}
+
+func TestResolveContactReuse(t *testing.T) {
+	u, db := newTestManager(t)
+
+	// Creates a contact when none exists.
+	alice := newContact("alice@example.com", "", "Alice", "Original")
+	resolve(t, u, alice, models.ContactReuse)
+	if r := fetchRow(t, db, alice.ID); r.Type != "contact" || r.FirstName != "Alice" {
+		t.Fatalf("unexpected created row: %+v", r)
+	}
+
+	// A later reuse with a different name resolves to the same contact untouched.
+	again := newContact("alice@example.com", "", "Changed", "Name")
+	resolve(t, u, again, models.ContactReuse)
+	if again.ID != alice.ID {
+		t.Fatalf("expected reuse of contact %d, got %d", alice.ID, again.ID)
+	}
+	if r := fetchRow(t, db, alice.ID); r.FirstName != "Alice" || r.LastName != "Original" {
+		t.Fatalf("reuse policy modified the contact: %+v", r)
+	}
+
+	// Email matching is case-insensitive.
+	upper := newContact("ALICE@Example.COM", "", "X", "Y")
+	resolve(t, u, upper, models.ContactReuse)
+	if upper.ID != alice.ID {
+		t.Fatalf("expected case-insensitive match of contact %d, got %d", alice.ID, upper.ID)
+	}
+
+	// Creates a contact with external ID when none matches.
+	bob := newContact("bob@example.com", "ext-bob", "Bob", "")
+	resolve(t, u, bob, models.ContactReuse)
+	if r := fetchRow(t, db, bob.ID); r.ExtID != "ext-bob" {
+		t.Fatalf("expected ext_id ext-bob, got %+v", r)
+	}
+
+	// External ID match wins over the passed email, and the stored email is returned for use as recipient.
+	byExt := newContact("different@example.com", "ext-bob", "B", "")
+	resolve(t, u, byExt, models.ContactReuse)
+	if byExt.ID != bob.ID {
+		t.Fatalf("expected ext_id match of contact %d, got %d", bob.ID, byExt.ID)
+	}
+	if byExt.Email.String != "bob@example.com" {
+		t.Fatalf("expected stored email bob@example.com back, got %q", byExt.Email.String)
+	}
+	if r := fetchRow(t, db, bob.ID); r.Email != "bob@example.com" {
+		t.Fatalf("reuse policy modified stored email: %+v", r)
+	}
+
+	// Plain email reuse also matches a contact that has an ext_id.
+	byEmail := newContact("bob@example.com", "", "B", "")
+	resolve(t, u, byEmail, models.ContactReuse)
+	if byEmail.ID != bob.ID {
+		t.Fatalf("expected email match of contact %d, got %d", bob.ID, byEmail.ID)
+	}
+
+	// An agent carrying the same external ID must never be resolved as the contact.
+	agentID := insertAgent(t, db, "agent@example.com", "ext-agent")
+	carol := newContact("carol@example.com", "ext-agent", "Carol", "")
+	resolve(t, u, carol, models.ContactReuse)
+	if carol.ID == agentID {
+		t.Fatalf("resolved an agent (%d) as a contact", agentID)
+	}
+	if r := fetchRow(t, db, carol.ID); r.Type != "contact" {
+		t.Fatalf("expected new contact, got %+v", r)
+	}
+
+	// An agent's email must never be resolved as the contact either.
+	agentEmail := newContact("agent@example.com", "", "NotAgent", "")
+	resolve(t, u, agentEmail, models.ContactReuse)
+	if agentEmail.ID == agentID {
+		t.Fatalf("resolved an agent (%d) as a contact by email", agentID)
+	}
+
+	// Soft-deleted contacts are not matched; a fresh contact is created.
+	dave := newContact("dave@example.com", "", "Dave", "")
+	resolve(t, u, dave, models.ContactReuse)
+	db.MustExec(`UPDATE users SET deleted_at = now() WHERE id = $1`, dave.ID)
+	dave2 := newContact("dave@example.com", "", "Dave", "")
+	resolve(t, u, dave2, models.ContactReuse)
+	if dave2.ID == dave.ID {
+		t.Fatalf("resolved a soft-deleted contact %d", dave.ID)
+	}
+}
+
+func TestResolveContactSync(t *testing.T) {
+	u, db := newTestManager(t)
+
+	// Creates a contact, normalizing the email to lowercase.
+	eve := newContact("EVE@Example.com", "", "Eve", "One")
+	resolve(t, u, eve, models.ContactSync)
+	if r := fetchRow(t, db, eve.ID); r.Email != "eve@example.com" {
+		t.Fatalf("expected normalized email, got %+v", r)
+	}
+
+	// Sync by email updates the name on the matched contact.
+	renamed := newContact("eve@example.com", "", "Eva", "Two")
+	resolve(t, u, renamed, models.ContactSync)
+	if renamed.ID != eve.ID {
+		t.Fatalf("expected match of contact %d, got %d", eve.ID, renamed.ID)
+	}
+	if r := fetchRow(t, db, eve.ID); r.FirstName != "Eva" || r.LastName != "Two" {
+		t.Fatalf("expected updated name, got %+v", r)
+	}
+
+	// Blank names do not clobber stored ones.
+	blank := newContact("eve@example.com", "", "", "")
+	resolve(t, u, blank, models.ContactSync)
+	if r := fetchRow(t, db, eve.ID); r.FirstName != "Eva" || r.LastName != "Two" {
+		t.Fatalf("blank names clobbered stored ones: %+v", r)
+	}
+
+	// Sync with an ext_id enriches the matched no-ext contact.
+	enrich := newContact("eve@example.com", "ext-eve", "Eva", "")
+	resolve(t, u, enrich, models.ContactSync)
+	if enrich.ID != eve.ID {
+		t.Fatalf("expected enrichment of contact %d, got %d", eve.ID, enrich.ID)
+	}
+	if r := fetchRow(t, db, eve.ID); r.ExtID != "ext-eve" {
+		t.Fatalf("expected enriched ext_id, got %+v", r)
+	}
+
+	// Sync by ext_id updates email and name.
+	updated := newContact("eve2@example.com", "ext-eve", "Evelyn", "Three")
+	resolve(t, u, updated, models.ContactSync)
+	if updated.ID != eve.ID {
+		t.Fatalf("expected ext_id match of contact %d, got %d", eve.ID, updated.ID)
+	}
+	if r := fetchRow(t, db, eve.ID); r.Email != "eve2@example.com" || r.FirstName != "Evelyn" {
+		t.Fatalf("expected updated email/name, got %+v", r)
+	}
+
+	// An empty email on an ext_id sync keeps the stored email.
+	noEmail := newContact("", "ext-eve", "Evelyn", "")
+	resolve(t, u, noEmail, models.ContactSync)
+	if r := fetchRow(t, db, eve.ID); r.Email != "eve2@example.com" {
+		t.Fatalf("empty email clobbered stored one: %+v", r)
+	}
+
+	// Sync without ext_id on an email owned by an ext_id contact reuses it without updating the name.
+	plain := newContact("eve2@example.com", "", "Someone", "Else")
+	resolve(t, u, plain, models.ContactSync)
+	if plain.ID != eve.ID {
+		t.Fatalf("expected reuse of ext_id contact %d, got %d", eve.ID, plain.ID)
+	}
+	if r := fetchRow(t, db, eve.ID); r.FirstName != "Evelyn" {
+		t.Fatalf("no-ext sync modified an ext_id contact: %+v", r)
+	}
+
+	// The same email with a different ext_id creates a second contact - one email can map to multiple external IDs.
+	other := newContact("eve2@example.com", "ext-other", "Other", "")
+	resolve(t, u, other, models.ContactSync)
+	if other.ID == eve.ID {
+		t.Fatalf("expected a second contact for a different ext_id, got the same one")
+	}
+	if n := countByEmail(t, db, "eve2@example.com"); n != 2 {
+		t.Fatalf("expected 2 contacts with the shared email, got %d", n)
+	}
+
+	// An ext_id already owned by another contact wins over an email-matched contact.
+	frank := newContact("frank@example.com", "", "Frank", "")
+	resolve(t, u, frank, models.ContactSync)
+	taken := newContact("frank@example.com", "ext-eve", "Franklin", "")
+	resolve(t, u, taken, models.ContactSync)
+	if taken.ID != eve.ID {
+		t.Fatalf("expected ext_id owner %d to win, got %d", eve.ID, taken.ID)
+	}
+	if r := fetchRow(t, db, frank.ID); r.ExtID != "" || r.FirstName != "Frank" {
+		t.Fatalf("email-matched contact was modified: %+v", r)
+	}
+
+	// An agent's email must never be matched.
+	agentID := insertAgent(t, db, "agent2@example.com", "")
+	notAgent := newContact("agent2@example.com", "", "NotAgent", "")
+	resolve(t, u, notAgent, models.ContactSync)
+	if notAgent.ID == agentID {
+		t.Fatalf("resolved an agent (%d) as a contact", agentID)
+	}
+	if r := fetchRow(t, db, agentID); r.FirstName != "Agent" {
+		t.Fatalf("sync modified an agent row: %+v", r)
+	}
+}
+
+func TestResolveContactConcurrent(t *testing.T) {
+	u, db := newTestManager(t)
+
+	race := func(policy models.ContactPolicy, email, extID string) {
+		t.Helper()
+		var (
+			wg  sync.WaitGroup
+			mu  sync.Mutex
+			ids = map[int]struct{}{}
+		)
+		for range 10 {
+			wg.Go(func() {
+				c := newContact(email, extID, "Race", "")
+				if err := u.ResolveContact(c, policy); err != nil {
+					t.Errorf("ResolveContact: %v", err)
+					return
+				}
+				mu.Lock()
+				ids[c.ID] = struct{}{}
+				mu.Unlock()
+			})
+		}
+		wg.Wait()
+		if len(ids) != 1 {
+			t.Fatalf("concurrent resolves produced %d distinct contacts: %v", len(ids), ids)
+		}
+		if n := countByEmail(t, db, email); n != 1 {
+			t.Fatalf("expected 1 contact with email %s, got %d", email, n)
+		}
+	}
+
+	race(models.ContactReuse, "race-reuse@example.com", "")
+	race(models.ContactReuse, "race-reuse-ext@example.com", "ext-race-reuse")
+	race(models.ContactSync, "race-sync@example.com", "")
+	race(models.ContactSync, "race-sync-ext@example.com", "ext-race-sync")
+}

--- a/internal/user/contact_test.go
+++ b/internal/user/contact_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/abhinavxd/libredesk/internal/user/models"
 	"github.com/jmoiron/sqlx"
 	"github.com/volatiletech/null/v9"
+	"github.com/zerodha/logf"
 )
 
 type userRow struct {
@@ -21,7 +22,8 @@ type userRow struct {
 func newTestManager(t *testing.T) (*Manager, *sqlx.DB) {
 	t.Helper()
 	db := testutil.NewDB(t, "user_contact")
-	mgr, err := New(testutil.NewI18n(t), Opts{DB: db, Lo: testutil.NewLogger(t)})
+	lo := logf.New(logf.Opts{})
+	mgr, err := New(testutil.NewI18n(t), Opts{DB: db, Lo: &lo})
 	if err != nil {
 		t.Fatalf("creating user manager: %v", err)
 	}
@@ -123,6 +125,16 @@ func TestResolveContactReuse(t *testing.T) {
 	}
 	if r := fetchRow(t, db, bob.ID); r.Email != "bob@example.com" {
 		t.Fatalf("reuse policy modified stored email: %+v", r)
+	}
+
+	// An unknown ext_id with an existing contact's email falls back to the email match instead of inserting a duplicate.
+	staleExt := newContact("alice@example.com", "ext-unknown", "A", "")
+	resolve(t, u, staleExt, models.ContactReuse)
+	if staleExt.ID != alice.ID {
+		t.Fatalf("expected email fallback to contact %d, got %d", alice.ID, staleExt.ID)
+	}
+	if n := countByEmail(t, db, "alice@example.com"); n != 1 {
+		t.Fatalf("unknown ext_id created a duplicate contact, got %d rows", n)
 	}
 
 	// Plain email reuse also matches a contact that has an ext_id.

--- a/internal/user/contact_test.go
+++ b/internal/user/contact_test.go
@@ -80,6 +80,16 @@ func insertAgent(t *testing.T, db *sqlx.DB, email, extID string) int {
 	return id
 }
 
+func insertVisitor(t *testing.T, db *sqlx.DB, email string) int {
+	t.Helper()
+	var id int
+	err := db.QueryRow(`INSERT INTO users (type, email, first_name) VALUES ('visitor', $1, 'Visitor') RETURNING id`, email).Scan(&id)
+	if err != nil {
+		t.Fatalf("inserting visitor: %v", err)
+	}
+	return id
+}
+
 func TestResolveContactReuse(t *testing.T) {
 	u, db := newTestManager(t)
 
@@ -170,6 +180,72 @@ func TestResolveContactReuse(t *testing.T) {
 	resolve(t, u, dave2, models.ContactReuse)
 	if dave2.ID == dave.ID {
 		t.Fatalf("resolved a soft-deleted contact %d", dave.ID)
+	}
+
+	stale2 := newContact("bob@example.com", "ext-unknown-2", "B", "")
+	resolve(t, u, stale2, models.ContactReuse)
+	if stale2.ID != bob.ID {
+		t.Fatalf("expected email fallback to contact %d, got %d", bob.ID, stale2.ID)
+	}
+	if r := fetchRow(t, db, bob.ID); r.ExtID != "ext-bob" {
+		t.Fatalf("email fallback modified the contact's ext_id: %+v", r)
+	}
+	if r := fetchRow(t, db, alice.ID); r.ExtID != "" {
+		t.Fatalf("earlier fallback wrote the unknown ext_id onto the contact: %+v", r)
+	}
+
+	shared := newContact("shared@example.com", "", "Plain", "")
+	resolve(t, u, shared, models.ContactSync)
+	sharedExt := newContact("shared2@example.com", "ext-shared", "Ext", "")
+	resolve(t, u, sharedExt, models.ContactSync)
+	moved := newContact("shared@example.com", "ext-shared", "Ext", "")
+	resolve(t, u, moved, models.ContactSync)
+	if moved.ID != sharedExt.ID || moved.ID == shared.ID {
+		t.Fatalf("setup: expected the ext contact to take the shared email, got %d", moved.ID)
+	}
+	for range 3 {
+		pick := newContact("shared@example.com", "", "P", "")
+		resolve(t, u, pick, models.ContactReuse)
+		if pick.ID != sharedExt.ID {
+			t.Fatalf("email match on a shared email is not deterministic: expected %d, got %d", sharedExt.ID, pick.ID)
+		}
+	}
+
+	gone := newContact("gone@example.com", "ext-gone", "Gone", "")
+	resolve(t, u, gone, models.ContactReuse)
+	db.MustExec(`UPDATE users SET deleted_at = now() WHERE id = $1`, gone.ID)
+	afterGone := newContact("alice@example.com", "ext-gone", "A", "")
+	resolve(t, u, afterGone, models.ContactReuse)
+	if afterGone.ID != alice.ID {
+		t.Fatalf("expected email fallback past the deleted ext_id owner to %d, got %d", alice.ID, afterGone.ID)
+	}
+
+	// A deleted contact's ext_id is reusable without a unique violation.
+	reborn := newContact("reborn@example.com", "ext-gone", "Reborn", "")
+	resolve(t, u, reborn, models.ContactReuse)
+	if reborn.ID == gone.ID {
+		t.Fatalf("resurrected the soft-deleted contact %d", gone.ID)
+	}
+	if r := fetchRow(t, db, reborn.ID); r.ExtID != "ext-gone" {
+		t.Fatalf("expected the freed ext_id on the new contact, got %+v", r)
+	}
+
+	anon := newContact("", "ext-anon", "Anon", "")
+	resolve(t, u, anon, models.ContactReuse)
+	anon2 := newContact("", "ext-anon", "Anon", "")
+	resolve(t, u, anon2, models.ContactReuse)
+	if anon2.ID != anon.ID {
+		t.Fatalf("email-less ext_id resolve duplicated the contact: %d vs %d", anon.ID, anon2.ID)
+	}
+
+	visitorID := insertVisitor(t, db, "visitor@example.com")
+	viaEmail := newContact("visitor@example.com", "", "V", "")
+	resolve(t, u, viaEmail, models.ContactReuse)
+	if viaEmail.ID == visitorID {
+		t.Fatalf("resolved a visitor (%d) as a contact", visitorID)
+	}
+	if r := fetchRow(t, db, viaEmail.ID); r.Type != "contact" {
+		t.Fatalf("expected a contact row, got %+v", r)
 	}
 }
 
@@ -268,6 +344,37 @@ func TestResolveContactSync(t *testing.T) {
 	}
 	if r := fetchRow(t, db, agentID); r.FirstName != "Agent" {
 		t.Fatalf("sync modified an agent row: %+v", r)
+	}
+
+	dead := newContact("dead@example.com", "", "Dead", "")
+	resolve(t, u, dead, models.ContactSync)
+	db.MustExec(`UPDATE users SET deleted_at = now() WHERE id = $1`, dead.ID)
+	fresh := newContact("dead@example.com", "", "Fresh", "")
+	resolve(t, u, fresh, models.ContactSync)
+	if fresh.ID == dead.ID {
+		t.Fatalf("sync resurrected the soft-deleted contact %d", dead.ID)
+	}
+
+	deadExt := newContact("deadext@example.com", "ext-dead", "Dead", "")
+	resolve(t, u, deadExt, models.ContactSync)
+	db.MustExec(`UPDATE users SET deleted_at = now() WHERE id = $1`, deadExt.ID)
+	freshExt := newContact("deadext2@example.com", "ext-dead", "Fresh", "")
+	resolve(t, u, freshExt, models.ContactSync)
+	if freshExt.ID == deadExt.ID {
+		t.Fatalf("sync resurrected the soft-deleted contact %d", deadExt.ID)
+	}
+	if r := fetchRow(t, db, freshExt.ID); r.ExtID != "ext-dead" || r.Email != "deadext2@example.com" {
+		t.Fatalf("expected the freed ext_id on a fresh contact, got %+v", r)
+	}
+
+	visitorID := insertVisitor(t, db, "visitor2@example.com")
+	viaEmail := newContact("visitor2@example.com", "ext-visitor", "V", "")
+	resolve(t, u, viaEmail, models.ContactSync)
+	if viaEmail.ID == visitorID {
+		t.Fatalf("resolved a visitor (%d) as a contact", visitorID)
+	}
+	if r := fetchRow(t, db, visitorID); r.ExtID != "" {
+		t.Fatalf("sync enriched a visitor row: %+v", r)
 	}
 }
 

--- a/internal/user/contact_test.go
+++ b/internal/user/contact_test.go
@@ -1,25 +1,13 @@
 package user
 
 import (
-	"fmt"
-	"net/url"
-	"os"
 	"sync"
 	"testing"
 
+	"github.com/abhinavxd/libredesk/internal/testutil"
 	"github.com/abhinavxd/libredesk/internal/user/models"
 	"github.com/jmoiron/sqlx"
-	"github.com/knadh/go-i18n"
 	"github.com/volatiletech/null/v9"
-	"github.com/zerodha/logf"
-
-	_ "github.com/lib/pq"
-)
-
-const (
-	testDBDSNEnv     = "LIBREDESK_TEST_DB_DSN"
-	testDBDefaultDSN = "postgres://libredesk:libredesk@127.0.0.1:5432/libredesk?sslmode=disable&connect_timeout=3"
-	testDBName       = "libredesk_contact_test"
 )
 
 type userRow struct {
@@ -30,49 +18,10 @@ type userRow struct {
 	Type      string
 }
 
-// newTestManager provisions a fresh test database with schema.sql applied and returns a Manager on it.
 func newTestManager(t *testing.T) (*Manager, *sqlx.DB) {
 	t.Helper()
-
-	dsn := os.Getenv(testDBDSNEnv)
-	if dsn == "" {
-		dsn = testDBDefaultDSN
-	}
-	admin, err := sqlx.Connect("postgres", dsn)
-	if err != nil {
-		t.Skipf("test database unreachable, set %s or start the dev postgres: %v", testDBDSNEnv, err)
-	}
-	defer admin.Close()
-
-	admin.MustExec(`SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1`, testDBName)
-	admin.MustExec(fmt.Sprintf(`DROP DATABASE IF EXISTS %s`, testDBName))
-	admin.MustExec(fmt.Sprintf(`CREATE DATABASE %s`, testDBName))
-
-	u, err := url.Parse(dsn)
-	if err != nil {
-		t.Fatalf("parsing test DSN: %v", err)
-	}
-	u.Path = "/" + testDBName
-	db, err := sqlx.Connect("postgres", u.String())
-	if err != nil {
-		t.Fatalf("connecting to test database: %v", err)
-	}
-	t.Cleanup(func() { db.Close() })
-
-	schema, err := os.ReadFile("../../schema.sql")
-	if err != nil {
-		t.Fatalf("reading schema.sql: %v", err)
-	}
-	if _, err := db.Exec(string(schema)); err != nil {
-		t.Fatalf("applying schema.sql: %v", err)
-	}
-
-	i18nMgr, err := i18n.NewFromFile("../../i18n/en-US.json")
-	if err != nil {
-		t.Fatalf("loading i18n: %v", err)
-	}
-	lo := logf.New(logf.Opts{})
-	mgr, err := New(i18nMgr, Opts{DB: db, Lo: &lo})
+	db := testutil.NewDB(t, "user_contact")
+	mgr, err := New(testutil.NewI18n(t), Opts{DB: db, Lo: testutil.NewLogger(t)})
 	if err != nil {
 		t.Fatalf("creating user manager: %v", err)
 	}

--- a/internal/user/models/models.go
+++ b/internal/user/models/models.go
@@ -32,6 +32,16 @@ const (
 	AwayAndReassigning = "away_and_reassigning"
 )
 
+// ContactPolicy controls whether contact resolution may modify a matched contact.
+type ContactPolicy int
+
+const (
+	// ContactReuse resolves to the existing contact without modifying it.
+	ContactReuse ContactPolicy = iota
+	// ContactSync also updates name/email and enriches external_user_id on a match.
+	ContactSync
+)
+
 type UserCompact struct {
 	ID                 int         `db:"id" json:"id"`
 	Type               string      `db:"type" json:"type"`

--- a/internal/user/queries.sql
+++ b/internal/user/queries.sql
@@ -187,6 +187,12 @@ DO UPDATE SET first_name = COALESCE(NULLIF(EXCLUDED.first_name, ''), users.first
               updated_at = now()
 RETURNING id;
 
+-- name: insert-contact-if-absent
+INSERT INTO users (email, type, first_name, last_name, "password", avatar_url, external_user_id, custom_attributes)
+VALUES ($1, 'contact', $2, $3, $4, $5, $6, $7)
+ON CONFLICT DO NOTHING
+RETURNING id;
+
 -- name: get-contact-by-email
 SELECT id, external_user_id FROM users
 WHERE email = $1 AND type = 'contact' AND deleted_at IS NULL

--- a/internal/user/queries.sql
+++ b/internal/user/queries.sql
@@ -381,6 +381,7 @@ LEFT JOIN roles r ON r.id = ur.role_id
 LEFT JOIN LATERAL unnest(r.permissions) AS p ON true
 WHERE u.deleted_at IS NULL
     AND u.external_user_id = $1
+    AND u.type = 'contact'
 GROUP BY u.id;
 
 -- name: get-visitor-by-email

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -100,6 +100,7 @@ type queries struct {
 	InsertAgent                   *sqlx.Stmt `query:"insert-agent"`
 	InsertContactWithExtID        *sqlx.Stmt `query:"insert-contact-with-external-id"`
 	InsertContactNoExtID          *sqlx.Stmt `query:"insert-contact-without-external-id"`
+	InsertContactIfAbsent         *sqlx.Stmt `query:"insert-contact-if-absent"`
 	GetContactByEmail             *sqlx.Stmt `query:"get-contact-by-email"`
 	GetContactByEmailWithoutExtID *sqlx.Stmt `query:"get-contact-by-email-without-ext-id"`
 	IsEmailBlocked                *sqlx.Stmt `query:"is-email-blocked"`

--- a/internal/user/user.go
+++ b/internal/user/user.go
@@ -206,8 +206,8 @@ func (u *Manager) GetSystemUser() (models.User, error) {
 	return u.Get(0, models.SystemUserEmail, []string{models.UserTypeAgent})
 }
 
-// GetByExternalID retrieves a user by external user ID.
-func (u *Manager) GetByExternalID(externalUserID string) (models.User, error) {
+// GetContactByExternalID retrieves a contact by external user ID.
+func (u *Manager) GetContactByExternalID(externalUserID string) (models.User, error) {
 	var user models.User
 	if err := u.q.GetUserByExternalID.Get(&user, externalUserID); err != nil {
 		if err == sql.ErrNoRows {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact matching during conversation creation using external IDs or email addresses.
  * Prevented duplicate contacts when an existing match is found, including during concurrent requests.
  * Contact handling now respects authorization settings and returns consistent errors for access or resolution failures.
  * Preserved stored contact details when reusing contacts matched by external ID.
  * Included external contact IDs when starting conversations from a selected contact.
* **Tests**
  * Added database-backed coverage for contact reuse, synchronization, matching, and concurrency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->