### PR TITLE
apply Geist to toasts, charts and form controls

### DIFF
--- a/frontend/shared-ui/assets/styles/main.scss
+++ b/frontend/shared-ui/assets/styles/main.scss
@@ -4,6 +4,12 @@
 
 :root {
   font-size: 16px;
+  // unovis injects its own :root font stack at runtime, after this stylesheet.
+  --vis-font-family: theme('fontFamily.sans') !important;
+}
+
+[data-sonner-toaster] {
+  font-family: inherit;
 }
 
 ::view-transition-old(root),

--- a/frontend/shared-ui/assets/styles/main.scss
+++ b/frontend/shared-ui/assets/styles/main.scss
@@ -4,8 +4,6 @@
 
 :root {
   font-size: 16px;
-  // unovis injects its own :root font stack at runtime, after this stylesheet.
-  --vis-font-family: theme('fontFamily.sans') !important;
 }
 
 [data-sonner-toaster] {
@@ -29,6 +27,7 @@
   html,
   body {
     @apply font-sans;
+    --vis-font-family: theme('fontFamily.sans');
     min-height: 100%;
     overflow: hidden;
     margin: 0;

--- a/static/public/static/fonts.css
+++ b/static/public/static/fonts.css
@@ -14,3 +14,12 @@
   font-display: swap;
   src: url('/static/public/static/fonts/Geist-Italic-Variable.woff2') format('woff2');
 }
+
+/* Form controls default to the browser UI font, not the page font. */
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized typography across the interface by applying the page’s font consistently.
  * Updated notifications, buttons, inputs, selects, textareas, and other form controls to inherit the surrounding font.
  * Improved font consistency across the application by ensuring core interface elements follow the active page typography without overriding custom styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->