### PR TITLE
Feat/is cloud support

### DIFF
--- a/cmd/ai.go
+++ b/cmd/ai.go
@@ -99,6 +99,9 @@ func handleUpdateAIConfig(r *fastglue.Request) error {
 		providerType = r.RequestCtx.UserValue("type").(string)
 		req          aimodels.ProviderConfig
 	)
+	if ko.Bool("app.is_cloud") {
+		return r.SendErrorEnvelope(fasthttp.StatusForbidden, "AI provider settings are managed by LibreDesk Cloud.", nil, envelope.PermissionError)
+	}
 	if err := r.Decode(&req, "json"); err != nil {
 		return sendErrorEnvelope(r, envelope.NewError(envelope.InputError, app.i18n.T("errors.parsingRequest"), nil))
 	}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,6 +30,7 @@ func handleGetConfig(r *fastglue.Request) error {
 		"app.favicon_url": settings["app.favicon_url"],
 		"app.logo_url":    settings["app.logo_url"],
 		"app.site_name":   settings["app.site_name"],
+		"app.is_cloud":    ko.Bool("app.is_cloud"),
 	}
 
 	// Get all OIDC providers

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -833,7 +833,7 @@ func initAuthz(i18n *i18n.I18n) *authz.Enforcer {
 // initSSRFControl builds the shared outbound-request guard from config.
 func initSSRFControl() ssrf.Control {
 	lo := initLogger("ssrf")
-	return ssrf.NewControl(ko.Bool("ssrf.enabled"), ko.Strings("ssrf.allowed_cidrs"), lo)
+	return ssrf.NewControl(ko.Bool("app.is_cloud") || ko.Bool("ssrf.enabled"), ko.Strings("ssrf.allowed_cidrs"), lo)
 }
 
 // initAuth initializes the authentication manager.

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -57,6 +57,18 @@ func handleUpdateGeneralSettings(r *fastglue.Request) error {
 	}
 	// Trim whitespace and trailing slash from root URL.
 	req.RootURL = strings.TrimRight(strings.TrimSpace(req.RootURL), "/")
+	if ko.Bool("app.is_cloud") {
+		// The hosted service owns its public URL. Preserve the persisted value rather
+		// than trusting the value submitted by the client.
+		rootURL, err := app.setting.GetAppRootURL()
+		if err != nil {
+			return sendErrorEnvelope(r, err)
+		}
+		req.RootURL = rootURL
+		if req.MaxFileUploadSize > 25 {
+			req.MaxFileUploadSize = 25
+		}
+	}
 
 	// Get current language before update.
 	app.Lock()
@@ -118,6 +130,9 @@ func handleUpdateEmailNotificationSettings(r *fastglue.Request) error {
 		req = models.EmailNotification{}
 		cur = models.EmailNotification{}
 	)
+	if ko.Bool("app.is_cloud") {
+		return r.SendErrorEnvelope(fasthttp.StatusForbidden, "Email notification settings are managed by LibreDesk Cloud.", nil, envelope.PermissionError)
+	}
 
 	if err := r.Decode(&req, "json"); err != nil {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.T("globals.messages.badRequest"), nil, envelope.InputError)

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -1,4 +1,6 @@
 [app]
+# Enable hosted/cloud deployment restrictions. Leave false for self-hosted installs.
+is_cloud = false
 # Log level: info, debug, warn, error, fatal
 log_level = "debug"
 # Environment: dev, prod.

--- a/frontend/apps/main/src/components/sidebar/Sidebar.vue
+++ b/frontend/apps/main/src/components/sidebar/Sidebar.vue
@@ -218,7 +218,11 @@ const navigateToViewInbox = (viewID) => {
   }
 }
 
-const filteredAdminNavItems = computed(() => filterNavItems(adminNavItems, userStore.can))
+const filteredAdminNavItems = computed(() => filterNavItems(
+  adminNavItems,
+  userStore.can,
+  settingsStore.public_config?.['app.is_cloud'] === true
+))
 const filteredReportsNavItems = computed(() => filterNavItems(reportsNavItems, userStore.can))
 const filteredContactsNavItems = computed(() => filterNavItems(contactNavItems, userStore.can))
 

--- a/frontend/apps/main/src/constants/navigation.js
+++ b/frontend/apps/main/src/constants/navigation.js
@@ -53,6 +53,7 @@ export const adminNavItems = [
         titleKey: 'globals.terms.provider',
         href: '/admin/ai/providers',
         permission: 'ai:manage',
+        hideInCloud: true,
         isTitleKeyPlural: true,
         icon: 'Sparkles'
       },
@@ -194,6 +195,7 @@ export const adminNavItems = [
         titleKey: 'globals.terms.email',
         href: '/admin/notification',
         permission: 'notification_settings:manage',
+        hideInCloud: true,
         icon: 'Mail'
       },
       {

--- a/frontend/apps/main/src/features/admin/general/GeneralSettingForm.vue
+++ b/frontend/apps/main/src/features/admin/general/GeneralSettingForm.vue
@@ -84,7 +84,7 @@
           {{ t('globals.terms.rootURL') }}
         </FormLabel>
         <FormControl>
-          <Input type="text" placeholder="" v-bind="field" />
+          <Input type="text" placeholder="" v-bind="field" :disabled="props.isCloud" />
         </FormControl>
         <FormDescription>
           {{ t('admin.general.rootURL.description') }}
@@ -123,7 +123,7 @@
           {{ t('admin.general.maxAllowedFileUploadSize') }}
         </FormLabel>
         <FormControl>
-          <Input type="number" placeholder="10" v-bind="field" />
+          <Input type="number" placeholder="10" v-bind="field" :max="props.isCloud ? 25 : 500" />
         </FormControl>
         <FormDescription>
           {{ t('admin.general.maxAllowedFileUploadSize.description') }}
@@ -234,12 +234,16 @@ const props = defineProps({
   isLoading: {
     type: Boolean,
     default: false
+  },
+  isCloud: {
+    type: Boolean,
+    default: false
   }
 })
 
 const submitLabel = props.submitLabel || t('globals.messages.save')
 const form = useForm({
-  validationSchema: toTypedSchema(createFormSchema(t))
+  validationSchema: toTypedSchema(createFormSchema(t, props.isCloud))
 })
 
 onMounted(() => {

--- a/frontend/apps/main/src/features/admin/general/formSchema.js
+++ b/frontend/apps/main/src/features/admin/general/formSchema.js
@@ -1,6 +1,6 @@
 import * as z from 'zod'
 
-export const createFormSchema = (t) => z.object({
+export const createFormSchema = (t, isCloud = false) => z.object({
   site_name: z
     .string({
       required_error: t('globals.messages.required'),
@@ -36,7 +36,7 @@ export const createFormSchema = (t) => z.object({
     .min(1, {
       message: t('admin.general.maxAllowedFileUploadSize.valid')
     })
-    .max(500, {
+    .max(isCloud ? 25 : 500, {
       message: t('admin.general.maxAllowedFileUploadSize.valid')
     }),
   allowed_file_upload_extensions: z.array(z.string()).nullable().optional().default([]),

--- a/frontend/apps/main/src/utils/nav-permissions.js
+++ b/frontend/apps/main/src/utils/nav-permissions.js
@@ -1,9 +1,10 @@
-export const filterNavItems = (navItems, can) => {
+export const filterNavItems = (navItems, can, isCloud = false) => {
     return navItems
         .map(item => {
+            if (isCloud && item.hideInCloud) return null
             // Process children first
             const filteredChildren = item.children
-                ? filterNavItems(item.children, can)
+                ? filterNavItems(item.children, can, isCloud)
                 : undefined
             // Check item's permission
             const hasAccess = item.permission ? can(item.permission) : true

--- a/frontend/apps/main/src/views/admin/general/General.vue
+++ b/frontend/apps/main/src/views/admin/general/General.vue
@@ -6,6 +6,7 @@
           :submitForm="submitForm"
           :initial-values="initialValues"
           :available-languages="availableLanguages"
+          :is-cloud="settingsStore.public_config?.['app.is_cloud'] === true"
         />
       </LoadingOverlay>
     </template>


### PR DESCRIPTION
## Summary

Adds `is_cloud` support to LibreDesk for cloud-specific restrictions.

- Adds `is_cloud` configuration and exposes it via `/api/v1/config`.
- Restricts notification and AI provider settings in cloud mode.
- Prevents changing `app.root_url` in cloud mode.
- Caps cloud file uploads at 25 MB.
- Adds corresponding frontend visibility and read-only controls.
- Keeps self-hosted behavior unchanged when `is_cloud=false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cloud deployment support with tailored administration controls.
  * Cloud deployments now automatically enable SSRF protection.
  * File upload limits are capped at 25 in cloud environments.
  * Cloud administrators cannot modify AI provider or email notification settings.
  * Restricted settings are hidden from cloud administration navigation.

* **Bug Fixes**
  * Cloud deployments now preserve the configured application URL during settings updates.
  * Configuration responses accurately identify cloud environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->