### PR TITLE
downscale avatars to 256px on upload

### DIFF
--- a/cmd/users.go
+++ b/cmd/users.go
@@ -512,10 +512,14 @@ func uploadUserAvatar(r *fastglue.Request, user models.User, files []*multipart.
 
 	srcFileName := stringutil.SanitizeFilename(fileHeader.Filename)
 	srcContentType := fileHeader.Header.Get("Content-Type")
-	srcFileSize := fileHeader.Size
 
-	// Reset ptr.
-	file.Seek(0, 0)
+	resized, err := image.Downscale(image.AvatarMaxDim, file)
+	if err != nil {
+		app.lo.Error("error downscaling avatar", "user_id", user.ID, "error", err)
+		return envelope.NewError(envelope.InputError, app.i18n.T("globals.messages.fileTypeisNotAnImage"), nil)
+	}
+	srcFileSize := resized.Len()
+
 	linkedModel := null.StringFrom(mmodels.ModelUser)
 	linkedID := null.IntFrom(user.ID)
 	disposition := null.NewString("", false)
@@ -523,7 +527,7 @@ func uploadUserAvatar(r *fastglue.Request, user models.User, files []*multipart.
 	meta := []byte("{}")
 	// Agent and AI assistant avatars are public: both appear as authors on the help center.
 	private := user.Type != models.UserTypeAgent && user.Type != models.UserTypeAIAssistant
-	media, err := app.media.UploadAndInsert(srcFileName, srcContentType, contentID, linkedModel, linkedID, file, int(srcFileSize), disposition, meta, private)
+	media, err := app.media.UploadAndInsert(srcFileName, srcContentType, contentID, linkedModel, linkedID, resized, srcFileSize, disposition, meta, private)
 	if err != nil {
 		app.lo.Error("error uploading file", "user_id", user.ID, "error", err)
 		return envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.errorUploadingFile"), nil)

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	maxAvatarSizeMB = 2
+	// Bounds the request body only; the stored file is capped by image.AvatarMaxDim regardless.
+	maxAvatarSizeMB = 10
 )
 
 type resetPasswordRequest struct {

--- a/frontend/shared-ui/components/ui/avatar/AvatarUpload.vue
+++ b/frontend/shared-ui/components/ui/avatar/AvatarUpload.vue
@@ -96,6 +96,8 @@ const props = defineProps({
   }
 })
 
+const AVATAR_MAX_DIM = 256
+
 const emit = defineEmits(['upload', 'remove'])
 const { t } = useI18n()
 const fileInput = ref(null)
@@ -126,7 +128,7 @@ function closeCropper() {
 
 async function applyCrop() {
   if (!cropper) return
-  const blob = await cropper.getBlob()
+  const blob = await cropper.getBlob({ maxWidth: AVATAR_MAX_DIM, maxHeight: AVATAR_MAX_DIM })
   if (!blob) return
   emit('upload', new File([blob], 'avatar.png', { type: blob.type || 'image/png' }))
   closeCropper()

--- a/frontend/shared-ui/components/ui/avatar/AvatarUpload.vue
+++ b/frontend/shared-ui/components/ui/avatar/AvatarUpload.vue
@@ -96,8 +96,6 @@ const props = defineProps({
   }
 })
 
-const AVATAR_MAX_DIM = 256
-
 const emit = defineEmits(['upload', 'remove'])
 const { t } = useI18n()
 const fileInput = ref(null)
@@ -128,7 +126,7 @@ function closeCropper() {
 
 async function applyCrop() {
   if (!cropper) return
-  const blob = await cropper.getBlob({ maxWidth: AVATAR_MAX_DIM, maxHeight: AVATAR_MAX_DIM })
+  const blob = await cropper.getBlob()
   if (!blob) return
   emit('upload', new File([blob], 'avatar.png', { type: blob.type || 'image/png' }))
   closeCropper()

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -19,6 +19,9 @@ const (
 	llmJPEGQuality = 85
 	// maxDecodePixels bounds width*height read from the header, blocking a small file that declares huge dimensions. 25 MP is ~100 MB of RGBA per agent worker.
 	maxDecodePixels = 25_000_000
+	// AvatarMaxDim caps an avatar's longest edge. The largest render is 112px (size-28) at 2x DPI.
+	AvatarMaxDim      = 256
+	avatarJPEGQuality = 85
 )
 
 var (
@@ -99,4 +102,42 @@ func EncodeForLLM(content []byte) (data string, mediaType string, err error) {
 		return "", "", err
 	}
 	return base64.StdEncoding.EncodeToString(out.Bytes()), "image/jpeg", nil
+}
+
+// Downscale fits the image within maxDim on both edges and re-encodes it in its source format.
+func Downscale(maxDim int, r io.ReadSeeker) (*bytes.Reader, error) {
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	cfg, format, err := image.DecodeConfig(r)
+	if err != nil {
+		return nil, err
+	}
+	if cfg.Width <= 0 || cfg.Height <= 0 || cfg.Width > maxDecodePixels/cfg.Height {
+		return nil, fmt.Errorf("invalid or too-large image dimensions %dx%d", cfg.Width, cfg.Height)
+	}
+	if _, err := r.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	// Re-encoding drops EXIF, so bake in the rotation the browser would otherwise have honoured.
+	img, err := imaging.Decode(r, imaging.AutoOrientation(true))
+	if err != nil {
+		return nil, err
+	}
+
+	img = imaging.Fit(img, maxDim, maxDim, imaging.Lanczos)
+
+	var out bytes.Buffer
+	switch format {
+	case "jpeg":
+		err = imaging.Encode(&out, img, imaging.JPEG, imaging.JPEGQuality(avatarJPEGQuality))
+	case "gif":
+		err = imaging.Encode(&out, img, imaging.GIF)
+	default:
+		err = imaging.Encode(&out, img, imaging.PNG)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(out.Bytes()), nil
 }

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -19,8 +19,8 @@ const (
 	llmJPEGQuality = 85
 	// maxDecodePixels bounds width*height read from the header, blocking a small file that declares huge dimensions. 25 MP is ~100 MB of RGBA per agent worker.
 	maxDecodePixels = 25_000_000
-	// AvatarMaxDim caps an avatar's longest edge. The largest render is 112px (size-28) at 2x DPI.
-	AvatarMaxDim      = 256
+	// AvatarMaxDim caps an avatar's longest edge. The largest render is the 128px `lg` variant, at up to 4x DPI.
+	AvatarMaxDim      = 512
 	avatarJPEGQuality = 85
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Avatar uploads now support files up to 10 MB.
  - Avatars are automatically resized to fit within 512 pixels.
  - Correct image orientation is preserved, with support for common image formats.
  - Resized image data is used during upload.

- **Bug Fixes**
  - Invalid or unsupported images now return a clear image-related input error.
  - Uploaded file sizes are calculated accurately after resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->