### PR TITLE
read the per user type config in the livechat widget preview

### DIFF
--- a/frontend/apps/main/src/features/admin/inbox/LivechatWidgetPreview.vue
+++ b/frontend/apps/main/src/features/admin/inbox/LivechatWidgetPreview.vue
@@ -8,7 +8,7 @@
         :style="{ bottom: windowBottom + 'px' }"
       >
         <div
-          class="libredesk-widget-preview flex flex-col h-full  bg-background text-foreground rounded-2xl overflow-hidden shadow-2xl border border-border"
+          class="libredesk-widget-preview flex flex-col h-full bg-background text-foreground rounded-2xl overflow-hidden shadow-2xl border border-border"
           :class="isDark ? 'dark' : 'light'"
           :style="primaryStyle"
         >
@@ -214,7 +214,7 @@
                       </p>
                     </div>
                   </div>
-                  <div class="relative z-10 px-4 pb-4">
+                  <div v-if="canStartConversation" class="relative z-10 px-4 pb-4">
                     <Button
                       type="button"
                       class="w-full flex items-center justify-center gap-1"
@@ -296,7 +296,7 @@
                     </div>
                   </div>
                 </div>
-                <div class="absolute bottom-0 inset-x-0">
+                <div v-if="canStartFromMessages" class="absolute bottom-0 inset-x-0">
                   <div
                     class="h-20 bg-gradient-to-t from-background via-background/80 to-transparent pointer-events-none"
                   ></div>
@@ -375,6 +375,10 @@ const HEX_COLOR = /^#([0-9a-f]{6}|[0-9a-f]{3})$/i
 const LAUNCHER_SIZE = 52
 
 const props = defineProps({
+  userType: {
+    type: String,
+    default: 'visitors'
+  },
   config: {
     type: Object,
     default: () => ({})
@@ -463,15 +467,22 @@ const showFade = computed(
 )
 const fadeStyle = { background: 'linear-gradient(to bottom, transparent, hsl(var(--background)))' }
 
+const userTypeConfig = computed(() => props.config[props.userType] || {})
+
+const canStartConversation = computed(() => Boolean(userTypeConfig.value.allow_start_conversation))
+
+// The messages tab always previews an existing conversation, so it follows the multiple rule too.
+const canStartFromMessages = computed(
+  () => canStartConversation.value && userTypeConfig.value.prevent_multiple_conversations !== true
+)
+
 const startButtonText = computed(
-  () =>
-    props.config.visitors?.start_conversation_button_text ||
-    props.config.users?.start_conversation_button_text ||
-    t('globals.messages.sendUsMessage')
+  () => userTypeConfig.value.start_conversation_button_text || t('globals.messages.sendUsMessage')
 )
 const messagesButtonText = computed(
   () =>
-    props.config.users?.start_conversation_button_text || t('globals.messages.startNewConversation')
+    userTypeConfig.value.start_conversation_button_text ||
+    t('globals.messages.startNewConversation')
 )
 
 const sampleMessages = computed(() => [

--- a/frontend/apps/main/src/views/admin/inbox/InboxView.vue
+++ b/frontend/apps/main/src/views/admin/inbox/InboxView.vue
@@ -8,10 +8,22 @@
       <!-- The livechat form writes its live config here so the preview replaces the help rail. -->
       <div v-if="livechatPreview" class="space-y-4 sticky top-2">
         <div class="space-y-2">
-          <h4 class="text-sm font-medium text-foreground">
-            {{ $t('admin.inbox.livechat.preview') }}
-          </h4>
-          <LivechatWidgetPreview :config="livechatPreview" />
+          <div class="flex items-center justify-between gap-2">
+            <h4 class="text-sm font-medium text-foreground">
+              {{ $t('admin.inbox.livechat.preview') }}
+            </h4>
+            <Tabs v-model="previewUserType">
+              <TabsList class="h-8 p-0.5">
+                <TabsTrigger value="visitors" class="text-xs">
+                  {{ $t('admin.inbox.livechat.userSettings.visitors') }}
+                </TabsTrigger>
+                <TabsTrigger value="users" class="text-xs">
+                  {{ $t('globals.terms.users') }}
+                </TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+          <LivechatWidgetPreview :config="livechatPreview" :user-type="previewUserType" />
         </div>
         <div class="space-y-1">
           <p class="text-sm text-muted-foreground">{{ $t('admin.inbox.help.livechat') }}</p>
@@ -59,7 +71,9 @@
 import { ref, provide } from 'vue'
 import AdminSplitLayout from '@/layouts/admin/AdminSplitLayout.vue'
 import LivechatWidgetPreview from '@/features/admin/inbox/LivechatWidgetPreview.vue'
+import { Tabs, TabsList, TabsTrigger } from '@shared-ui/components/ui/tabs'
 
+const previewUserType = ref('visitors')
 const livechatPreview = ref(null)
 provide('livechatPreview', livechatPreview)
 </script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added visitor and user tabs to the live chat preview.
  - Preview behavior now adapts to the selected user type.
  - Start-conversation buttons appear only when allowed by conversation settings.
  - Updated button labels and improved preview styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->