### PR TITLE
restrict private note deletion to the note author or an admin

### DIFF
--- a/cmd/messages_delete.go
+++ b/cmd/messages_delete.go
@@ -23,7 +23,13 @@ func handleDeleteMessage(r *fastglue.Request) error {
 		return sendErrorEnvelope(r, err)
 	}
 
-	content, err := app.conversation.DeletePrivateMessage(cuuid, uuid)
+	// Agents may delete only their own private notes, admins may delete any.
+	senderID := user.ID
+	if user.HasAdminRole() {
+		senderID = 0
+	}
+
+	content, err := app.conversation.DeletePrivateMessage(cuuid, uuid, senderID)
 	if err != nil {
 		return sendErrorEnvelope(r, err)
 	}

--- a/frontend/apps/main/src/features/conversation/message/MessageBubble.vue
+++ b/frontend/apps/main/src/features/conversation/message/MessageBubble.vue
@@ -58,7 +58,7 @@
       >
         <!-- Delete note menu (private notes, appears on hover, left of bubble) -->
         <div
-          v-if="isPrivateMessage && !isDeleted"
+          v-if="canDeleteNote"
           class="flex-shrink-0 transition-opacity duration-200 can-hover:opacity-0 can-hover:group-hover:opacity-100 focus-within:!opacity-100"
         >
           <DropdownMenu>
@@ -393,6 +393,12 @@ const bubbleClasses = computed(() => ({
 
 const isPrivateMessage = computed(() => isOutgoing.value && props.message.private)
 const isDeleted = computed(() => !!props.message.meta?.deleted_at)
+const canDeleteNote = computed(
+  () =>
+    isPrivateMessage.value &&
+    !isDeleted.value &&
+    (props.message.sender_id === userStore.userID || userStore.hasAdminRole)
+)
 const showCheckCheck = computed(
   () => isOutgoing.value && props.message.status === 'sent' && !isPrivateMessage.value
 )

--- a/internal/conversation/message_delete.go
+++ b/internal/conversation/message_delete.go
@@ -8,13 +8,13 @@ import (
 	"github.com/abhinavxd/libredesk/internal/envelope"
 )
 
-// DeletePrivateMessage soft-deletes a private note, unlinks its media for GC, and returns the tombstone text.
-func (m *Manager) DeletePrivateMessage(conversationUUID, messageUUID string) (string, error) {
+// DeletePrivateMessage soft-deletes a private note, unlinks its media for GC, and returns the tombstone text. A senderID of 0 skips the author check.
+func (m *Manager) DeletePrivateMessage(conversationUUID, messageUUID string, senderID int) (string, error) {
 	m.lo.Info("deleting private note", "conversation_uuid", conversationUUID, "message_uuid", messageUUID)
 
 	var previewUpdated bool
 	deletedPreview := m.i18n.T("conversation.privateNoteDeleted")
-	if err := m.q.DeletePrivateMessage.Get(&previewUpdated, messageUUID, conversationUUID, deletedPreview); err != nil {
+	if err := m.q.DeletePrivateMessage.Get(&previewUpdated, messageUUID, conversationUUID, deletedPreview, senderID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return "", envelope.NewError(envelope.NotFoundError, m.i18n.Ts("globals.messages.notFound", "name", m.i18n.Ts("globals.terms.message")), nil)
 		}

--- a/internal/conversation/queries.sql
+++ b/internal/conversation/queries.sql
@@ -649,7 +649,7 @@ DELETE FROM conversation_messages WHERE CASE
 END;
 
 -- name: delete-private-message
--- $1 = message uuid, $2 = conversation uuid, $3 = deleted placeholder text.
+-- $1 = message uuid, $2 = conversation uuid, $3 = deleted placeholder text, $4 = sender id, 0 to skip the sender check.
 WITH deleted AS (
     UPDATE conversation_messages
     SET content = $3, text_content = $3, updated_at = NOW(),
@@ -657,6 +657,7 @@ WITH deleted AS (
     WHERE uuid = $1
       AND private = true
       AND meta->>'deleted_at' IS NULL
+      AND ($4 = 0 OR sender_id = $4)
       AND conversation_id = (SELECT id FROM conversations WHERE uuid = $2)
     RETURNING id, conversation_id, created_at
 ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Private notes can now be deleted only by their author or an administrator.
  * Deletion controls are hidden from unauthorized users.
  * Existing deletion behavior, error handling, and conversation updates remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->