### PR TITLE
Fixes thumbnail rotation issues

### DIFF
--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -68,7 +68,7 @@ func GetDimensions(r io.Reader) (int, int, error) {
 // CreateThumb generates a thumbnail of the given image file with the specified maximum dimension.
 // The thumbnail's width will be resized to `thumbPxSize` while maintaining the aspect ratio.
 func CreateThumb(thumbPxSize int, r io.Reader) (*bytes.Reader, error) {
-	img, err := imaging.Decode(r)
+	img, err := imaging.Decode(r, imaging.AutoOrientation(true))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes thumbnail rotation issues

Adding `imaging.AutoOrientation(true)` ensures that the image is decoded in the correct orientation based on the EXIF data without making assumptions.

Manually verified the fix after the change and confirmed that it's working as expected

Fixes #538

<img width="1717" height="616" alt="Screenshot 2026-08-28 at 12 19 54 PM" src="https://github.com/user-attachments/assets/fba53aa3-73d9-4db1-9c3b-42f3287e50d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thumbnails now automatically respect an image’s EXIF orientation.
  * Thumbnails are generated in PNG format for more consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->