### PR TITLE
close websockets and bound the http server shutdown

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -72,6 +72,9 @@ jobs:
           # E2E runs over plain HTTP, so the Secure session/csrf cookies must be off
           # or real login + writes would be rejected.
           LIBREDESK_APP__SERVER__DISABLE_SECURE_COOKIES: "true"
+          # The livechat widget suite makes far more than 100 widget requests a minute.
+          LIBREDESK_RATE_LIMIT__WIDGET__REQUESTS_PER_MINUTE: "100000"
+          LIBREDESK_RATE_LIMIT__PUBLIC__REQUESTS_PER_MINUTE: "100000"
           CYPRESS_SYSTEM_PASSWORD: "StrongPass!123"
           CYPRESS_MAILHOG_URL: "http://localhost:8025"
         run: |

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -225,8 +225,7 @@ func handleChatInit(r *fastglue.Request) error {
 		isVisitor = true
 		visitor, newSessionToken, conversationAttrs, err = createVisitorContact(app, req.FormData, config, inbox)
 		if err != nil {
-			app.lo.Error("error creating visitor contact", "error", err)
-			return r.SendErrorEnvelope(fasthttp.StatusInternalServerError, app.i18n.T("globals.messages.somethingWentWrong"), nil, envelope.GeneralError)
+			return sendErrorEnvelope(r, err)
 		}
 		contactID = visitor.ID
 	}
@@ -807,7 +806,7 @@ func resolveOrCreateExternalContact(app *App, claims Claims) (int, error) {
 // createVisitorContact creates a new visitor contact from form data.
 func createVisitorContact(app *App, formData map[string]any, config livechat.Config, inbox imodels.Inbox) (umodels.User, string, map[string]any, error) {
 	// Validate form data and get final name/email/phone for new visitor.
-	finalName, finalEmail, finalPhone, finalPhoneCountryCode, err := validateFormData(formData, config, nil)
+	finalName, finalEmail, finalPhone, finalPhoneCountryCode, err := validateFormData(app, formData, config, nil)
 	if err != nil {
 		return umodels.User{}, "", nil, err
 	}
@@ -825,13 +824,13 @@ func createVisitorContact(app *App, formData map[string]any, config livechat.Con
 
 	if err := app.user.CreateVisitor(&visitor); err != nil {
 		app.lo.Error("error creating visitor contact", "error", err)
-		return umodels.User{}, "", nil, err
+		return umodels.User{}, "", nil, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
 
 	token, err := generateSessionToken(app, visitor.ID, inbox.ID, true, "", defaultSessionTTL)
 	if err != nil {
 		app.lo.Error("error generating session token for visitor", "error", err)
-		return umodels.User{}, "", nil, err
+		return umodels.User{}, "", nil, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
 
 	return visitor, token, formConvoAttrs, nil
@@ -1149,7 +1148,7 @@ func validateAttributeValue(key string, value any, app *App) any {
 }
 
 // validateFormData returns the final name/email/phone/phone country code to persist from the pre-chat form.
-func validateFormData(formData map[string]any, config livechat.Config, existingUser *umodels.User) (string, string, string, string, error) {
+func validateFormData(app *App, formData map[string]any, config livechat.Config, existingUser *umodels.User) (string, string, string, string, error) {
 	var finalName, finalEmail, finalPhone, finalPhoneCountryCode string
 
 	if !config.PreChatForm.Enabled {
@@ -1173,35 +1172,35 @@ func validateFormData(formData map[string]any, config livechat.Config, existingU
 		case "name":
 			finalName = resolveFormField(formData, field.Key, exName)
 			if field.Required && finalName == "" {
-				return "", "", "", "", fmt.Errorf("name is required")
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.required", "name", "{globals.terms.name}"), nil)
 			}
 			if len(finalName) > maxNameLength {
-				return "", "", "", "", fmt.Errorf("name too long")
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxNameLength)), nil)
 			}
 
 		case "email":
 			finalEmail = resolveFormField(formData, field.Key, exEmail)
 			if field.Required && finalEmail == "" {
-				return "", "", "", "", fmt.Errorf("email is required")
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.required", "name", "{globals.terms.email}"), nil)
 			}
 			if len(finalEmail) > maxEmailLength {
-				return "", "", "", "", fmt.Errorf("email too long")
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxEmailLength)), nil)
 			}
 			if finalEmail != "" && !stringutil.ValidEmail(finalEmail) {
-				return "", "", "", "", fmt.Errorf("invalid email format")
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.T("validation.invalidEmail"), nil)
 			}
 
 		case fieldTypePhone:
 			finalPhone = resolveFormField(formData, field.Key, exPhone)
 			finalPhoneCountryCode = resolveFormField(formData, field.Key+phoneCountryCodeSuffix, exPhoneCountryCode)
 			if field.Required && (finalPhone == "" || finalPhoneCountryCode == "") {
-				return "", "", "", "", fmt.Errorf("phone is required")
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.required", "name", "{globals.terms.phoneNumber}"), nil)
 			}
 			if len(finalPhone) > maxPhoneNumberLength {
-				return "", "", "", "", fmt.Errorf("phone too long")
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxPhoneNumberLength)), nil)
 			}
 			if len(finalPhoneCountryCode) > maxPhoneCountryCodeLength {
-				return "", "", "", "", fmt.Errorf("phone country code too long")
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxPhoneCountryCodeLength)), nil)
 			}
 			if finalPhone == "" {
 				finalPhoneCountryCode = ""

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -1200,7 +1200,7 @@ func validateFormData(app *App, formData map[string]any, config livechat.Config,
 				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.fieldTooLong", "field", "{globals.terms.phoneNumber}", "max", strconv.Itoa(maxPhoneNumberLength)), nil)
 			}
 			if len(finalPhoneCountryCode) > maxPhoneCountryCodeLength {
-				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.fieldTooLong", "field", "{globals.terms.phoneNumber}", "max", strconv.Itoa(maxPhoneCountryCodeLength)), nil)
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.fieldTooLong", "field", "{globals.terms.countryCode}", "max", strconv.Itoa(maxPhoneCountryCodeLength)), nil)
 			}
 			if finalPhone == "" {
 				finalPhoneCountryCode = ""

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -383,10 +383,10 @@ func handleAuthExchange(r *fastglue.Request) error {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.required", "name", "first_name"), nil, envelope.InputError)
 	}
 	if len(claims.LastName) > maxNameLength {
-		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxNameLength)), nil, envelope.InputError)
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.fieldTooLong", "field", "{globals.terms.name}", "max", strconv.Itoa(maxNameLength)), nil, envelope.InputError)
 	}
 	if len(claims.PhoneNumber) > maxPhoneNumberLength {
-		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxPhoneNumberLength)), nil, envelope.InputError)
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.fieldTooLong", "field", "{globals.terms.phoneNumber}", "max", strconv.Itoa(maxPhoneNumberLength)), nil, envelope.InputError)
 	}
 	// Country code is cosmetic - drop an invalid one instead of failing the whole exchange.
 	if len(claims.PhoneNumberCountryCode) > maxPhoneCountryCodeLength {
@@ -1175,7 +1175,7 @@ func validateFormData(app *App, formData map[string]any, config livechat.Config,
 				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.required", "name", "{globals.terms.name}"), nil)
 			}
 			if len(finalName) > maxNameLength {
-				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxNameLength)), nil)
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.fieldTooLong", "field", "{globals.terms.name}", "max", strconv.Itoa(maxNameLength)), nil)
 			}
 
 		case "email":
@@ -1184,7 +1184,7 @@ func validateFormData(app *App, formData map[string]any, config livechat.Config,
 				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.required", "name", "{globals.terms.email}"), nil)
 			}
 			if len(finalEmail) > maxEmailLength {
-				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxEmailLength)), nil)
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.fieldTooLong", "field", "{globals.terms.email}", "max", strconv.Itoa(maxEmailLength)), nil)
 			}
 			if finalEmail != "" && !stringutil.ValidEmail(finalEmail) {
 				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.T("validation.invalidEmail"), nil)
@@ -1197,10 +1197,10 @@ func validateFormData(app *App, formData map[string]any, config livechat.Config,
 				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.required", "name", "{globals.terms.phoneNumber}"), nil)
 			}
 			if len(finalPhone) > maxPhoneNumberLength {
-				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxPhoneNumberLength)), nil)
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.fieldTooLong", "field", "{globals.terms.phoneNumber}", "max", strconv.Itoa(maxPhoneNumberLength)), nil)
 			}
 			if len(finalPhoneCountryCode) > maxPhoneCountryCodeLength {
-				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxPhoneCountryCodeLength)), nil)
+				return "", "", "", "", envelope.NewError(envelope.InputError, app.i18n.Ts("globals.messages.fieldTooLong", "field", "{globals.terms.phoneNumber}", "max", strconv.Itoa(maxPhoneCountryCodeLength)), nil)
 			}
 			if finalPhone == "" {
 				finalPhoneCountryCode = ""

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,7 +88,7 @@ var (
 const (
 	sampleEncKey = "your-32-char-random-string-here!"
 
-	serverShutdownTimeout = 3 * time.Second
+	serverShutdownTimeout = 10 * time.Second
 )
 
 // App is the global app context which is passed and injected in the http handlers.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -87,6 +87,8 @@ var (
 
 const (
 	sampleEncKey = "your-32-char-random-string-here!"
+
+	serverShutdownTimeout = 3 * time.Second
 )
 
 // App is the global app context which is passed and injected in the http handlers.
@@ -365,8 +367,15 @@ func main() {
 
 	// Wait for shutdown signal.
 	<-ctx.Done()
+	closedAgentConns := wsHub.CloseAll()
+	closedLiveChatInboxes := inbox.CloseLiveChatClients()
+	colorlog.Red("Closed %d agent websocket connections and %d livechat inboxes.", closedAgentConns, closedLiveChatInboxes)
 	colorlog.Red("Shutting down HTTP server...")
-	s.Shutdown()
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), serverShutdownTimeout)
+	if err := s.ShutdownWithContext(shutdownCtx); err != nil {
+		colorlog.Red("HTTP server did not finish within %s, abandoning in-flight requests: %v", serverShutdownTimeout, err)
+	}
+	cancelShutdown()
 	colorlog.Red("Shutting down AI agent...")
 	aiAgent.Close()
 	colorlog.Red("Shutting down AI...")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,7 +88,7 @@ var (
 const (
 	sampleEncKey = "your-32-char-random-string-here!"
 
-	serverShutdownTimeout = 10 * time.Second
+	serverShutdownTimeout = 8 * time.Second
 )
 
 // App is the global app context which is passed and injected in the http handlers.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"log"
@@ -373,7 +374,11 @@ func main() {
 	colorlog.Red("Shutting down HTTP server...")
 	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), serverShutdownTimeout)
 	if err := s.ShutdownWithContext(shutdownCtx); err != nil {
-		colorlog.Red("HTTP server drain timed out after %s, exiting with connections still open: %v", serverShutdownTimeout, err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			colorlog.Red("HTTP server drain timed out after %s, exiting with connections still open: %v", serverShutdownTimeout, err)
+		} else {
+			colorlog.Red("error shutting down HTTP server: %v", err)
+		}
 	}
 	cancelShutdown()
 	colorlog.Red("Shutting down AI agent...")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -373,7 +373,7 @@ func main() {
 	colorlog.Red("Shutting down HTTP server...")
 	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), serverShutdownTimeout)
 	if err := s.ShutdownWithContext(shutdownCtx); err != nil {
-		colorlog.Red("HTTP server did not finish within %s, abandoning in-flight requests: %v", serverShutdownTimeout, err)
+		colorlog.Red("HTTP server drain timed out after %s, exiting with connections still open: %v", serverShutdownTimeout, err)
 	}
 	cancelShutdown()
 	colorlog.Red("Shutting down AI agent...")

--- a/cmd/widget_ws.go
+++ b/cmd/widget_ws.go
@@ -135,12 +135,14 @@ func handleWidgetWS(r *fastglue.Request) error {
 		}()
 
 		for {
-			// Checked before the deadline is refreshed, else the refresh undoes the expiry disconnect() set.
+			conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
+
+			// Checked after the refresh: CloseChannel marks the client before disconnect() expires the deadline, so
+			// either this sees it or the expiry landed after the refresh and ReadJSON returns immediately.
 			if client != nil && client.IsClosed() {
 				break
 			}
 
-			conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
 			var msg WidgetMessage
 			if err := conn.ReadJSON(&msg); err != nil {
 				app.lo.Debug("widget websocket connection closed", "error", err)

--- a/cmd/widget_ws.go
+++ b/cmd/widget_ws.go
@@ -142,6 +142,10 @@ func handleWidgetWS(r *fastglue.Request) error {
 				break
 			}
 
+			if client != nil && client.IsClosed() {
+				break
+			}
+
 			switch msg.Type {
 			case WidgetMsgTypeJoin:
 				// Clean up previous client on re-join.
@@ -247,7 +251,10 @@ func handleInboxJoin(app *App, sc *safeConn, data json.RawMessage, token, client
 	}
 
 	userIDStr := fmt.Sprintf("%d", user.ID)
-	client, err := liveChat.AddClient(userIDStr)
+	// fasthttp makes Close a no-op on a hijacked conn; expiring the read deadline is what drops it.
+	client, err := liveChat.AddClient(userIDStr, func() {
+		sc.conn.SetReadDeadline(time.Now())
+	})
 	if err != nil {
 		return nil, nil, "", 0, fmt.Errorf("adding client to live chat: %w", err)
 	}

--- a/cmd/widget_ws.go
+++ b/cmd/widget_ws.go
@@ -135,14 +135,15 @@ func handleWidgetWS(r *fastglue.Request) error {
 		}()
 
 		for {
+			// Checked before the deadline is refreshed, else the refresh undoes the expiry disconnect() set.
+			if client != nil && client.IsClosed() {
+				break
+			}
+
 			conn.SetReadDeadline(time.Now().Add(wsReadDeadline))
 			var msg WidgetMessage
 			if err := conn.ReadJSON(&msg); err != nil {
 				app.lo.Debug("widget websocket connection closed", "error", err)
-				break
-			}
-
-			if client != nil && client.IsClosed() {
 				break
 			}
 
@@ -152,9 +153,8 @@ func handleWidgetWS(r *fastglue.Request) error {
 				if client != nil && liveChat != nil {
 					liveChat.RemoveClient(client)
 					client.CloseChannel()
-					client = nil
-					liveChat = nil
 				}
+				client, liveChat, inboxUUID, userID = nil, nil, "", 0
 
 				joinedClient, joinedLiveChat, joinedInboxUUID, joinedUserID, err := handleInboxJoin(app, sc, msg.Data, msg.Token, clientIP)
 				if err != nil {

--- a/frontend/apps/main/src/websocket.js
+++ b/frontend/apps/main/src/websocket.js
@@ -34,6 +34,8 @@ export class WebSocketClient {
   connect () {
     if (this.isReconnecting || this.manualClose) return
 
+    if (this.socket) this.socket.close()
+
     try {
       this.socket = new WebSocket('/ws')
       this.socket.addEventListener('open', this.handleOpen.bind(this))
@@ -46,7 +48,8 @@ export class WebSocketClient {
     }
   }
 
-  handleOpen () {
+  handleOpen (event) {
+    if (event.target !== this.socket) return
     console.log('WebSocket connected')
     const wasReconnect = this.reconnectAttempts > 0
     this.reconnectInterval = 1000
@@ -67,6 +70,7 @@ export class WebSocketClient {
   }
 
   handleMessage (event) {
+    if (event.target !== this.socket) return
     try {
       if (!event.data) return
 
@@ -140,11 +144,13 @@ export class WebSocketClient {
   }
 
   handleError (event) {
+    if (event.target !== this.socket) return
     console.error('WebSocket error:', event)
     this.reconnect()
   }
 
-  handleClose () {
+  handleClose (event) {
+    if (event.target !== this.socket) return
     this.clearPing()
     if (!this.manualClose) {
       this.reconnect()

--- a/frontend/apps/widget/src/views/ConversationsView.vue
+++ b/frontend/apps/widget/src/views/ConversationsView.vue
@@ -18,10 +18,7 @@
       <!-- Floating button -->
       <div class="absolute bottom-4 inset-x-0 mx-auto w-fit z-10">
         <Button @click="startNewConversation">
-          {{
-            widgetStore.config?.users?.start_conversation_button_text ||
-            $t('globals.messages.startNewConversation')
-          }}
+          {{ startButtonText }}
         </Button>
       </div>
     </div>
@@ -30,6 +27,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { Button } from '@shared-ui/components/ui/button'
 import { useChatStore } from '../store/chat.js'
 import { useWidgetStore } from '../store/widget.js'
@@ -37,9 +35,15 @@ import { useUserStore } from '@widget/store/user.js'
 import ConversationsList from '../components/ConversationsList.vue'
 import WidgetHeader from '../layouts/WidgetHeader.vue'
 
+const { t } = useI18n()
 const chatStore = useChatStore()
 const widgetStore = useWidgetStore()
 const userStore = useUserStore()
+
+const startButtonText = computed(() => {
+  const userConfig = userStore.isVisitor ? widgetStore.config?.visitors : widgetStore.config?.users
+  return userConfig?.start_conversation_button_text || t('globals.messages.startNewConversation')
+})
 
 const canStartNewConversation = computed(() => {
   const userConfig = userStore.isVisitor ? widgetStore.config?.visitors : widgetStore.config?.users

--- a/frontend/apps/widget/src/views/ConversationsView.vue
+++ b/frontend/apps/widget/src/views/ConversationsView.vue
@@ -42,18 +42,10 @@ const widgetStore = useWidgetStore()
 const userStore = useUserStore()
 
 const canStartNewConversation = computed(() => {
-  const isVisitor = userStore.isVisitor
-  if (isVisitor) {
-    if (widgetStore.config?.visitors?.prevent_multiple_conversations) {
-      return !chatStore.hasConversations
-    }
-    return widgetStore.config?.visitors?.allow_start_conversation ?? true
-  } else {
-    if (widgetStore.config?.users?.prevent_multiple_conversations) {
-      return !chatStore.hasConversations
-    }
-    return widgetStore.config?.users?.allow_start_conversation ?? true
-  }
+  const userConfig = userStore.isVisitor ? widgetStore.config?.visitors : widgetStore.config?.users
+  // Mirrors the server check, else the button is offered and the send fails.
+  if (!userConfig?.allow_start_conversation) return false
+  return userConfig?.prevent_multiple_conversations !== true || !chatStore.hasConversations
 })
 
 const startNewConversation = () => {

--- a/frontend/apps/widget/src/views/HomeView.vue
+++ b/frontend/apps/widget/src/views/HomeView.vue
@@ -58,6 +58,8 @@ const mostRecentConversation = computed(() => {
 
 const canStartConversation = computed(() => {
   const userConfig = userStore.isVisitor ? config.value.visitors : config.value.users
+  // Mirrors the server check, else the button is offered and the send fails.
+  if (!userConfig?.allow_start_conversation) return false
   return userConfig?.prevent_multiple_conversations !== true || !chatStore.hasConversations
 })
 

--- a/frontend/apps/widget/src/websocket.js
+++ b/frontend/apps/widget/src/websocket.js
@@ -54,6 +54,8 @@ export class WidgetWebSocketClient {
   connect () {
     if (this.isReconnecting || this.manualClose) return
 
+    if (this.socket) this.socket.close()
+
     try {
       this.socket = new WebSocket('/widget/ws')
       this.socket.addEventListener('open', this.handleOpen.bind(this))
@@ -66,7 +68,8 @@ export class WidgetWebSocketClient {
     }
   }
 
-  handleOpen () {
+  handleOpen (event) {
+    if (event.target !== this.socket) return
     this.reconnectAttempts = 0
     this.isReconnecting = false
     this.lastPong = Date.now()
@@ -146,11 +149,13 @@ export class WidgetWebSocketClient {
   }
 
   handleError (event) {
+    if (event.target !== this.socket) return
     console.error('Widget WebSocket error:', event)
     this.reconnect()
   }
 
-  handleClose () {
+  handleClose (event) {
+    if (event.target !== this.socket) return
     this.clearPing()
     if (!this.manualClose) {
       this.beginRecovery()

--- a/frontend/apps/widget/src/websocket.js
+++ b/frontend/apps/widget/src/websocket.js
@@ -93,6 +93,7 @@ export class WidgetWebSocketClient {
   }
 
   handleMessage (event) {
+    if (event.target !== this.socket) return
     const chatStore = useChatStore()
     try {
       if (!event.data) return

--- a/frontend/apps/widget/src/websocket.test.js
+++ b/frontend/apps/widget/src/websocket.test.js
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+const chatStore = { addMessageToConversation: vi.fn(), currentConversation: null }
+const widgetStore = {
+  setConnectionFailed: vi.fn(),
+  setConnecting: vi.fn(),
+  setConnected: vi.fn(),
+  isOpen: false,
+  isInChatView: false
+}
+
+vi.mock('./store/chat.js', () => ({ useChatStore: () => chatStore }))
+vi.mock('./store/widget.js', () => ({ useWidgetStore: () => widgetStore }))
+vi.mock('@shared-ui/composables/useNotificationSound.js', () => ({ playNotificationSound: vi.fn() }))
+
+const sockets = []
+
+class FakeSocket {
+  constructor() {
+    this.readyState = FakeSocket.CONNECTING
+    this.listeners = {}
+    this.closed = false
+    this.sent = []
+    sockets.push(this)
+  }
+
+  addEventListener(type, handler) {
+    this.listeners[type] = handler
+  }
+
+  send(payload) {
+    this.sent.push(payload)
+  }
+
+  close() {
+    this.closed = true
+  }
+
+  emit(type, data) {
+    this.listeners[type]({ target: this, data })
+  }
+}
+FakeSocket.CONNECTING = 0
+FakeSocket.OPEN = 1
+
+const newMessageFrame = (body) =>
+  JSON.stringify({
+    type: 'new_message',
+    data: { conversation_uuid: 'convo-1', content: body, author: { type: 'agent' } }
+  })
+
+let WidgetWebSocketClient
+
+describe('Widget websocket client', () => {
+  beforeEach(async () => {
+    sockets.length = 0
+    vi.clearAllMocks()
+    vi.stubGlobal('WebSocket', FakeSocket)
+    vi.useFakeTimers()
+    WidgetWebSocketClient = (await import('./websocket.js')).WidgetWebSocketClient
+  })
+
+  const connected = () => {
+    const client = new WidgetWebSocketClient()
+    client.init('token', 'inbox-uuid')
+    return client
+  }
+
+  test('closes the previous socket before opening a new one', () => {
+    const client = connected()
+    const first = sockets[0]
+
+    client.reconnect()
+    vi.advanceTimersByTime(2000)
+
+    expect(sockets).toHaveLength(2)
+    expect(first.closed).toBe(true)
+  })
+
+  test('a superseded socket cannot trigger another reconnect', () => {
+    const client = connected()
+    const first = sockets[0]
+
+    client.reconnect()
+    vi.advanceTimersByTime(2000)
+    expect(sockets).toHaveLength(2)
+
+    first.emit('close')
+    vi.advanceTimersByTime(10000)
+
+    expect(sockets).toHaveLength(2)
+  })
+
+  test('a superseded socket cannot deliver messages into the store', () => {
+    const client = connected()
+    const first = sockets[0]
+
+    client.reconnect()
+    vi.advanceTimersByTime(2000)
+
+    first.emit('message', newMessageFrame('from the dead socket'))
+
+    expect(chatStore.addMessageToConversation).not.toHaveBeenCalled()
+  })
+
+  test('the current socket still delivers messages', () => {
+    connected()
+
+    sockets[0].emit('message', newMessageFrame('hello'))
+
+    expect(chatStore.addMessageToConversation).toHaveBeenCalledWith(
+      'convo-1',
+      expect.objectContaining({ content: 'hello' })
+    )
+  })
+
+  test('a superseded socket cannot mark the connection healthy', () => {
+    const client = connected()
+    const first = sockets[0]
+
+    client.reconnect()
+    vi.advanceTimersByTime(2000)
+    vi.clearAllMocks()
+
+    first.emit('open')
+
+    expect(widgetStore.setConnectionFailed).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/cypress/e2e/integration/livechat/config.cy.js
+++ b/frontend/cypress/e2e/integration/livechat/config.cy.js
@@ -277,4 +277,47 @@ describe('Live chat widget config applied end to end', () => {
       })
     )
   })
+
+  it('keeps the messages-tab button off when visitors may not start one but multiples are prevented', () => {
+    cy.createLivechatInbox(
+      withStart({
+        visitors: {
+          allow_start_conversation: true,
+          prevent_multiple_conversations: true,
+          start_conversation_button_text: startText
+        }
+      })
+    ).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains('Messages').click()
+      cy.widgetBody().contains(startText).should('be.visible')
+    })
+
+    cy.createLivechatInbox(
+      withStart({
+        visitors: {
+          allow_start_conversation: false,
+          prevent_multiple_conversations: true,
+          start_conversation_button_text: startText
+        }
+      })
+    ).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains('Messages').click()
+      cy.widgetBody().contains('Home').should('be.visible')
+      cy.widgetBody().should('not.contain', startText)
+    })
+  })
+
+  it('uses the visitor label on the messages tab, not the agent-side one', () => {
+    cy.createLivechatInbox({
+      visitors: { allow_start_conversation: true, start_conversation_button_text: 'Visitor label' },
+      users: { allow_start_conversation: true, start_conversation_button_text: 'User label' }
+    }).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains('Messages').click()
+      cy.widgetBody().contains('Visitor label').should('be.visible')
+      cy.widgetBody().should('not.contain', 'User label')
+    })
+  })
 })

--- a/frontend/cypress/e2e/integration/livechat/config.cy.js
+++ b/frontend/cypress/e2e/integration/livechat/config.cy.js
@@ -1,0 +1,280 @@
+const startText = 'Cypress start chat'
+
+const withStart = (overrides = {}) => ({
+  visitors: { allow_start_conversation: true, start_conversation_button_text: startText },
+  users: { allow_start_conversation: true, start_conversation_button_text: startText },
+  ...overrides
+})
+
+describe('Live chat widget config applied end to end', () => {
+  it('shows brand name, logo, greeting and introduction on the home screen', () => {
+    cy.createLivechatInbox(
+      withStart({
+        brand_name: 'Cypress Brand',
+        logo_url: `${Cypress.config('baseUrl')}/static/public/launcher-logo.png`,
+        greeting_message: 'Hello from Cypress',
+        introduction_message: 'We reply fast'
+      })
+    ).then((inbox) => {
+      cy.visitWidgetHost(inbox.uuid)
+      cy.widgetLauncher().click()
+      cy.widgetBody().contains('Hello from Cypress').should('be.visible')
+      cy.widgetBody().contains('We reply fast').should('be.visible')
+      cy.widgetBody().find('img[src*="launcher-logo.png"]').should('exist')
+      cy.widgetBody().contains(startText).click()
+      cy.widgetBody().contains('Cypress Brand').should('be.visible')
+    })
+  })
+
+  it('applies the launcher color from config', () => {
+    cy.createLivechatInbox(
+      withStart({ colors: { primary: '#ff0000' }, launcher: { color: '#00ff00', position: 'right', spacing: { side: 20, bottom: 20 } } })
+    ).then((inbox) => {
+      cy.visitWidgetHost(inbox.uuid)
+      cy.widgetLauncher().then((el) => {
+        const style = el[0].ownerDocument.defaultView.getComputedStyle(el[0])
+        expect(style.backgroundColor, 'launcher color not applied').to.eq('rgb(0, 255, 0)')
+      })
+    })
+  })
+
+  it('shows the notice banner only when enabled', () => {
+    cy.createLivechatInbox(
+      withStart({ notice_banner: { enabled: true, text: 'Cypress notice text' } })
+    ).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains(startText).click()
+      cy.widgetBody().contains('Cypress notice text').should('be.visible')
+    })
+
+    cy.createLivechatInbox(
+      withStart({ notice_banner: { enabled: false, text: 'Hidden notice' } })
+    ).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains(startText).click()
+      cy.widgetBody().find('textarea').should('be.visible')
+      cy.widgetBody().contains('Hidden notice').should('not.exist')
+    })
+  })
+
+  it('hides the powered-by link when show_powered_by is false', () => {
+    cy.createLivechatInbox(withStart({ show_powered_by: true })).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains(startText).click()
+      cy.widgetBody().find('a[href="https://libredesk.io"]').should('exist')
+    })
+
+    cy.createLivechatInbox(withStart({ show_powered_by: false })).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains(startText).click()
+      cy.widgetBody().find('textarea').should('be.visible')
+      cy.widgetBody().find('a[href="https://libredesk.io"]').should('not.exist')
+    })
+  })
+
+  it('toggles the emoji and file upload actions from features', () => {
+    cy.createLivechatInbox(withStart({ features: { emoji: true, file_upload: true } })).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains(startText).click()
+      cy.widgetBody().find('button[aria-label="Add emoji"]').should('exist')
+      // The attach button only renders once a conversation exists to upload against.
+      cy.widgetSend(`Message for upload ${Date.now()}`)
+      cy.widgetBody().find('button[aria-label="Attach file"]').should('exist')
+    })
+
+    cy.createLivechatInbox(withStart({ features: { emoji: false, file_upload: false } })).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains(startText).click()
+      cy.widgetBody().find('textarea').should('be.visible')
+      cy.widgetBody().find('button[aria-label="Add emoji"]').should('not.exist')
+      cy.widgetBody().find('button[aria-label="Attach file"]').should('not.exist')
+    })
+  })
+
+  it('renders configured home apps', () => {
+    cy.createLivechatInbox(
+      withStart({
+        home_apps: [
+          { type: 'announcement', title: 'Cypress announcement', description: 'Read this', url: '' },
+          { type: 'external_link', text: 'Cypress docs link', url: 'https://example.test/docs' }
+        ]
+      })
+    ).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains('Cypress announcement').should('be.visible')
+      cy.widgetBody().contains('Cypress docs link').should('be.visible')
+    })
+  })
+
+  it('opens straight into the chat when direct_to_conversation is set', () => {
+    cy.createLivechatInbox(withStart({ direct_to_conversation: true })).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().find('textarea', { timeout: 20000 }).should('be.visible')
+    })
+  })
+
+  it('hides the start button when visitors may not start conversations', () => {
+    let inbox
+    cy.createLivechatInbox(
+      withStart({ visitors: { allow_start_conversation: false, start_conversation_button_text: startText } })
+    ).then((created) => {
+      inbox = created
+    })
+    cy.then(() => cy.openWidget(inbox))
+    cy.widgetBody().contains('Home').should('be.visible')
+    cy.widgetBody().should('not.contain', startText)
+    cy.then(() =>
+      cy.conversationForInbox(inbox).then((conversation) => {
+        expect(conversation, 'a conversation was created anyway').to.be.null
+      })
+    )
+  })
+
+  it('replaces the start button with the running conversation when multiples are prevented', () => {
+    cy.createLivechatInbox(
+      withStart({
+        visitors: {
+          allow_start_conversation: true,
+          prevent_multiple_conversations: true,
+          start_conversation_button_text: startText
+        }
+      })
+    ).then((inbox) => {
+      const firstMessage = `First conversation ${Date.now()}`
+      cy.openWidget(inbox)
+      cy.widgetBody().contains(startText).click()
+      cy.widgetSend(firstMessage)
+      cy.widgetBody().find('button[aria-label="Go back"]').click()
+      cy.widgetBody().contains('Home').click()
+      cy.widgetBody().contains(firstMessage, { timeout: 20000 }).should('be.visible')
+      cy.widgetBody().should('not.contain', startText)
+    })
+  })
+
+  it('blocks replies to a closed conversation when configured', () => {
+    let inbox
+    cy.createLivechatInbox(
+      withStart({
+        visitors: {
+          allow_start_conversation: true,
+          prevent_reply_to_closed_conversation: true,
+          start_conversation_button_text: startText
+        }
+      })
+    ).then((created) => {
+      inbox = created
+    })
+    cy.then(() => cy.openWidget(inbox))
+    cy.widgetBody().contains(startText).click()
+    cy.widgetSend(`Message before close ${Date.now()}`)
+    cy.then(() => cy.closeConversation(inbox))
+    cy.widgetBody().find('textarea', { timeout: 20000 }).should('not.exist')
+  })
+
+  it('applies dark mode', () => {
+    cy.createLivechatInbox(withStart({ dark_mode: true })).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().find('.dark').should('exist')
+    })
+  })
+
+  it('paints the home screen background from config', () => {
+    cy.createLivechatInbox(
+      withStart({
+        home_screen: {
+          header_text_color: 'light',
+          background: { type: 'gradient', gradient_start: '#112233', gradient_end: '#445566' },
+          fade_background: true
+        }
+      })
+    ).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains(startText)
+      cy.widgetBody().then((body) => {
+        const hasGradient = Array.from(body[0].querySelectorAll('div')).some((el) =>
+          (el.getAttribute('style') || '').includes('gradient')
+        )
+        expect(hasGradient, 'gradient background not applied').to.be.true
+      })
+    })
+  })
+
+  it('shows the reply expectation message once business hours are configured', () => {
+    let inbox
+    cy.login()
+    cy.api('POST', '/api/v1/business-hours', {
+      name: `Cypress always open ${Date.now()}`,
+      is_always_open: true,
+      hours: {},
+      holidays: []
+    })
+      .its('body.data.id')
+      .then((id) => cy.setDefaultBusinessHours(String(id)))
+
+    cy.createLivechatInbox(
+      withStart({
+        chat_reply_expectation_message: 'We usually reply in 5 minutes',
+        show_office_hours_in_chat: true
+      })
+    ).then((created) => {
+      inbox = created
+    })
+    cy.then(() => cy.openWidget(inbox))
+    cy.widgetBody().contains(startText).click()
+    // The message only renders against a live conversation.
+    cy.then(() => cy.widgetSend(`Expectation probe ${Date.now()}`))
+    cy.widgetBody().contains('We usually reply in 5 minutes', { timeout: 20000 }).should('be.visible')
+    cy.then(() => cy.setDefaultBusinessHours(''))
+  })
+
+  it('renders the widget in the configured language', () => {
+    cy.createLivechatInbox({
+      language: 'de-DE',
+      fallback_language: 'en-US',
+      visitors: { allow_start_conversation: true },
+      users: { allow_start_conversation: true }
+    }).then((inbox) => {
+      cy.openWidget(inbox)
+      cy.widgetBody().contains('Senden Sie uns eine Nachricht', { timeout: 20000 }).should('be.visible')
+    })
+  })
+
+  it('collects pre-chat form fields and attaches them to the contact', () => {
+    const stamp = Date.now()
+    const email = `prechat.${stamp}@cypress.test`
+    let inbox
+
+    cy.createLivechatInbox(
+      withStart({
+        prechat_form: {
+          enabled: true,
+          title: 'Tell us about you',
+          fields: [
+            { key: 'name', type: 'text', label: 'Name', required: true, enabled: true, order: 1, is_default: true },
+            { key: 'email', type: 'email', label: 'Email', required: true, enabled: true, order: 2, is_default: true }
+          ]
+        }
+      })
+    ).then((created) => {
+      inbox = created
+    })
+
+    cy.then(() => cy.openWidget(inbox))
+    cy.widgetBody().contains(startText).click()
+    cy.widgetBody().contains('Tell us about you').should('be.visible')
+
+    cy.widgetBody().contains('button', 'Start chat').should('be.disabled')
+    cy.widgetBody().find('input').eq(0).type('Cypress Prechat')
+    cy.widgetBody().find('input').eq(1).type(email)
+    cy.widgetBody().find('textarea').should('be.visible').type(`Prechat message ${stamp}`)
+    cy.widgetBody().contains('button', 'Start chat').click()
+    cy.widgetBody().contains(`Prechat message ${stamp}`, { timeout: 20000 }).should('be.visible')
+
+    cy.then(() =>
+      cy.latestConversation(inbox).then((conversation) => {
+        expect(conversation.contact.email, 'pre-chat email not saved on the contact').to.eq(email)
+        expect(JSON.stringify(conversation.contact)).to.include('Cypress Prechat')
+      })
+    )
+  })
+})

--- a/frontend/cypress/e2e/integration/livechat/embed.cy.js
+++ b/frontend/cypress/e2e/integration/livechat/embed.cy.js
@@ -1,0 +1,154 @@
+const startButtonText = 'Cypress start chat'
+
+const embedConfig = (overrides = {}) => ({
+  visitors: { allow_start_conversation: true, start_conversation_button_text: startButtonText },
+  users: { allow_start_conversation: true, start_conversation_button_text: startButtonText },
+  ...overrides
+})
+
+describe('Live chat widget embedded on a host page', () => {
+  it('renders the launcher and keeps the panel closed until clicked', () => {
+    cy.createLivechatInbox(embedConfig()).then((inbox) => {
+      cy.visitWidgetHost(inbox.uuid)
+      cy.widgetLauncher().should('be.visible')
+      cy.get('iframe[src*="/widget?inbox_id="]').should('not.be.visible')
+
+      cy.widgetLauncher().click()
+      cy.get('iframe[src*="/widget?inbox_id="]').should('be.visible')
+      cy.widgetBody().contains(startButtonText).should('be.visible')
+    })
+  })
+
+  it('moves the launcher when the inbox launcher position changes', () => {
+    cy.createLivechatInbox(
+      embedConfig({ launcher: { position: 'right', spacing: { side: 20, bottom: 20 } } })
+    ).then((inbox) => {
+      cy.visitWidgetHost(inbox.uuid)
+      cy.widgetWrapperSide().then((side) => {
+        expect(side.right, 'launcher not on the right').to.eq('20px')
+        expect(side.left).to.eq('auto')
+      })
+
+      cy.then(() =>
+        cy.saveLivechatInbox(inbox, { launcher: { position: 'left', spacing: { side: 40, bottom: 60 } } })
+      )
+      cy.then(() => cy.visitWidgetHost(inbox.uuid))
+      cy.widgetWrapperSide().then((side) => {
+        expect(side.left, 'launcher did not move to the left').to.eq('40px')
+        expect(side.right).to.eq('auto')
+        expect(side.bottom).to.eq('60px')
+      })
+    })
+  })
+
+  it('starts a conversation as a visitor and shows the agent reply', () => {
+    const visitorMessage = `Visitor from the widget ${Date.now()}`
+    const agentMessage = `Agent answer ${Date.now()}`
+    let inbox
+
+    cy.createLivechatInbox(embedConfig()).then((created) => {
+      inbox = created
+    })
+    cy.then(() => cy.visitWidgetHost(inbox.uuid))
+    cy.widgetLauncher().click()
+
+    cy.widgetBody().contains(startButtonText).click()
+    cy.widgetBody().find('textarea').should('be.visible').type(visitorMessage)
+    cy.widgetBody().find('button[aria-label="Send"]').click()
+    cy.widgetBody().contains(visitorMessage, { timeout: 20000 }).should('be.visible')
+
+    cy.then(() => cy.agentReplyToLatestConversation(inbox, agentMessage))
+    cy.widgetBody().contains(agentMessage, { timeout: 20000 }).should('be.visible')
+  })
+
+  it('keeps delivering agent replies in the widget after the inbox is saved', () => {
+    const visitorMessage = `Visitor before save ${Date.now()}`
+    const beforeSave = `Agent before save ${Date.now()}`
+    const afterSave = `Agent after save ${Date.now()}`
+    let inbox
+
+    cy.createLivechatInbox(embedConfig()).then((created) => {
+      inbox = created
+    })
+    cy.then(() => cy.visitWidgetHost(inbox.uuid))
+    cy.widgetLauncher().click()
+    cy.widgetBody().contains(startButtonText).click()
+    cy.widgetBody().find('textarea').should('be.visible').type(visitorMessage)
+    cy.widgetBody().find('button[aria-label="Send"]').click()
+    cy.widgetBody().contains(visitorMessage, { timeout: 20000 }).should('be.visible')
+
+    cy.then(() => cy.agentReplyToLatestConversation(inbox, beforeSave))
+    cy.widgetBody().contains(beforeSave, { timeout: 20000 }).should('be.visible')
+
+    cy.then(() => cy.saveLivechatInbox(inbox, { brand_name: 'Cypress saved' }))
+
+    cy.then(() => cy.agentReplyToLatestConversation(inbox, afterSave))
+    cy.widgetBody().contains(afterSave, { timeout: 30000 }).should('be.visible')
+  })
+
+  it('identifies the contact from a signed JWT', () => {
+    const stamp = Date.now()
+    const email = `jwt.visitor.${stamp}@cypress.test`
+    const secret = `cypress-secret-${stamp}`
+    const visitorMessage = `JWT visitor message ${stamp}`
+    let inbox
+
+    cy.createLivechatInbox(embedConfig(), { secret }).then((created) => {
+      inbox = created
+    })
+
+    cy.then(() => {
+      cy.intercept('POST', '/api/v1/widget/chat/auth/exchange').as('exchange')
+      return cy.visitWidgetHost(inbox.uuid, {
+        secret,
+        jwtPayload: {
+          external_user_id: `cypress_${stamp}`,
+          email,
+          first_name: 'Cypress',
+          last_name: 'Visitor'
+        }
+      })
+    })
+    cy.wait('@exchange').its('response.statusCode').should('eq', 200)
+
+    cy.widgetLauncher().click()
+    cy.widgetBody().contains(startButtonText).click()
+    cy.widgetBody().find('textarea').should('be.visible').type(visitorMessage)
+    cy.widgetBody().find('button[aria-label="Send"]').click()
+    cy.widgetBody().contains(visitorMessage, { timeout: 20000 }).should('be.visible')
+
+    cy.then(() =>
+      cy.latestConversation(inbox).then((conversation) => {
+        expect(JSON.stringify(conversation), 'conversation not attached to the JWT contact').to.include(email)
+      })
+    )
+  })
+
+  it('enforces a required pre-chat field before the chat opens', () => {
+    cy.createLivechatInbox(
+      embedConfig({
+        prechat_form: {
+          enabled: true,
+          title: 'Before we start',
+          fields: [
+            {
+              key: 'name',
+              type: 'text',
+              label: 'Name',
+              required: true,
+              enabled: true,
+              order: 1,
+              is_default: true
+            }
+          ]
+        }
+      })
+    ).then((inbox) => {
+      cy.visitWidgetHost(inbox.uuid)
+      cy.widgetLauncher().click()
+      cy.widgetBody().contains(startButtonText).click()
+      cy.widgetBody().contains('Before we start').should('be.visible')
+      cy.widgetBody().find('input').should('exist')
+    })
+  })
+})

--- a/frontend/cypress/e2e/integration/livechat/messaging.cy.js
+++ b/frontend/cypress/e2e/integration/livechat/messaging.cy.js
@@ -1,0 +1,125 @@
+import { joined, gotMessage } from '../../../support/livechat'
+
+describe('Live chat widget messaging', () => {
+  let inbox
+  let session
+  let socket
+  const openingMessage = `Visitor opening ${Date.now()}`
+
+  beforeEach(() => {
+    cy.createLivechatInbox().then((created) => {
+      inbox = created
+    })
+    cy.then(() => cy.widgetInit(inbox.uuid, { message: openingMessage })).then((res) => {
+      session = res
+    })
+    cy.visit('/inboxes/all')
+    cy.then(() => cy.openWidgetSocket(session.sessionToken, inbox.uuid)).then((s) => {
+      socket = s
+    })
+    cy.then(() => cy.waitForFrame(joined(socket), 'widget never joined the inbox'))
+  })
+
+  it('lands the visitor opening message on the conversation', () => {
+    cy.then(() =>
+      cy
+        .api('GET', `/api/v1/conversations/${session.conversationUuid}/messages`)
+        .then(({ status, body }) => {
+          expect(status).to.eq(200)
+          expect(JSON.stringify(body.data), 'opening message missing').to.include(openingMessage)
+        })
+    )
+  })
+
+  it('delivers an agent reply over the socket', () => {
+    const reply = `Agent reply ${Date.now()}`
+    cy.agentReply(() => session.conversationUuid, reply)
+    cy.then(() => cy.waitForFrame(gotMessage(socket, reply), 'agent reply never reached the widget'))
+  })
+
+  it('accepts a visitor reply and echoes it back to the widget', () => {
+    const message = `Visitor reply ${Date.now()}`
+    cy.then(() =>
+      cy
+        .widgetApi(
+          'POST',
+          `/api/v1/widget/chat/conversations/${session.conversationUuid}/message`,
+          session.sessionToken,
+          inbox.uuid,
+          { message }
+        )
+        .its('status')
+        .should('eq', 200)
+    )
+    cy.then(() =>
+      cy
+        .api('GET', `/api/v1/conversations/${session.conversationUuid}/messages`)
+        .then(({ body }) => {
+          expect(JSON.stringify(body.data), 'visitor reply missing').to.include(message)
+        })
+    )
+  })
+
+  it('rejects an empty and an oversized visitor message', () => {
+    const send = (message) =>
+      cy.widgetApi(
+        'POST',
+        `/api/v1/widget/chat/conversations/${session.conversationUuid}/message`,
+        session.sessionToken,
+        inbox.uuid,
+        { message },
+        { failOnStatusCode: false }
+      )
+
+    cy.then(() => send('').its('status').should('eq', 400))
+    cy.then(() => send('x'.repeat(10001)).its('status').should('eq', 400))
+  })
+
+  it('pushes a conversation update when the agent changes status', () => {
+    cy.then(() =>
+      cy
+        .api('PUT', `/api/v1/conversations/${session.conversationUuid}/status`, { status: 'Resolved' })
+        .its('status')
+        .should('eq', 200)
+    )
+    cy.then(() =>
+      cy.waitForFrame(
+        () => socket.received.some((m) => m.type === 'conversation_update'),
+        'status change never reached the widget'
+      )
+    )
+  })
+
+  it('accepts typing and page_visit frames without dropping the socket', () => {
+    cy.then(() => {
+      socket.ws.send(
+        JSON.stringify({
+          type: 'typing',
+          data: { conversation_uuid: session.conversationUuid, is_typing: true }
+        })
+      )
+      socket.ws.send(
+        JSON.stringify({ type: 'page_visit', data: { url: 'https://example.test/pricing', title: 'Pricing' } })
+      )
+    })
+    cy.then(() =>
+      cy.waitForFrame(() => socket.received.some((m) => m.type === 'pong'), 'socket stopped answering pings', 15000)
+    )
+    cy.then(() => expect(socket.closed, 'socket dropped after client frames').to.be.false)
+  })
+
+  it('marks the conversation seen for the visitor', () => {
+    cy.then(() =>
+      cy
+        .widgetApi(
+          'POST',
+          `/api/v1/widget/chat/conversations/${session.conversationUuid}/update-last-seen`,
+          session.sessionToken,
+          inbox.uuid,
+          {}
+        )
+        .its('status')
+        .should('eq', 200)
+    )
+  })
+})

--- a/frontend/cypress/e2e/integration/livechat/resilience.cy.js
+++ b/frontend/cypress/e2e/integration/livechat/resilience.cy.js
@@ -1,0 +1,112 @@
+import { joined, gotMessage } from '../../../support/livechat'
+
+describe('Live chat widget connection resilience', () => {
+  let inbox
+  let session
+
+  beforeEach(() => {
+    cy.createLivechatInbox().then((created) => {
+      inbox = created
+    })
+    cy.then(() => cy.widgetInit(inbox.uuid)).then((res) => {
+      session = res
+    })
+    cy.visit('/inboxes/all') // same-origin window to open the widget socket from
+  })
+
+  it('keeps delivering agent replies after the inbox is saved', () => {
+    const before = `Reply before save ${Date.now()}`
+    const after = `Reply after save ${Date.now()}`
+    let socket
+
+    cy.then(() => cy.openWidgetSocket(session.sessionToken, inbox.uuid)).then((s) => {
+      socket = s
+    })
+    cy.then(() => cy.waitForFrame(joined(socket), 'widget never joined the inbox'))
+
+    cy.agentReply(() => session.conversationUuid, before)
+    cy.then(() => cy.waitForFrame(gotMessage(socket, before), 'agent reply never reached the widget'))
+
+    cy.then(() => cy.saveLivechatInbox(inbox, { brand_name: 'Cypress saved' }))
+    cy.then(() => cy.waitForFrame(() => socket.closed, 'inbox save left the widget socket open'))
+
+    let reconnected
+    cy.then(() => cy.openWidgetSocket(session.sessionToken, inbox.uuid)).then((s) => {
+      reconnected = s
+    })
+    cy.then(() => cy.waitForFrame(joined(reconnected), 'widget never rejoined after the inbox save'))
+
+    cy.agentReply(() => session.conversationUuid, after)
+    cy.then(() =>
+      cy.waitForFrame(gotMessage(reconnected, after), 'reply after the inbox save never reached the widget')
+    )
+  })
+
+  it('drops a socket that stops sending pings', () => {
+    let socket
+
+    cy.then(() => cy.openWidgetSocket(session.sessionToken, inbox.uuid, { keepAlive: false })).then((s) => {
+      socket = s
+    })
+    cy.then(() => cy.waitForFrame(joined(socket), 'widget never joined the inbox'))
+    cy.then(() =>
+      cy.waitForFrame(() => socket.closed, 'silent socket outlived the read deadline', 30000)
+    )
+  })
+
+  it('refuses a join past the per-user connection cap', () => {
+    const cap = 10
+    const sockets = []
+
+    Cypress._.times(cap, () => {
+      cy.then(() => cy.openWidgetSocket(session.sessionToken, inbox.uuid)).then((s) => sockets.push(s))
+    })
+    cy.then(() =>
+      cy.waitForFrame(
+        () => sockets.every((s) => s.received.some((m) => m.type === 'joined')),
+        'not every socket under the cap joined'
+      )
+    )
+
+    let overflow
+    cy.then(() => cy.openWidgetSocket(session.sessionToken, inbox.uuid)).then((s) => {
+      overflow = s
+    })
+    cy.then(() =>
+      cy.waitForFrame(
+        () => overflow.received.some((m) => m.type === 'error'),
+        'join past the connection cap was not refused'
+      )
+    )
+    cy.then(() => expect(joined(overflow)(), 'capped socket still joined').to.be.false)
+  })
+
+  it('replays messages missed while disconnected', () => {
+    const missed = `Reply while offline ${Date.now()}`
+    let socket
+
+    cy.then(() => cy.openWidgetSocket(session.sessionToken, inbox.uuid)).then((s) => {
+      socket = s
+    })
+    cy.then(() => cy.waitForFrame(joined(socket), 'widget never joined the inbox'))
+    cy.then(() => socket.ws.close())
+    cy.then(() => cy.waitForFrame(() => socket.closed, 'socket never closed'))
+
+    cy.agentReply(() => session.conversationUuid, missed)
+
+    cy.then(() =>
+      cy
+        .widgetApi(
+          'GET',
+          `/api/v1/widget/chat/conversations/${session.conversationUuid}`,
+          session.sessionToken,
+          inbox.uuid
+        )
+        .then(({ status, body }) => {
+          expect(status).to.eq(200)
+          const messages = JSON.stringify(body.data)
+          expect(messages, 'missed reply absent from the conversation').to.include(missed)
+        })
+    )
+  })
+})

--- a/frontend/cypress/e2e/integration/livechat/session.cy.js
+++ b/frontend/cypress/e2e/integration/livechat/session.cy.js
@@ -129,4 +129,53 @@ describe('Live chat widget session and auth', () => {
     })
     cy.then(() => cy.waitForFrame(joined(socket), 'session did not survive a reload'))
   })
+
+  it('merges an anonymous visitor into the JWT contact', () => {
+    const stamp = Date.now()
+    const email = `merge.${stamp}@cypress.test`
+    const secret = `cypress-secret-${stamp}`
+    let jwtInbox
+    let visitorToken
+    let contactToken
+
+    cy.createLivechatInbox({}, { secret }).then((created) => {
+      jwtInbox = created
+    })
+    cy.then(() => cy.widgetInit(jwtInbox.uuid, { message: `Anonymous message ${stamp}` })).then((res) => {
+      visitorToken = res.sessionToken
+    })
+
+    cy.then(() =>
+      cy
+        .signWidgetJWT(
+          { external_user_id: `merge_${stamp}`, email, first_name: 'Merged', last_name: 'Contact' },
+          secret
+        )
+        .then((jwt) =>
+          cy
+            .widgetApi('POST', '/api/v1/widget/chat/auth/exchange', null, jwtInbox.uuid, { jwt })
+            .then(({ status, body }) => {
+              expect(status).to.eq(200)
+              contactToken = body.data.session_token
+            })
+        )
+    )
+
+    cy.then(() =>
+      cy
+        .widgetApi('GET', '/api/v1/widget/chat/conversations', contactToken, jwtInbox.uuid, null, {
+          headers: { 'X-Libredesk-Visitor-Token': visitorToken }
+        })
+        .then((res) => {
+          expect(res.status).to.eq(200)
+          expect(res.headers['x-libredesk-clear-visitor'], 'visitor token not cleared after merge').to.eq('true')
+        })
+    )
+
+    cy.then(() =>
+      cy.latestConversation(jwtInbox).then((conversation) => {
+        expect(conversation.contact.email, 'conversation not moved to the JWT contact').to.eq(email)
+      })
+    )
+  })
 })

--- a/frontend/cypress/e2e/integration/livechat/session.cy.js
+++ b/frontend/cypress/e2e/integration/livechat/session.cy.js
@@ -1,0 +1,132 @@
+import { joined } from '../../../support/livechat'
+
+describe('Live chat widget session and auth', () => {
+  let inbox
+  let session
+
+  beforeEach(() => {
+    cy.createLivechatInbox().then((created) => {
+      inbox = created
+    })
+    cy.then(() => cy.widgetInit(inbox.uuid)).then((res) => {
+      session = res
+    })
+  })
+
+  it('issues a session token that identifies the visitor', () => {
+    cy.then(() =>
+      cy
+        .widgetApi('GET', '/api/v1/widget/chat/auth/me', session.sessionToken, inbox.uuid)
+        .then(({ status, body }) => {
+          expect(status).to.eq(200)
+          expect(body.data, 'auth/me returned no user').to.not.be.null
+        })
+    )
+  })
+
+  it('rejects a missing, garbage, or foreign-inbox token', () => {
+    cy.then(() =>
+      cy
+        .widgetApi('GET', '/api/v1/widget/chat/auth/me', null, inbox.uuid, null, {
+          failOnStatusCode: false
+        })
+        .its('status')
+        .should('eq', 401)
+    )
+    cy.then(() =>
+      cy
+        .widgetApi('GET', '/api/v1/widget/chat/auth/me', 'not-a-real-token', inbox.uuid, null, {
+          failOnStatusCode: false
+        })
+        .its('status')
+        .should('eq', 401)
+    )
+
+    let other
+    cy.createLivechatInbox().then((created) => {
+      other = created
+    })
+    cy.then(() =>
+      cy
+        .widgetApi('GET', '/api/v1/widget/chat/auth/me', session.sessionToken, other.uuid, null, {
+          failOnStatusCode: false
+        })
+        .its('status')
+        .should('eq', 401)
+    )
+  })
+
+  it('refuses a socket join carrying a bad token', () => {
+    cy.visit('/inboxes/all')
+    let socket
+    cy.then(() => cy.openWidgetSocket('not-a-real-token', inbox.uuid)).then((s) => {
+      socket = s
+    })
+    cy.then(() =>
+      cy.waitForFrame(
+        () => socket.received.some((m) => m.type === 'error'),
+        'bad token was allowed to join'
+      )
+    )
+    cy.then(() => expect(joined(socket)(), 'bad token still joined').to.be.false)
+  })
+
+  it('rejects a numeric or unknown inbox id', () => {
+    cy.then(() =>
+      cy
+        .widgetApi('GET', '/api/v1/widget/chat/settings', null, '1', null, { failOnStatusCode: false })
+        .its('status')
+        .should('eq', 400)
+    )
+    cy.then(() =>
+      cy
+        .widgetApi(
+          'GET',
+          '/api/v1/widget/chat/settings',
+          null,
+          '00000000-0000-0000-0000-000000000000',
+          null,
+          { failOnStatusCode: false }
+        )
+        .its('status')
+        .should('eq', 400)
+    )
+  })
+
+  it('locks out the widget once the inbox is disabled', () => {
+    cy.then(() => cy.api('PUT', `/api/v1/inboxes/${inbox.id}`, { ...inbox.payload, enabled: false }))
+    cy.then(() =>
+      cy
+        .widgetApi('GET', '/api/v1/widget/chat/settings', null, inbox.uuid, null, {
+          failOnStatusCode: false
+        })
+        .its('status')
+        .should('eq', 400)
+    )
+    cy.then(() =>
+      cy.widgetInit(inbox.uuid, {}, { failOnStatusCode: false }).its('status').should('eq', 400)
+    )
+  })
+
+  it('blocks a visitor whose IP is on the inbox blocklist', () => {
+    cy.then(() => cy.saveLivechatInbox(inbox, { blocked_ips: ['0.0.0.0/0'] }))
+    cy.then(() =>
+      cy
+        .widgetApi('GET', '/api/v1/widget/chat/settings', null, inbox.uuid, null, {
+          failOnStatusCode: false
+        })
+        .its('status')
+        .should('eq', 403)
+    )
+  })
+
+  it('keeps the session usable across a page reload', () => {
+    cy.visit('/inboxes/all')
+    cy.reload()
+    let socket
+    cy.then(() => cy.openWidgetSocket(session.sessionToken, inbox.uuid)).then((s) => {
+      socket = s
+    })
+    cy.then(() => cy.waitForFrame(joined(socket), 'session did not survive a reload'))
+  })
+})

--- a/frontend/cypress/e2e/integration/livechat/settings.cy.js
+++ b/frontend/cypress/e2e/integration/livechat/settings.cy.js
@@ -1,0 +1,129 @@
+describe('Live chat widget settings and init rules', () => {
+  it('serves launcher settings without a session', () => {
+    cy.createLivechatInbox({ launcher: { position: 'left' } }).then((inbox) => {
+      cy.widgetApi('GET', '/api/v1/widget/chat/settings/launcher', null, inbox.uuid).then(
+        ({ status, body }) => {
+          expect(status).to.eq(200)
+          expect(body.data.launcher.position).to.eq('left')
+        }
+      )
+    })
+  })
+
+  it('withholds server-side config from the public settings response', () => {
+    cy.createLivechatInbox({
+      blocked_ips: ['203.0.113.7'],
+      trusted_domains: ['example.test'],
+      session_duration: '4h'
+    }).then((inbox) => {
+      cy.widgetApi('GET', '/api/v1/widget/chat/settings', null, inbox.uuid).then(({ status, body }) => {
+        expect(status).to.eq(200)
+        expect(body.data.brand_name).to.eq('Cypress')
+        expect(body.data).to.not.have.property('blocked_ips')
+        expect(body.data).to.not.have.property('trusted_domains')
+        expect(body.data).to.not.have.property('session_duration')
+      })
+    })
+  })
+
+  it('publishes the enabled pre-chat form fields', () => {
+    cy.createLivechatInbox({
+      prechat_form: {
+        enabled: true,
+        title: 'Before we start',
+        fields: [
+          { key: 'name', type: 'text', label: 'Name', required: true, enabled: true, order: 1, is_default: true },
+          { key: 'email', type: 'email', label: 'Email', required: false, enabled: false, order: 2, is_default: true }
+        ]
+      }
+    }).then((inbox) => {
+      cy.widgetApi('GET', '/api/v1/widget/chat/settings', null, inbox.uuid).then(({ body }) => {
+        const keys = body.data.prechat_form.fields.map((f) => f.key)
+        expect(body.data.prechat_form.enabled).to.be.true
+        expect(keys).to.include('name')
+      })
+    })
+  })
+
+  it('refuses init when a required pre-chat field is missing', () => {
+    cy.createLivechatInbox({
+      prechat_form: {
+        enabled: true,
+        fields: [
+          { key: 'name', type: 'text', label: 'Name', required: true, enabled: true, order: 1, is_default: true }
+        ]
+      }
+    }).then((inbox) => {
+      cy.widgetInit(inbox.uuid, { form_data: {} }, { failOnStatusCode: false }).then((res) => {
+        expect(res.status, 'init accepted a missing required field').to.eq(400)
+        expect(res.body.message, 'error did not name the field').to.match(/name/i)
+      })
+      cy.widgetInit(inbox.uuid, { form_data: { name: 'Cypress Visitor' } }).its('status').should('eq', 200)
+    })
+  })
+
+  it('refuses init when an email pre-chat field is malformed', () => {
+    cy.createLivechatInbox({
+      prechat_form: {
+        enabled: true,
+        fields: [
+          { key: 'email', type: 'email', label: 'Email', required: true, enabled: true, order: 1, is_default: true }
+        ]
+      }
+    }).then((inbox) => {
+      cy.widgetInit(inbox.uuid, { form_data: { email: 'not-an-email' } }, { failOnStatusCode: false }).then(
+        (res) => {
+          expect(res.status, 'init accepted a malformed email').to.eq(400)
+          expect(res.body.message, 'error did not mention the email').to.match(/email/i)
+        }
+      )
+      cy.widgetInit(inbox.uuid, { form_data: { email: 'visitor@example.test' } })
+        .its('status')
+        .should('eq', 200)
+    })
+  })
+
+  it('refuses init when visitors may not start conversations', () => {
+    cy.createLivechatInbox({ visitors: { allow_start_conversation: false } }).then((inbox) => {
+      cy.widgetInit(inbox.uuid, {}, { failOnStatusCode: false }).its('status').should('eq', 400)
+    })
+  })
+
+  it('refuses a second conversation when multiples are prevented', () => {
+    cy.createLivechatInbox({ visitors: { prevent_multiple_conversations: true } }).then((inbox) => {
+      let token
+      cy.widgetInit(inbox.uuid).then((res) => {
+        token = res.sessionToken
+      })
+      cy.then(() =>
+        cy
+          .request({
+            method: 'POST',
+            url: '/api/v1/widget/chat/conversations/init',
+            headers: {
+              'X-Libredesk-Inbox-ID': inbox.uuid,
+              Authorization: `Bearer ${token}`
+            },
+            body: { message: 'Second conversation' },
+            failOnStatusCode: false
+          })
+          .its('status')
+          .should('eq', 403)
+      )
+    })
+  })
+
+  it('rejects init without a message', () => {
+    cy.createLivechatInbox().then((inbox) => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/widget/chat/conversations/init',
+        headers: { 'X-Libredesk-Inbox-ID': inbox.uuid },
+        body: {},
+        failOnStatusCode: false
+      })
+        .its('status')
+        .should('eq', 400)
+    })
+  })
+})

--- a/frontend/cypress/e2e/integration/livechat/settings.cy.js
+++ b/frontend/cypress/e2e/integration/livechat/settings.cy.js
@@ -126,4 +126,22 @@ describe('Live chat widget settings and init rules', () => {
         .should('eq', 400)
     })
   })
+
+  it('names the field when a pre-chat value is too long', () => {
+    cy.createLivechatInbox({
+      prechat_form: {
+        enabled: true,
+        fields: [
+          { key: 'name', type: 'text', label: 'Name', required: true, enabled: true, order: 1, is_default: true }
+        ]
+      }
+    }).then((inbox) => {
+      cy.widgetInit(inbox.uuid, { form_data: { name: 'x'.repeat(300) } }, { failOnStatusCode: false }).then(
+        (res) => {
+          expect(res.status).to.eq(400)
+          expect(res.body.message, 'error does not name the field').to.match(/name/i)
+        }
+      )
+    })
+  })
 })

--- a/frontend/cypress/support/e2e.js
+++ b/frontend/cypress/support/e2e.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands'
+import './livechat'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/frontend/cypress/support/livechat.js
+++ b/frontend/cypress/support/livechat.js
@@ -152,3 +152,185 @@ after(() => {
     cy.api('DELETE', `/api/v1/inboxes/${id}`, null, { failOnStatusCode: false })
   })
 })
+
+const embedHostPath = '/__widget-embed-test'
+
+// Served from the app's own origin, else the iframe is cross-origin and its DOM is unreachable.
+Cypress.Commands.add('visitWidgetHost', (inboxUuid, { secret = null, jwtPayload = null } = {}) => {
+  const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>widget embed host</title></head>
+<body>
+<h1 id="host-title">Customer site</h1>
+<script>
+window.__widgetMessages = []
+window.addEventListener('message', function (e) {
+  if (!e.source || e.source === window) return
+  var lc = window.Libredesk
+  var fromIframe = !!(lc && lc.iframe && e.source === lc.iframe.contentWindow)
+  window.__widgetMessages.push(((e.data || {}).type || '?') + ':' + fromIframe)
+})
+</script>
+<script>
+function b64url (bytes) {
+  let s = ''
+  bytes.forEach(b => { s += String.fromCharCode(b) })
+  return btoa(s).replace(/\\+/g, '-').replace(/\\//g, '_').replace(/=+$/, '')
+}
+async function signJWT (payload, secret) {
+  const enc = new TextEncoder()
+  const h = b64url(enc.encode(JSON.stringify({ alg: 'HS256', typ: 'JWT' })))
+  const p = b64url(enc.encode(JSON.stringify(payload)))
+  const key = await crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(h + '.' + p))
+  return h + '.' + p + '.' + b64url(new Uint8Array(sig))
+}
+;(async function () {
+  const cfg = { baseURL: window.location.origin, inboxID: ${JSON.stringify(inboxUuid)} }
+  const secret = ${JSON.stringify(secret)}
+  const payload = ${JSON.stringify(jwtPayload)}
+  if (secret && payload) {
+    payload.exp = Math.floor(Date.now() / 1000) + 3600
+    cfg.userJWT = await signJWT(payload, secret)
+    window.__widgetJWT = cfg.userJWT
+  }
+  window.LibredeskSettings = cfg
+  const s = document.createElement('script')
+  s.src = '/widget.js'
+  document.body.appendChild(s)
+})()
+</script>
+</body></html>`
+  cy.intercept('GET', `${embedHostPath}*`, {
+    statusCode: 200,
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+    body: html
+  }).as('embedHost')
+  cy.visit(embedHostPath)
+  return cy.window({ timeout: 20000 }).its('Libredesk.toggleButton', { timeout: 20000 })
+})
+
+Cypress.Commands.add('widgetLauncher', () =>
+  cy.window().its('Libredesk.toggleButton').then((el) => cy.wrap(el, { log: false }))
+)
+
+Cypress.Commands.add('widgetWrapperSide', () =>
+  cy.window().its('Libredesk.widgetButtonWrapper').then((el) => {
+    const s = el.ownerDocument.defaultView.getComputedStyle(el)
+    return { left: s.left, right: s.right, bottom: s.bottom }
+  })
+)
+
+Cypress.Commands.add('widgetBody', () =>
+  cy
+    .get('iframe[src*="/widget?inbox_id="]', { timeout: 20000 })
+    .its('0.contentDocument.body', { timeout: 20000 })
+    .should('not.be.empty')
+    .then((body) => cy.wrap(body, { log: false }))
+)
+
+// No cy.login() here: cy.session() blanks the page, which would tear down an embedded widget mid-test.
+Cypress.Commands.add('latestConversation', (inbox) => {
+  return cy
+    .api(
+      'GET',
+      '/api/v1/conversations/all?order=desc&order_by=conversations.created_at&page=1&page_size=50'
+    )
+    .then(({ body }) => {
+      const match = body.data.results.find((c) => c.inbox_name === inbox.payload.name)
+      expect(match, `no conversation found for inbox ${inbox.payload.name}`).to.exist
+      return match
+    })
+})
+
+Cypress.Commands.add('agentReplyToLatestConversation', (inbox, body) =>
+  cy.latestConversation(inbox).then((conversation) =>
+    cy
+      .api('POST', `/api/v1/conversations/${conversation.uuid}/messages`, {
+        message: `<p>${body}</p>`,
+        private: false,
+        sender_type: 'agent'
+      })
+      .its('status')
+      .should('eq', 200)
+  )
+)
+
+Cypress.Commands.add('openWidget', (inbox, opts = {}) => {
+  cy.visitWidgetHost(inbox.uuid, opts)
+  cy.widgetLauncher().click()
+  return cy.widgetBody()
+})
+
+Cypress.Commands.add('widgetSend', (text) => {
+  cy.widgetBody().find('textarea').should('be.visible').type(text)
+  cy.widgetBody().find('button[aria-label="Send"]').click()
+  return cy.widgetBody().contains(text, { timeout: 20000 }).should('be.visible')
+})
+
+Cypress.Commands.add('closeConversation', (inbox) =>
+  cy.latestConversation(inbox).then((conversation) =>
+    cy
+      .api('PUT', `/api/v1/conversations/${conversation.uuid}/status`, { status: 'Closed' })
+      .its('status')
+      .should('eq', 200)
+  )
+)
+
+Cypress.Commands.add('conversationForInbox', (inbox) =>
+  cy
+    .api('GET', '/api/v1/conversations/all?order=desc&order_by=conversations.created_at&page=1&page_size=50')
+    .then(({ body }) => body.data.results.find((c) => c.inbox_name === inbox.payload.name) || null)
+)
+
+// Retries because the visitor-to-contact merge lands on a later widget request, not on the exchange itself.
+Cypress.Commands.add('waitForConversationContact', (inbox, email, timeout = 20000) =>
+  cy.wrap(null, { timeout, log: false }).should(() => {
+    const found = Cypress.$.ajax({
+      url: '/api/v1/conversations/all?order=desc&order_by=conversations.created_at&page=1&page_size=50',
+      async: false
+    })
+    const results = JSON.parse(found.responseText).data.results
+    const match = results.find((c) => c.inbox_name === inbox.payload.name)
+    expect(match && match.contact && match.contact.email, 'contact email on the conversation').to.eq(email)
+  })
+)
+
+Cypress.Commands.add('setDefaultBusinessHours', (businessHoursId) =>
+  cy.api('GET', '/api/v1/settings/general').then(({ body }) => {
+    const settings = { ...body.data, 'app.business_hours_id': businessHoursId }
+    delete settings['app.version']
+    delete settings['app.update']
+    delete settings['app.restart_required']
+    return cy.api('PUT', '/api/v1/settings/general', settings).its('status').should('eq', 200)
+  })
+)
+
+// The widget renders a message optimistically, so the session cookie can lag behind it.
+Cypress.Commands.add('waitForWidgetCookie', (inbox, type = 'session', timeout = 20000) =>
+  cy.wrap(null, { timeout, log: false }).should(() => {
+    const doc = cy.state('window').document
+    expect(doc.cookie, `libredesk-${type} cookie`).to.include(`libredesk-${type}-${inbox.uuid}=`)
+  })
+)
+
+const b64url = (bytes) => {
+  let s = ''
+  bytes.forEach((b) => {
+    s += String.fromCharCode(b)
+  })
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+Cypress.Commands.add('signWidgetJWT', (payload, secret) => {
+  const enc = new TextEncoder()
+  const body = { exp: Math.floor(Date.now() / 1000) + 3600, ...payload }
+  const header = b64url(enc.encode(JSON.stringify({ alg: 'HS256', typ: 'JWT' })))
+  const claims = b64url(enc.encode(JSON.stringify(body)))
+  return cy.wrap(
+    window.crypto.subtle
+      .importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+      .then((key) => window.crypto.subtle.sign('HMAC', key, enc.encode(`${header}.${claims}`)))
+      .then((sig) => `${header}.${claims}.${b64url(new Uint8Array(sig))}`),
+    { log: false }
+  )
+})

--- a/frontend/cypress/support/livechat.js
+++ b/frontend/cypress/support/livechat.js
@@ -1,0 +1,154 @@
+const openSockets = []
+const createdInboxes = []
+
+const baseConfig = () => ({
+  brand_name: 'Cypress',
+  colors: { primary: '#112233' },
+  launcher: { position: 'right', spacing: { side: 20, bottom: 20 } },
+  session_duration: '4h',
+  visitors: { allow_start_conversation: true },
+  users: { allow_start_conversation: true }
+})
+
+const merge = (base, extra) => {
+  const out = { ...base }
+  Object.entries(extra || {}).forEach(([key, value]) => {
+    out[key] =
+      value && typeof value === 'object' && !Array.isArray(value)
+        ? merge(base[key] || {}, value)
+        : value
+  })
+  return out
+}
+
+Cypress.Commands.add('createLivechatInbox', (configOverrides = {}, inboxOverrides = {}) => {
+  const stamp = `${Date.now()}${Cypress._.random(1000, 9999)}`
+  const payload = {
+    name: `Livechat ${stamp}`,
+    channel: 'livechat',
+    enabled: true,
+    from: `Livechat <livechat+${stamp}@cypress.test>`,
+    config: merge(baseConfig(), configOverrides),
+    ...inboxOverrides
+  }
+  cy.login()
+  return cy.api('POST', '/api/v1/inboxes', payload).then(({ body }) => {
+    const inbox = { id: body.data.id, uuid: body.data.uuid, payload }
+    expect(inbox.uuid, 'inbox uuid').to.be.a('string').and.not.be.empty
+    createdInboxes.push(inbox.id)
+    return inbox
+  })
+})
+
+Cypress.Commands.add('saveLivechatInbox', (inbox, configOverrides = {}) => {
+  const payload = { ...inbox.payload, config: merge(inbox.payload.config, configOverrides) }
+  inbox.payload = payload
+  return cy.api('PUT', `/api/v1/inboxes/${inbox.id}`, payload).its('status').should('eq', 200)
+})
+
+Cypress.Commands.add('widgetInit', (inboxUuid, body = {}, options = {}) =>
+  cy
+    .request({
+      method: 'POST',
+      url: '/api/v1/widget/chat/conversations/init',
+      headers: { 'X-Libredesk-Inbox-ID': inboxUuid, ...(options.headers || {}) },
+      body: { message: body.message || `Visitor hello ${Date.now()}`, ...body },
+      failOnStatusCode: options.failOnStatusCode !== false
+    })
+    .then((res) => {
+      if (res.status !== 200) return res
+      return {
+        status: res.status,
+        body: res.body,
+        message: res.requestBody?.message,
+        sessionToken: res.body.data.session_token,
+        conversationUuid: res.body.data.conversation.uuid
+      }
+    })
+)
+
+Cypress.Commands.add('widgetApi', (method, path, sessionToken, inboxUuid, body, options = {}) =>
+  cy.request({
+    method,
+    url: path,
+    body,
+    failOnStatusCode: options.failOnStatusCode !== false,
+    headers: {
+      'X-Libredesk-Inbox-ID': inboxUuid,
+      ...(sessionToken ? { Authorization: `Bearer ${sessionToken}` } : {}),
+      ...(options.headers || {})
+    }
+  })
+)
+
+// keepAlive false lets the server's 20s read deadline expire.
+Cypress.Commands.add('openWidgetSocket', (sessionToken, inboxUuid, { keepAlive = true } = {}) =>
+  cy.window().then((win) => {
+    const scheme = win.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const ws = new win.WebSocket(`${scheme}//${win.location.host}/widget/ws`)
+    const socket = { ws, received: [], closed: false, pinger: null }
+    ws.addEventListener('message', (event) => socket.received.push(JSON.parse(event.data)))
+    ws.addEventListener('close', () => {
+      socket.closed = true
+      win.clearInterval(socket.pinger)
+    })
+    ws.addEventListener('open', () => {
+      ws.send(JSON.stringify({ type: 'join', token: sessionToken, data: { inbox_id: inboxUuid } }))
+      if (keepAlive) {
+        socket.pinger = win.setInterval(() => ws.send(JSON.stringify({ type: 'ping' })), 5000)
+      }
+    })
+    openSockets.push(socket)
+    return socket
+  })
+)
+
+// cy.wrap(null).should(fn) retries the callback until it passes or times out.
+Cypress.Commands.add('waitForFrame', (predicate, errorMsg, timeout = 20000) =>
+  cy.wrap(null, { timeout, log: false }).should(() => {
+    expect(predicate(), errorMsg).to.be.true
+  })
+)
+
+Cypress.Commands.add('frameOfType', (socket, type) => {
+  const frame = socket.received.find((m) => m.type === type)
+  return cy.wrap(frame, { log: false })
+})
+
+export const joined = (socket) => () => socket.received.some((m) => m.type === 'joined')
+
+export const gotMessage = (socket, bodyText) => () =>
+  socket.received.some(
+    (m) =>
+      m.type === 'new_message' &&
+      `${m.data?.content || ''}${m.data?.text_content || ''}`.includes(bodyText)
+  )
+
+// cy.then defers the URL until conversationUuid has actually been assigned.
+Cypress.Commands.add('agentReply', (conversationUuidRef, body) =>
+  cy.then(() => {
+    const uuid = typeof conversationUuidRef === 'function' ? conversationUuidRef() : conversationUuidRef
+    return cy
+      .api('POST', `/api/v1/conversations/${uuid}/messages`, {
+        message: `<p>${body}</p>`,
+        private: false,
+        sender_type: 'agent'
+      })
+      .its('status')
+      .should('eq', 200)
+  })
+)
+
+afterEach(() => {
+  openSockets.splice(0).forEach((socket) => {
+    if (socket.ws) socket.ws.close()
+  })
+})
+
+after(() => {
+  if (!createdInboxes.length) return
+  cy.login()
+  createdInboxes.splice(0).forEach((id) => {
+    cy.api('DELETE', `/api/v1/inboxes/${id}`, null, { failOnStatusCode: false })
+  })
+})

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "test:run": "vitest run",
     "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
     "test:e2e:ci": "cypress run --e2e --headless",
+    "test:e2e:livechat": "cypress run --e2e --spec \"cypress/e2e/integration/livechat/*.cy.js\"",
     "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'",
     "test:unit": "cypress run --component",
     "test:unit:dev": "cypress open --component",

--- a/i18n/en-US.json
+++ b/i18n/en-US.json
@@ -958,6 +958,7 @@
   "globals.terms.conversation": "Conversation | Conversations",
   "globals.terms.copy": "Copy",
   "globals.terms.country": "Country",
+  "globals.terms.countryCode": "Country code",
   "globals.terms.createdAt": "Created at",
   "globals.terms.question": "Question",
   "globals.terms.answer": "Answer",

--- a/internal/inbox/channel/livechat/livechat.go
+++ b/internal/inbox/channel/livechat/livechat.go
@@ -23,8 +23,8 @@ const (
 	ChannelLiveChat       = "livechat"
 	MaxConnectionsPerUser = 10
 
-	HomeAppAnnouncement  = "announcement"
-	HomeAppExternalLink  = "external_link"
+	HomeAppAnnouncement = "announcement"
+	HomeAppExternalLink = "external_link"
 )
 
 type PreChatFormField struct {
@@ -126,10 +126,15 @@ type Config struct {
 
 // Client represents a connected chat client
 type Client struct {
-	ID        string
-	Channel   chan []byte
-	closed    atomic.Bool
-	closeOnce sync.Once
+	ID         string
+	Channel    chan []byte
+	disconnect func()
+	closed     atomic.Bool
+	closeOnce  sync.Once
+}
+
+func (c *Client) IsClosed() bool {
+	return c.closed.Load()
 }
 
 // CloseChannel closes the client's channel exactly once. Safe to call multiple times.
@@ -263,13 +268,15 @@ func (lc *LiveChat) Send(message models.OutboundMessage) error {
 	return nil
 }
 
-// Close closes all connected client channels and clears the client map.
 func (lc *LiveChat) Close() error {
 	lc.clientsMutex.Lock()
 	defer lc.clientsMutex.Unlock()
 	for _, clients := range lc.clients {
 		for _, c := range clients {
 			c.CloseChannel()
+			if c.disconnect != nil {
+				c.disconnect()
+			}
 		}
 	}
 	lc.clients = make(map[string][]*Client)
@@ -302,7 +309,7 @@ func (lc *LiveChat) Channel() string {
 }
 
 // AddClient adds a new client to the live chat session.
-func (lc *LiveChat) AddClient(userID string) (*Client, error) {
+func (lc *LiveChat) AddClient(userID string, disconnect func()) (*Client, error) {
 	lc.clientsMutex.Lock()
 	defer lc.clientsMutex.Unlock()
 
@@ -313,8 +320,9 @@ func (lc *LiveChat) AddClient(userID string) (*Client, error) {
 	}
 
 	client := &Client{
-		ID:      userID,
-		Channel: make(chan []byte, 128),
+		ID:         userID,
+		disconnect: disconnect,
+		Channel:    make(chan []byte, 128),
 	}
 
 	// Add the client to the clients map.

--- a/internal/inbox/inbox.go
+++ b/internal/inbox/inbox.go
@@ -486,6 +486,24 @@ func (m *Manager) UpdateConfig(id int, config json.RawMessage) error {
 	return nil
 }
 
+// CloseLiveChatClients disconnects widget websocket clients and returns the number of inboxes closed.
+func (m *Manager) CloseLiveChatClients() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var n int
+	for _, inb := range m.inboxes {
+		if inb.Channel() != ChannelLiveChat {
+			continue
+		}
+		if err := inb.Close(); err != nil {
+			m.lo.Error("error closing livechat inbox", "error", err)
+			continue
+		}
+		n++
+	}
+	return n
+}
+
 // stopInbox cancels the receiver for a single inbox, waits for its goroutine
 // to exit, then closes the inbox. Caller must NOT hold m.mu.
 func (m *Manager) stopInbox(id int) {

--- a/internal/report/queries.sql
+++ b/internal/report/queries.sql
@@ -36,7 +36,7 @@ agents AS (
         ) AS agents_reassigning,
         COUNT(*) FILTER (
             WHERE
-                availability_status = 'offline'
+                availability_status IN ('offline', 'away')
         ) AS agents_offline
     FROM
         users

--- a/internal/ws/client.go
+++ b/internal/ws/client.go
@@ -13,6 +13,7 @@ const (
 	pongWait        = 60 * time.Second
 	pingPeriod      = 25 * time.Second
 	writeWait       = 10 * time.Second
+	closeFrameWait  = 1 * time.Second
 	maxMessageSize  = 64 << 10
 	maxListSubUUIDs = 500
 )

--- a/internal/ws/ws.go
+++ b/internal/ws/ws.go
@@ -242,10 +242,13 @@ func (h *Hub) BroadcastTypingToAllConversationClients(conversationUUID string, d
 
 func closeClients(clients []*Client, closeCode int, reason string) {
 	closeMsg := websocket.FormatCloseMessage(closeCode, reason)
-	// One deadline for the whole pass, else a stalled connection costs closeFrameWait each.
 	deadline := time.Now().Add(closeFrameWait)
 	for _, c := range clients {
+		// fasthttp makes Close a no-op on a hijacked conn; expiring the read deadline and closing Send is what drops it.
 		_ = c.Conn.WriteControl(websocket.CloseMessage, closeMsg, deadline)
+		_ = c.Conn.SetReadDeadline(time.Now())
 		_ = c.Conn.Close()
+		c.Hub.RemoveClient(c)
+		c.close()
 	}
 }

--- a/internal/ws/ws.go
+++ b/internal/ws/ws.go
@@ -244,7 +244,6 @@ func closeClients(clients []*Client, closeCode int, reason string) {
 	closeMsg := websocket.FormatCloseMessage(closeCode, reason)
 	deadline := time.Now().Add(closeFrameWait)
 	for _, c := range clients {
-		// fasthttp makes Close a no-op on a hijacked conn; expiring the read deadline and closing Send is what drops it.
 		_ = c.Conn.WriteControl(websocket.CloseMessage, closeMsg, deadline)
 		_ = c.Conn.SetReadDeadline(time.Now())
 		_ = c.Conn.Close()

--- a/internal/ws/ws.go
+++ b/internal/ws/ws.go
@@ -60,11 +60,19 @@ func (h *Hub) KickUser(userID int) {
 		return
 	}
 	h.lo.Debug("kicking user ws connections", "user_id", userID, "connections", len(clients))
-	closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "kicked")
-	for _, c := range clients {
-		_ = c.Conn.WriteControl(websocket.CloseMessage, closeMsg, time.Now().Add(time.Second))
-		_ = c.Conn.Close()
+	closeClients(clients, websocket.CloseNormalClosure, "kicked")
+}
+
+// CloseAll sends a close frame to every connected client and returns the number closed.
+func (h *Hub) CloseAll() int {
+	h.clientsMutex.RLock()
+	clients := make([]*Client, 0, len(h.clients))
+	for _, userClients := range h.clients {
+		clients = append(clients, userClients...)
 	}
+	h.clientsMutex.RUnlock()
+	closeClients(clients, websocket.CloseGoingAway, "server shutting down")
+	return len(clients)
 }
 
 // SubscribeListReplace replaces list-source subs; open-source subs are untouched so deep links survive list refreshes.
@@ -229,5 +237,15 @@ func (h *Hub) BroadcastTypingToConversation(conversationUUID string, typingMsg m
 func (h *Hub) BroadcastTypingToAllConversationClients(conversationUUID string, data []byte) {
 	for _, c := range h.ListSubscribers(conversationUUID) {
 		c.SendMessage(data, websocket.TextMessage)
+	}
+}
+
+func closeClients(clients []*Client, closeCode int, reason string) {
+	closeMsg := websocket.FormatCloseMessage(closeCode, reason)
+	// One deadline for the whole pass, else a stalled connection costs closeFrameWait each.
+	deadline := time.Now().Add(closeFrameWait)
+	for _, c := range clients {
+		_ = c.Conn.WriteControl(websocket.CloseMessage, closeMsg, deadline)
+		_ = c.Conn.Close()
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown reliability and error reporting.
  * WebSocket and live-chat connections now close cleanly during shutdown.
  * Improved reconnection and stale-connection handling.
  * Chat validation and setup errors now provide clearer, localized feedback.
  * Prevented conversations from starting when visitor permissions disallow them.
  * Offline and away agents are now reflected accurately in availability reporting.

* **Tests**
  * Added comprehensive live-chat coverage for messaging, sessions, settings, access controls, reconnection, resilience, and configuration.
  * Added automated checks for widget and application WebSocket replacement and stale-event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->