### PR TITLE
feat(auth): add SSO-only login mode

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,8 +4,27 @@ import (
 	"encoding/json"
 
 	"github.com/abhinavxd/libredesk/internal/envelope"
+	oidcmodels "github.com/abhinavxd/libredesk/internal/oidc/models"
 	"github.com/zerodha/fastglue"
 )
+
+const localLoginEnabledKey = "auth.local_login_enabled"
+
+// isLocalLoginEnabled keeps local login available by default and whenever no
+// OIDC provider is enabled, preventing an administrator from locking everyone out.
+func isLocalLoginEnabled(providers []oidcmodels.OIDC) bool {
+	if !ko.Exists(localLoginEnabledKey) || ko.Bool(localLoginEnabledKey) {
+		return true
+	}
+
+	for _, provider := range providers {
+		if provider.Enabled {
+			return false
+		}
+	}
+
+	return true
+}
 
 // handleGetConfig returns the public configuration needed for app initialization, this includes minimal app settings and enabled SSO providers (without secrets).
 func handleGetConfig(r *fastglue.Request) error {
@@ -58,6 +77,7 @@ func handleGetConfig(r *fastglue.Request) error {
 
 	// Add SSO providers to the response
 	publicSettings["app.sso_providers"] = enabledProviders
+	publicSettings["app.local_login_enabled"] = isLocalLoginEnabled(oidcProviders)
 
 	return r.SendEnvelope(publicSettings)
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -70,7 +70,6 @@ func localLoginDisabledInConfig() bool {
 	return ko.Exists(localLoginEnabledKey) && !ko.Bool(localLoginEnabledKey)
 }
 
-// isLocalLoginEnabled stays true while no OIDC provider is enabled so a misconfigured deployment cannot lock admins out.
 func isLocalLoginEnabled(providers []oidcmodels.OIDC) bool {
 	if !localLoginDisabledInConfig() {
 		return true

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -10,22 +10,6 @@ import (
 
 const localLoginEnabledKey = "auth.local_login_enabled"
 
-// isLocalLoginEnabled keeps local login available by default and whenever no
-// OIDC provider is enabled, preventing an administrator from locking everyone out.
-func isLocalLoginEnabled(providers []oidcmodels.OIDC) bool {
-	if !ko.Exists(localLoginEnabledKey) || ko.Bool(localLoginEnabledKey) {
-		return true
-	}
-
-	for _, provider := range providers {
-		if provider.Enabled {
-			return false
-		}
-	}
-
-	return true
-}
-
 // handleGetConfig returns the public configuration needed for app initialization, this includes minimal app settings and enabled SSO providers (without secrets).
 func handleGetConfig(r *fastglue.Request) error {
 	var app = r.Context.(*App)
@@ -77,7 +61,24 @@ func handleGetConfig(r *fastglue.Request) error {
 
 	// Add SSO providers to the response
 	publicSettings["app.sso_providers"] = enabledProviders
-	publicSettings["app.local_login_enabled"] = isLocalLoginEnabled(oidcProviders)
+	publicSettings["auth.local_login_enabled"] = isLocalLoginEnabled(oidcProviders)
 
 	return r.SendEnvelope(publicSettings)
+}
+
+func localLoginDisabledInConfig() bool {
+	return ko.Exists(localLoginEnabledKey) && !ko.Bool(localLoginEnabledKey)
+}
+
+// isLocalLoginEnabled stays true while no OIDC provider is enabled so a misconfigured deployment cannot lock admins out.
+func isLocalLoginEnabled(providers []oidcmodels.OIDC) bool {
+	if !localLoginDisabledInConfig() {
+		return true
+	}
+	for _, provider := range providers {
+		if provider.Enabled {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	oidcmodels "github.com/abhinavxd/libredesk/internal/oidc/models"
+)
+
+func TestIsLocalLoginEnabled(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured *bool
+		providers  []oidcmodels.OIDC
+		want       bool
+	}{
+		{name: "defaults to enabled", want: true},
+		{name: "remains enabled when configured", configured: boolPointer(true), want: true},
+		{name: "remains enabled without an enabled OIDC provider", configured: boolPointer(false), providers: []oidcmodels.OIDC{{Enabled: false}}, want: true},
+		{name: "is disabled with an enabled OIDC provider", configured: boolPointer(false), providers: []oidcmodels.OIDC{{Enabled: true}}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ko.Delete(localLoginEnabledKey)
+			if tt.configured != nil {
+				if err := ko.Set(localLoginEnabledKey, *tt.configured); err != nil {
+					t.Fatalf("set config: %v", err)
+				}
+			}
+			t.Cleanup(func() { ko.Delete(localLoginEnabledKey) })
+
+			if got := isLocalLoginEnabled(tt.providers); got != tt.want {
+				t.Fatalf("isLocalLoginEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -21,6 +21,14 @@ func handleLogin(r *fastglue.Request) error {
 		loginReq loginRequest
 	)
 
+	oidcProviders, err := app.oidc.GetAll()
+	if err != nil {
+		return sendErrorEnvelope(r, err)
+	}
+	if !isLocalLoginEnabled(oidcProviders) {
+		return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Local login is disabled. Sign in with an SSO provider.", nil, envelope.PermissionError)
+	}
+
 	// Decode JSON request.
 	if err := r.Decode(&loginReq, "json"); err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.T("errors.parsingRequest"), nil, envelope.InputError)

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -21,12 +21,15 @@ func handleLogin(r *fastglue.Request) error {
 		loginReq loginRequest
 	)
 
-	oidcProviders, err := app.oidc.GetAll()
-	if err != nil {
-		return sendErrorEnvelope(r, err)
-	}
-	if !isLocalLoginEnabled(oidcProviders) {
-		return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Local login is disabled. Sign in with an SSO provider.", nil, envelope.PermissionError)
+	if localLoginDisabledInConfig() {
+		oidcProviders, err := app.oidc.GetAll()
+		if err != nil {
+			return sendErrorEnvelope(r, err)
+		}
+		if !isLocalLoginEnabled(oidcProviders) {
+			return r.SendErrorEnvelope(fasthttp.StatusForbidden, app.i18n.T("auth.localLoginDisabled"), nil, envelope.PermissionError)
+		}
+		app.lo.Warn("local login is disabled in config but no OIDC provider is enabled, allowing password login")
 	}
 
 	// Decode JSON request.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -38,6 +38,7 @@ keepalive_timeout = "10s"
 # Allow users to sign in with their LibreDesk email and password.
 # Disable this only after configuring and enabling at least one OIDC provider.
 # LibreDesk automatically keeps local login available when no OIDC provider is enabled to prevent lockout.
+# If an enabled provider is unavailable or misconfigured, set auth.local_login_enabled = true to restore password login.
 local_login_enabled = true
 
 # File upload provider to use, either `fs` or `s3`.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -34,6 +34,12 @@ read_buffer_size = 65536
 # Keepalive settings.
 keepalive_timeout = "10s"
 
+[auth]
+# Allow users to sign in with their LibreDesk email and password.
+# Disable this only after configuring and enabling at least one OIDC provider.
+# LibreDesk automatically keeps local login available when no OIDC provider is enabled to prevent lockout.
+local_login_enabled = true
+
 # File upload provider to use, either `fs` or `s3`.
 [upload]
 provider = "fs"

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -35,9 +35,9 @@ read_buffer_size = 65536
 keepalive_timeout = "10s"
 
 [auth]
-# Allow users to sign in with their LibreDesk email and password.
+# Allow users to sign in with their libredesk email and password.
 # Disable this only after configuring and enabling at least one OIDC provider.
-# LibreDesk automatically keeps local login available when no OIDC provider is enabled to prevent lockout.
+# libredesk automatically keeps local login available when no OIDC provider is enabled to prevent lockout.
 # If an enabled provider is unavailable or misconfigured, set auth.local_login_enabled = true to restore password login.
 local_login_enabled = true
 

--- a/frontend/apps/main/src/views/auth/UserLoginView.vue
+++ b/frontend/apps/main/src/views/auth/UserLoginView.vue
@@ -32,7 +32,7 @@
             {{ oidcProvider.name }}
           </Button>
 
-          <div class="relative">
+          <div v-if="localLoginEnabled" class="relative">
             <div class="absolute inset-0 flex items-center">
               <span class="w-full border-t border-border"></span>
             </div>
@@ -42,7 +42,7 @@
           </div>
         </div>
 
-        <form @submit.prevent="loginAction" class="space-y-3">
+        <form v-if="localLoginEnabled" @submit.prevent="loginAction" class="space-y-3">
           <div class="space-y-2">
             <Label for="email" class="text-muted-foreground">{{
               t('globals.terms.email')
@@ -245,6 +245,10 @@ const loginAction = () => {
 const enabledOIDCProviders = computed(() => {
   return oidcProviders.value.filter((provider) => !provider.disabled)
 })
+
+const localLoginEnabled = computed(
+  () => appSettingsStore.public_config?.['app.local_login_enabled'] !== false
+)
 
 const emailHasError = computed(() => {
   if (!submitted.value) return false

--- a/frontend/apps/main/src/views/auth/UserLoginView.vue
+++ b/frontend/apps/main/src/views/auth/UserLoginView.vue
@@ -247,7 +247,7 @@ const enabledOIDCProviders = computed(() => {
 })
 
 const localLoginEnabled = computed(
-  () => appSettingsStore.public_config?.['app.local_login_enabled'] !== false
+  () => appSettingsStore.public_config?.['auth.local_login_enabled'] !== false
 )
 
 const emailHasError = computed(() => {

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -591,6 +591,7 @@
   "auth.invalidOrExpiredSessionClearCookie": "Invalid or expired session. Please clear your cookies and try again.",
   "auth.invalidResetLink": "Invalid reset link. Please request a new password reset link.",
   "auth.loggingIn": "Logging in...",
+  "auth.localLoginDisabled": "Password login is disabled. Sign in with your SSO provider.",
   "auth.newPassword": "New password",
   "auth.orContinueWith": "Or continue with",
   "auth.passwordRequired": "Password is required.",


### PR DESCRIPTION
Closes #491.

## Summary

- Add an `auth.local_login_enabled` configuration option that defaults to enabled for backward compatibility.
- Hide the password form and its separator when local login is disabled.
- Enforce the setting on the login API so bypassing the UI cannot authenticate locally.
- Automatically keep local login available if no OIDC provider is enabled to prevent administrator lockout.
- Document the setting and cover its fallback behavior with tests.

## Verification

- `go test ./...`
- `bun run build:main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authentication setting to enable or disable local email/password sign-in.
  * Local sign-in is disabled when configured off and an OIDC provider is enabled.
  * Local sign-in remains available by default or when OIDC authentication is unavailable.
  * The login screen hides local sign-in options when unavailable.
  * Public configuration reports whether local sign-in is enabled.
  * Added guidance for configuring local sign-in and OIDC authentication.

* **Bug Fixes**
  * Blocked local-login requests when local authentication is disabled.
  * Added a localized message directing users to SSO when password login is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->