### PR TITLE
hide the ai generate reply button in the create conversation form

### DIFF
--- a/frontend/apps/main/src/features/conversation/CreateConversation.vue
+++ b/frontend/apps/main/src/features/conversation/CreateConversation.vue
@@ -243,6 +243,7 @@
               :handleFileUpload="handleFileUpload"
               @emojiSelect="handleEmojiSelect"
               :showSendButton="false"
+              :showGenerateReply="false"
             />
             <Button type="submit" :disabled="isDisabled" :isLoading="loading">
               {{ $t('globals.messages.submit') }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the reply-generation control from the new-conversation dialog for a cleaner conversation setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->