### PR TITLE
preserve unicode in attachment filenames and escape MIME headers properly

### DIFF
--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"mime"
 	"slices"
 	"strconv"
 	"strings"
@@ -357,7 +358,7 @@ func handleDownloadConversationTranscript(r *fastglue.Request) error {
 	transcript := app.conversation.BuildTranscript(*conversation, messages, time.Now())
 	safeRef := stringutil.SanitizeFilename(conversation.ReferenceNumber)
 	filename := fmt.Sprintf("transcript-%s.txt", safeRef)
-	r.RequestCtx.Response.Header.Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, filename))
+	r.RequestCtx.Response.Header.Set("Content-Disposition", mime.FormatMediaType("attachment", map[string]string{"filename": filename}))
 	r.RequestCtx.Response.Header.Set("X-Content-Type-Options", "nosniff")
 	r.RequestCtx.SetContentType("text/plain; charset=utf-8")
 	r.RequestCtx.SetBody(transcript)

--- a/cmd/media.go
+++ b/cmd/media.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/http"
 	"path/filepath"
 	"strings"
@@ -231,7 +232,7 @@ func serveMediaFile(r *fastglue.Request, app *App, uuid string, media *mmodels.M
 		}
 
 		r.RequestCtx.Response.Header.Set("Content-Type", media.ContentType)
-		r.RequestCtx.Response.Header.Set("Content-Disposition", fmt.Sprintf(`%s; filename="%s"`, disposition, media.Filename))
+		r.RequestCtx.Response.Header.Set("Content-Disposition", mime.FormatMediaType(disposition, map[string]string{"filename": media.Filename}))
 		r.RequestCtx.Response.Header.Set("X-Content-Type-Options", "nosniff")
 
 		fasthttp.ServeFile(r.RequestCtx, filepath.Join(ko.String("upload.fs.upload_path"), uuid))

--- a/internal/attachment/attachment.go
+++ b/internal/attachment/attachment.go
@@ -3,6 +3,7 @@ package attachment
 import (
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/textproto"
 )
 
@@ -64,10 +65,16 @@ func MakeHeader(contentType, contentID, fileName, encoding, disposition string) 
 		h.Set("Content-Disposition", "inline")
 		h.Set("Content-ID", "<"+contentID+">")
 	} else {
-		h.Set("Content-Disposition", fmt.Sprintf("%s; filename=\"%s\"", disposition, fileName))
+		h.Set("Content-Disposition", mime.FormatMediaType(disposition, map[string]string{"filename": fileName}))
 	}
 
-	h.Set("Content-Type", fmt.Sprintf("%s; name=\"%s\"", contentType, fileName))
+	// Round-trip through ParseMediaType so existing params (e.g. charset) survive alongside name.
+	if mt, params, err := mime.ParseMediaType(contentType); err == nil {
+		params["name"] = fileName
+		h.Set("Content-Type", mime.FormatMediaType(mt, params))
+	} else {
+		h.Set("Content-Type", contentType)
+	}
 	h.Set("Content-Transfer-Encoding", encoding)
 
 	return h

--- a/internal/attachment/attachment_test.go
+++ b/internal/attachment/attachment_test.go
@@ -26,7 +26,7 @@ func TestMakeHeader(t *testing.T) {
 			want: textproto.MIMEHeader{
 				"Content-Disposition":       []string{"inline"},
 				"Content-Id":                []string{"<123>"},
-				"Content-Type":              []string{"image/jpeg; name=\"test.jpg\""},
+				"Content-Type":              []string{"image/jpeg; name=test.jpg"},
 				"Content-Transfer-Encoding": []string{"base64"},
 			},
 		},
@@ -38,8 +38,21 @@ func TestMakeHeader(t *testing.T) {
 			encoding:    "base64",
 			disposition: "attachment",
 			want: textproto.MIMEHeader{
-				"Content-Disposition":       []string{"attachment; filename=\"doc.pdf\""},
-				"Content-Type":              []string{"application/pdf; name=\"doc.pdf\""},
+				"Content-Disposition":       []string{"attachment; filename=doc.pdf"},
+				"Content-Type":              []string{"application/pdf; name=doc.pdf"},
+				"Content-Transfer-Encoding": []string{"base64"},
+			},
+		},
+		{
+			name:        "content type with params keeps them",
+			contentType: "text/plain; charset=utf-8",
+			contentID:   "",
+			fileName:    "notes.txt",
+			encoding:    "base64",
+			disposition: "attachment",
+			want: textproto.MIMEHeader{
+				"Content-Disposition":       []string{"attachment; filename=notes.txt"},
+				"Content-Type":              []string{"text/plain; charset=utf-8; name=notes.txt"},
 				"Content-Transfer-Encoding": []string{"base64"},
 			},
 		},
@@ -51,8 +64,8 @@ func TestMakeHeader(t *testing.T) {
 			encoding:    "",
 			disposition: "",
 			want: textproto.MIMEHeader{
-				"Content-Disposition":       []string{"attachment; filename=\"file.txt\""},
-				"Content-Type":              []string{"application/octet-stream; name=\"file.txt\""},
+				"Content-Disposition":       []string{"attachment; filename=file.txt"},
+				"Content-Type":              []string{"application/octet-stream; name=file.txt"},
 				"Content-Transfer-Encoding": []string{"base64"},
 			},
 		},

--- a/internal/media/stores/s3/s3.go
+++ b/internal/media/stores/s3/s3.go
@@ -5,6 +5,7 @@ package s3
 import (
 	"fmt"
 	"io"
+	"mime"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -96,7 +97,7 @@ func (c *Client) GetURL(name string, disposition, fileName string) string {
 			Method:                     "GET",
 			Timestamp:                  time.Now(),
 			ExpirySeconds:              int(c.opts.Expiry.Seconds()),
-			ResponseContentDisposition: fmt.Sprintf("%s; filename=\"%s\"", disposition, fileName),
+			ResponseContentDisposition: mime.FormatMediaType(disposition, map[string]string{"filename": fileName}),
 		})
 		return u
 	}

--- a/internal/stringutil/stringutil.go
+++ b/internal/stringutil/stringutil.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"net/mail"
-	"path/filepath"
+	"path"
 	"regexp"
 	"strings"
 	"time"
@@ -21,11 +21,11 @@ const (
 )
 
 var (
-	regexpNonAlNum  = regexp.MustCompile(`[^a-zA-Z0-9\-_\.]+`)
-	regexpSpaces    = regexp.MustCompile(`[\s]+`)
-	uuidV4Regex     = regexp.MustCompile(`[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}`)
-	regexpRefNumber = regexp.MustCompile(`#(\d+)`)
-	regexpConvUUID  = regexp.MustCompile(`(?i)\+conv-[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}@`)
+	regexpUnsafeFileChars = regexp.MustCompile(`[\x00-\x1f\x7f\x{80}-\x{9f}]+`)
+	regexpSpaces          = regexp.MustCompile(`[\s]+`)
+	uuidV4Regex           = regexp.MustCompile(`[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}`)
+	regexpRefNumber       = regexp.MustCompile(`#(\d+)`)
+	regexpConvUUID        = regexp.MustCompile(`(?i)\+conv-[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}@`)
 
 	// markdownRenderer escapes raw HTML in the input; single newlines render as <br>.
 	markdownRenderer = goldmark.New(
@@ -57,20 +57,16 @@ func Markdown2HTML(md string) string {
 	return b.String()
 }
 
-// SanitizeFilename sanitizes the provided filename.
+// SanitizeFilename removes control characters and path separators, preserving Unicode.
 func SanitizeFilename(fName string) string {
-	// Trim whitespace.
-	name := strings.TrimSpace(fName)
-
-	// Replace whitespace and "/" with "-"
+	name := strings.TrimSpace(SanitizeUTF8(fName))
+	name = path.Base(strings.ReplaceAll(name, `\`, "/"))
 	name = regexpSpaces.ReplaceAllString(name, "-")
-
-	// Remove or replace any non-alphanumeric characters
-	name = regexpNonAlNum.ReplaceAllString(name, "")
-
-	// Convert to lowercase
-	name = strings.ToLower(name)
-	return filepath.Base(name)
+	name = regexpUnsafeFileChars.ReplaceAllString(name, "")
+	if name == "" || name == "." || name == ".." || name == "/" {
+		return "attachment"
+	}
+	return name
 }
 
 // RandomAlphanumeric generates a random alphanumeric string of length n.

--- a/internal/stringutil/stringutil_test.go
+++ b/internal/stringutil/stringutil_test.go
@@ -271,6 +271,40 @@ func TestSanitizeUTF8(t *testing.T) {
 	}
 }
 
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain ascii", "report.pdf", "report.pdf"},
+		{"case preserved", "Report.PDF", "Report.PDF"},
+		{"cyrillic preserved", "Документ_Иванов.pdf", "Документ_Иванов.pdf"},
+		{"chinese with space", "报告 2024.xlsx", "报告-2024.xlsx"},
+		{"spaces collapse to hyphen", "my  file name.txt", "my-file-name.txt"},
+		{"path traversal", "../../etc/passwd", "passwd"},
+		{"windows path stripped to base name", `dir\sub\file.txt`, "file.txt"},
+		{"control chars stripped", "a\r\nb\x00c.pdf", "a-bc.pdf"},
+		{"empty", "", "attachment"},
+		{"whitespace only", "   ", "attachment"},
+		{"dot only", ".", "attachment"},
+		{"dot dot", "..", "attachment"},
+		{"slash only", "/", "attachment"},
+		{"slashes only", "///", "attachment"},
+		{"backslash only", `\`, "attachment"},
+		{"c1 control stripped", "a\u0085b.pdf", "ab.pdf"},
+		{"invalid utf8 replaced", "rapport\xe9.pdf", "rapport�.pdf"},
+		{"emoji preserved", "photo😀.jpg", "photo😀.jpg"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SanitizeFilename(tt.input); got != tt.expected {
+				t.Errorf("SanitizeFilename(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestSplitName(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION


Fixes #483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved downloaded transcript and media filenames, including safer handling of special characters, whitespace, Unicode, and path separators.
  * Preserved existing media type parameters when adding attachment filenames.
  * Corrected filename encoding in downloads and presigned media links.
* **Tests**
  * Added coverage for filename sanitization, fallback names, Unicode, invalid characters, and media type parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->