### PR TITLE
stop duplicate key errors when adding conversation participants

### DIFF
--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -1791,13 +1791,13 @@ func (c *Manager) UpdateConversationCustomAttributes(uuid string, customAttribut
 
 // addConversationParticipant adds a user as participant to a conversation.
 func (c *Manager) addConversationParticipant(userID int, conversationUUID string) error {
-	_, err := c.q.InsertConversationParticipant.Exec(userID, conversationUUID)
+	res, err := c.q.InsertConversationParticipant.Exec(userID, conversationUUID)
 	if err != nil {
-		if dbutil.IsUniqueViolationError(err) {
-			return nil // Already a participant.
-		}
 		c.lo.Error("error adding conversation participant", "user_id", userID, "conversation_uuid", conversationUUID, "error", err)
 		return envelope.NewError(envelope.GeneralError, c.i18n.T("globals.messages.somethingWentWrong"), nil)
+	}
+	if rows, err := res.RowsAffected(); err == nil && rows == 0 {
+		return nil
 	}
 
 	// New participant added - log activity only for contacts with a different email than the conversation contact.

--- a/internal/conversation/queries.sql
+++ b/internal/conversation/queries.sql
@@ -508,7 +508,8 @@ WHERE conversation_id =
 -- name: insert-conversation-participant
 INSERT INTO conversation_participants
 (user_id, conversation_id)
-VALUES($1, (SELECT id FROM conversations WHERE uuid = $2));
+VALUES($1, (SELECT id FROM conversations WHERE uuid = $2))
+ON CONFLICT (conversation_id, user_id) DO NOTHING;
 
 -- name: get-unassigned-conversations
 SELECT


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when adding a participant who is already part of a conversation.
  * Prevented duplicate participant entries from generating unnecessary errors.
  * Ensured duplicate additions stop processing cleanly without affecting existing conversation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->