### PR TITLE
feat: add recipient filter to automation rules

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -284,7 +284,7 @@ func handleChatInit(r *fastglue.Request) error {
 	}
 
 	// Process post-message hooks for the new conversation and initial message.
-	if err := app.conversation.ProcessIncomingMessageHooks(conversationUUID, true); err != nil {
+	if err := app.conversation.ProcessIncomingMessageHooks(conversationUUID, true, nil); err != nil {
 		app.lo.Error("error processing incoming message hooks for initial message", "conversation_uuid", conversationUUID, "error", err)
 	}
 

--- a/cmd/custom_attributes.go
+++ b/cmd/custom_attributes.go
@@ -14,6 +14,7 @@ var (
 	// disallowedKeys contains keys that are not allowed for custom attributes as they're the default fields.
 	disallowedKeys = []string{
 		"contact_email",
+		"to",
 		"content",
 		"subject",
 		"status",

--- a/frontend/apps/main/src/composables/useConversationFilters.js
+++ b/frontend/apps/main/src/composables/useConversationFilters.js
@@ -166,6 +166,11 @@ export function useConversationFilters () {
             type: FIELD_TYPE.TEXT,
             operators: FIELD_OPERATORS.TEXT_AUTOMATION
         },
+        to: {
+            label: t('globals.terms.toEmailAddress'),
+            type: FIELD_TYPE.TEXT,
+            operators: FIELD_OPERATORS.TEXT
+        },
         content: {
             label: t('globals.terms.content'),
             type: FIELD_TYPE.TEXT,
@@ -209,6 +214,11 @@ export function useConversationFilters () {
     }))
 
     const conversationFilters = computed(() => ({
+        to: {
+            label: t('globals.terms.toEmailAddress'),
+            type: FIELD_TYPE.TEXT,
+            operators: FIELD_OPERATORS.TEXT
+        },
         status: {
             label: t('globals.terms.status'),
             type: FIELD_TYPE.SELECT,

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -936,6 +936,7 @@
   "globals.terms.firstName": "First name | First names",
   "globals.terms.firstReplyAt": "First reply at",
   "globals.terms.fromEmailAddress": "From email address | From email addresses",
+  "globals.terms.toEmailAddress": "To email address | To email addresses",
   "globals.terms.general": "General",
   "globals.terms.good": "Good",
   "globals.terms.google": "Google",

--- a/internal/automation/evaluator.go
+++ b/internal/automation/evaluator.go
@@ -103,8 +103,6 @@ func (e *Engine) evaluateGroup(rules []models.RuleDetail, operator string, conve
 func (e *Engine) evaluateRule(rule models.RuleDetail, conversation cmodels.Conversation, previousValues map[string]string) bool {
 	var (
 		valueToCompare   string
-		ruleValues       []string
-		conditionMet     bool
 		customAttributes map[string]any
 	)
 
@@ -160,6 +158,8 @@ func (e *Engine) evaluateRule(rule models.RuleDetail, conversation cmodels.Conve
 				return false
 			}
 			valueToCompare = previous
+		case models.ConversationIncomingTo:
+			return evaluateStringValues(conversation.IncomingTo, rule)
 		default:
 			e.lo.Error("error unrecognized conversation field", "field", rule.Field, "field_type", rule.FieldType, "conversation_uuid", conversation.UUID)
 			return false
@@ -200,103 +200,82 @@ func (e *Engine) evaluateRule(rule models.RuleDetail, conversation cmodels.Conve
 		return false
 	}
 
-	// Case sensitive match?
-	if !rule.CaseSensitiveMatch {
-		valueToCompare = strings.ToLower(valueToCompare)
-		rule.Value = strings.ToLower(rule.Value)
-	}
-
-	// Split and trim values for Contains/NotContains operations
-	if rule.Operator == models.RuleOperatorContains || rule.Operator == models.RuleOperatorNotContains {
-		ruleValues = strings.Split(rule.Value, ",")
-		for i := range ruleValues {
-			ruleValues[i] = strings.TrimSpace(ruleValues[i])
-			if !rule.CaseSensitiveMatch {
-				ruleValues[i] = strings.ToLower(ruleValues[i])
-			}
-		}
-	}
-
-	e.lo.Debug("evaluating rule", "rule_field", rule.Field, "rule_operator", rule.Operator,
-		"rule_value", rule.Value, "rule_values", ruleValues, "value_to_compare",
-		valueToCompare, "conversation_uuid", conversation.UUID)
-
-	// Compare with set operator
-	switch rule.Operator {
-	case models.RuleOperatorEquals:
-		conditionMet = valueToCompare == rule.Value
-	case models.RuleOperatorNotEqual:
-		conditionMet = valueToCompare != rule.Value
-	case models.RuleOperatorContains:
-		// Normalize input text by collapsing multiple spaces
-		normalizedInputText := strings.Join(strings.Fields(valueToCompare), " ")
-		conditionMet = false
-
-		// Check each rule value against the normalized input
-		for _, ruleValue := range ruleValues {
-			// Normalize rule value by collapsing multiple spaces
-			normalizedRuleValue := strings.Join(strings.Fields(ruleValue), " ")
-
-			// Respect CaseSensitiveMatch flag
-			if rule.CaseSensitiveMatch {
-				if strings.Contains(normalizedInputText, normalizedRuleValue) {
-					conditionMet = true
-					break
-				}
-			} else {
-				if strings.Contains(
-					strings.ToLower(normalizedInputText),
-					strings.ToLower(normalizedRuleValue),
-				) {
-					conditionMet = true
-					break
-				}
-			}
-		}
-	case models.RuleOperatorNotContains:
-		// Normalize input text by collapsing multiple spaces
-		normalizedInputText := strings.Join(strings.Fields(valueToCompare), " ")
-		conditionMet = true
-
-		// Check each rule value against the normalized input
-		for _, ruleValue := range ruleValues {
-			// Normalize rule value by collapsing multiple spaces
-			normalizedRuleValue := strings.Join(strings.Fields(ruleValue), " ")
-
-			// Respect CaseSensitiveMatch flag
-			if rule.CaseSensitiveMatch {
-				if strings.Contains(normalizedInputText, normalizedRuleValue) {
-					conditionMet = false
-					break
-				}
-			} else {
-				if strings.Contains(
-					strings.ToLower(normalizedInputText),
-					strings.ToLower(normalizedRuleValue),
-				) {
-					conditionMet = false
-					break
-				}
-			}
-		}
-	case models.RuleOperatorSet:
-		conditionMet = len(valueToCompare) > 0
-	case models.RuleOperatorNotSet:
-		conditionMet = len(valueToCompare) == 0
-	case models.RuleOperatorGreaterThan:
-		value1, _ := strconv.Atoi(valueToCompare)
-		value2, _ := strconv.Atoi(rule.Value)
-		conditionMet = value1 > value2
-	case models.RuleOperatorLessThan:
-		value1, _ := strconv.Atoi(valueToCompare)
-		value2, _ := strconv.Atoi(rule.Value)
-		conditionMet = value1 < value2
-	case models.RuleOperatorStartsWith:
-		conditionMet = strings.HasPrefix(valueToCompare, rule.Value)
-	default:
-		e.lo.Error("error unrecognized rule logical operator", "operator", rule.Operator)
-		return false
-	}
+	conditionMet := evaluateValue(valueToCompare, rule)
 	e.lo.Debug("conversation automation rule status", "has_met", conditionMet, "conversation_uuid", conversation.UUID)
 	return conditionMet
+}
+
+// evaluateValue compares one field value against a rule.
+func evaluateValue(value string, rule models.RuleDetail) bool {
+	left, right := value, rule.Value
+	if !rule.CaseSensitiveMatch {
+		left, right = strings.ToLower(left), strings.ToLower(right)
+	}
+
+	switch rule.Operator {
+	case models.RuleOperatorEquals:
+		return left == right
+	case models.RuleOperatorNotEqual:
+		return left != right
+	case models.RuleOperatorContains, models.RuleOperatorNotContains:
+		left = strings.Join(strings.Fields(left), " ")
+		matches := false
+		for _, ruleValue := range strings.Split(right, ",") {
+			ruleValue = strings.Join(strings.Fields(ruleValue), " ")
+			if strings.Contains(left, ruleValue) {
+				matches = true
+				break
+			}
+		}
+		return matches == (rule.Operator == models.RuleOperatorContains)
+	case models.RuleOperatorSet:
+		return len(value) > 0
+	case models.RuleOperatorNotSet:
+		return len(value) == 0
+	case models.RuleOperatorGreaterThan:
+		value1, _ := strconv.Atoi(value)
+		value2, _ := strconv.Atoi(rule.Value)
+		return value1 > value2
+	case models.RuleOperatorLessThan:
+		value1, _ := strconv.Atoi(value)
+		value2, _ := strconv.Atoi(rule.Value)
+		return value1 < value2
+	case models.RuleOperatorStartsWith:
+		return strings.HasPrefix(left, right)
+	default:
+		return false
+	}
+}
+
+// evaluateStringValues compares a rule against a multi-value field such as email recipients.
+// Positive operators match any value; negative operators require every value to differ.
+func evaluateStringValues(values []string, rule models.RuleDetail) bool {
+	nonEmptyValues := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			nonEmptyValues = append(nonEmptyValues, value)
+		}
+	}
+	values = nonEmptyValues
+
+	if rule.Operator == models.RuleOperatorSet {
+		return len(values) > 0
+	}
+	if rule.Operator == models.RuleOperatorNotSet {
+		return len(values) == 0
+	}
+
+	negative := rule.Operator == models.RuleOperatorNotEqual || rule.Operator == models.RuleOperatorNotContains
+	if rule.Operator == models.RuleOperatorNotEqual {
+		rule.Operator = models.RuleOperatorEquals
+	} else if rule.Operator == models.RuleOperatorNotContains {
+		rule.Operator = models.RuleOperatorContains
+	}
+
+	for _, value := range values {
+		if evaluateValue(value, rule) {
+			return !negative
+		}
+	}
+	return negative
 }

--- a/internal/automation/models/models.go
+++ b/internal/automation/models/models.go
@@ -54,6 +54,7 @@ const (
 	ConversationHoursSinceLastReply  = "hours_since_last_reply"
 	ConversationHoursSinceResolved   = "hours_since_resolved"
 	ConversationInbox                = "inbox"
+	ConversationIncomingTo           = "to"
 	ContactEmail                     = "contact_email"
 
 	ConversationPreviousStatus       = "previous_status"

--- a/internal/automation/recipient_test.go
+++ b/internal/automation/recipient_test.go
@@ -1,0 +1,69 @@
+package automation
+
+import (
+	"testing"
+
+	"github.com/abhinavxd/libredesk/internal/automation/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluateStringValuesEmailRecipients(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		rule   models.RuleDetail
+		want   bool
+	}{
+		{
+			name:   "equals any recipient case insensitively",
+			values: []string{"support@example.com", "foundation@zerya.dev"},
+			rule:   models.RuleDetail{Operator: models.RuleOperatorEquals, Value: "FOUNDATION@ZERYA.DEV"},
+			want:   true,
+		},
+		{
+			name:   "not equals requires all recipients to differ",
+			values: []string{"support@example.com", "foundation@zerya.dev"},
+			rule:   models.RuleDetail{Operator: models.RuleOperatorNotEqual, Value: "foundation@zerya.dev"},
+			want:   false,
+		},
+		{
+			name:   "contains matches any configured fragment",
+			values: []string{"foundation@zerya.dev"},
+			rule:   models.RuleDetail{Operator: models.RuleOperatorContains, Value: "example.org, @zerya.dev"},
+			want:   true,
+		},
+		{
+			name:   "case sensitive match is respected",
+			values: []string{"foundation@zerya.dev"},
+			rule: models.RuleDetail{
+				Operator:           models.RuleOperatorEquals,
+				Value:              "Foundation@zerya.dev",
+				CaseSensitiveMatch: true,
+			},
+			want: false,
+		},
+		{
+			name:   "set requires at least one recipient",
+			values: []string{"foundation@zerya.dev"},
+			rule:   models.RuleDetail{Operator: models.RuleOperatorSet},
+			want:   true,
+		},
+		{
+			name: "not set matches missing recipients",
+			rule: models.RuleDetail{Operator: models.RuleOperatorNotSet},
+			want: true,
+		},
+		{
+			name:   "empty recipients are not set",
+			values: []string{"", "  "},
+			rule:   models.RuleDetail{Operator: models.RuleOperatorNotSet},
+			want:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, evaluateStringValues(tt.values, tt.rule))
+		})
+	}
+}

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -1377,7 +1377,10 @@ func (m *Manager) ProcessIncomingMessageHooks(conversationUUID string, isNewConv
 		conversation, err := m.GetConversation(0, conversationUUID, "")
 		if err == nil {
 			conversation.IncomingTo = incomingTo
-			m.webhookStore.TriggerEvent(wmodels.EventConversationCreated, conversation)
+			m.webhookStore.TriggerEvent(wmodels.EventConversationCreated, struct {
+				models.Conversation
+				To []string `json:"to"`
+			}{Conversation: conversation, To: conversation.IncomingTo})
 			m.automation.EvaluateNewConversationRules(conversation)
 		}
 		return nil

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -489,7 +489,7 @@ func (m *Manager) CreateContactMessage(media []mmodels.Media, contactID int, con
 	}
 
 	// Process post-message hooks (reopen, waiting since, automation, SLA).
-	if err := m.ProcessIncomingMessageHooks(conversationUUID, isNewConversation); err != nil {
+	if err := m.ProcessIncomingMessageHooks(conversationUUID, isNewConversation, nil); err != nil {
 		m.lo.Error("error processing incoming message hooks", "conversation_uuid", conversationUUID, "error", err)
 	}
 
@@ -869,7 +869,13 @@ func (m *Manager) ProcessIncomingMessage(in models.IncomingMessage) (models.Mess
 	m.broadcastMessageToWidgetClients(&msg)
 
 	// Process post-message hooks (automation rules, webhooks, SLA, etc.).
-	if err := m.ProcessIncomingMessageHooks(msg.ConversationUUID, isNewConversation); err != nil {
+	var recipients struct {
+		To []string `json:"to"`
+	}
+	if err := json.Unmarshal(msg.Meta, &recipients); err != nil {
+		m.lo.Warn("error reading incoming message recipients", "conversation_uuid", msg.ConversationUUID, "error", err)
+	}
+	if err := m.ProcessIncomingMessageHooks(msg.ConversationUUID, isNewConversation, recipients.To); err != nil {
 		m.lo.Error("error processing incoming message hooks", "conversation_uuid", msg.ConversationUUID, "error", err)
 		return models.Message{}, fmt.Errorf("processing incoming message hooks: %w", err)
 	}
@@ -991,7 +997,7 @@ func (m *Manager) ProcessIncomingLiveChatMessage(msg models.Message) (models.Mes
 
 	// Process post-message hooks (automation rules, webhooks, SLA, etc.).
 	// isNewConversation = false since conversation always exists for live chat.
-	if err := m.ProcessIncomingMessageHooks(msg.ConversationUUID, false); err != nil {
+	if err := m.ProcessIncomingMessageHooks(msg.ConversationUUID, false, nil); err != nil {
 		m.lo.Error("error processing incoming message hooks", "conversation_uuid", msg.ConversationUUID, "error", err)
 	}
 
@@ -1361,7 +1367,7 @@ func (m *Manager) uploadThumbnailForMedia(media mmodels.Media, content []byte) e
 // ProcessIncomingMessageHooks handles automation rules, webhooks, SLA events, and other post-processing
 // for incoming messages. This allows other channels to insert messages first and then call this
 // function to trigger the necessary hooks.
-func (m *Manager) ProcessIncomingMessageHooks(conversationUUID string, isNewConversation bool) error {
+func (m *Manager) ProcessIncomingMessageHooks(conversationUUID string, isNewConversation bool, incomingTo []string) error {
 	// Start waiting since clock, cleared when agent replies.
 	now := time.Now()
 	m.UpdateConversationWaitingSince(conversationUUID, &now)
@@ -1370,6 +1376,7 @@ func (m *Manager) ProcessIncomingMessageHooks(conversationUUID string, isNewConv
 	if isNewConversation {
 		conversation, err := m.GetConversation(0, conversationUUID, "")
 		if err == nil {
+			conversation.IncomingTo = incomingTo
 			m.webhookStore.TriggerEvent(wmodels.EventConversationCreated, conversation)
 			m.automation.EvaluateNewConversationRules(conversation)
 		}
@@ -1398,6 +1405,7 @@ func (m *Manager) ProcessIncomingMessageHooks(conversationUUID string, isNewConv
 	if err != nil {
 		m.lo.Error("error fetching conversation for incoming message hooks", "conversation_uuid", conversationUUID, "error", err)
 	} else {
+		conversation.IncomingTo = incomingTo
 		// Trigger automations on incoming message event.
 		if previousValues == nil {
 			previousValues = amodels.PreviousValues(conversation)

--- a/internal/conversation/models/models.go
+++ b/internal/conversation/models/models.go
@@ -185,6 +185,7 @@ type Conversation struct {
 	InboxChannel              string                 `db:"inbox_channel" json:"inbox_channel"`
 	Tags                      null.JSON              `db:"tags" json:"tags"`
 	Meta                      json.RawMessage        `db:"meta" json:"meta"`
+	IncomingTo                []string               `db:"-" json:"-"`
 	CustomAttributes          json.RawMessage        `db:"custom_attributes" json:"custom_attributes"`
 	LastMessageAt             null.Time              `db:"last_message_at" json:"last_message_at"`
 	LastMessage               null.String            `db:"last_message" json:"last_message"`


### PR DESCRIPTION
Basically, there may be cases where you have a single inbox but use services like Cloudflare Email Routing, causing emails sent to multiple addresses to end up in the same inbox. Adding this configuration option allows you to filter those emails accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “To email address” conversation filter with standard text-based filtering.
  - Automation rules can evaluate incoming message recipients using matching, containment, and set/not-set conditions.
  - Incoming conversation data now retains recipient addresses for filtering and automation workflows.

- **Updates**
  - Reserved “to” as a system field, preventing its use as a custom attribute key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->