### PR TITLE
exclude private notes from the overview message volume counts

### DIFF
--- a/internal/report/queries.sql
+++ b/internal/report/queries.sql
@@ -278,6 +278,7 @@ WITH per_conversation AS (
         conversation_messages
     WHERE
         type IN ('incoming', 'outgoing')
+        AND private = false
         AND created_at >= CASE
             WHEN %d = 0 THEN CURRENT_DATE
             ELSE NOW() - INTERVAL '%d days'

--- a/internal/report/queries.sql
+++ b/internal/report/queries.sql
@@ -279,6 +279,7 @@ WITH per_conversation AS (
     WHERE
         type IN ('incoming', 'outgoing')
         AND private = false
+        AND (type = 'incoming' OR status = 'sent')
         AND created_at >= CASE
             WHEN %d = 0 THEN CURRENT_DATE
             ELSE NOW() - INTERVAL '%d days'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message-volume statistics now exclude private messages.
  * Statistics include only incoming messages and outgoing messages that were sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->