### PR TITLE
raise the response body pool limit to 1mb

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -339,8 +339,8 @@ func main() {
 	initHandlers(g, wsHub)
 	g.Router.NotFound = helpCenterHostNotFound(app, g)
 
-	// fasthttp keeps a RequestCtx's response buffer at full capacity and recycles the ctx across connections, and a hijacked websocket holds its ctx until the socket closes.
-	fasthttp.SetBodySizePoolLimit(64<<10, 64<<10) // 64 KiB
+	// Buffers above this are dropped rather than reused, and the ones we keep stay with the connection until it closes.
+	fasthttp.SetBodySizePoolLimit(64<<10, 1<<20) // request: 64 KiB, response: 1 MiB
 
 	s := &fasthttp.Server{
 		Name:                 appName,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management for HTTP request and response buffers.
  * Large buffers are now discarded instead of being reused, helping maintain consistent resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->