### PR TITLE
Fix: disable mentions for replies in tiptap

### DIFF
--- a/frontend/apps/main/src/components/editor/ConversationEditor.vue
+++ b/frontend/apps/main/src/components/editor/ConversationEditor.vue
@@ -84,6 +84,7 @@ const { editor, extractMentions, focus } = useTextEditor({
   isInlineEnabled: () => props.enableInlineImages,
   linkedModel: props.linkedModel,
   getSuggestions: props.getSuggestions,
+  enableMentions: () => props.enableMentions,
   onSend: () => {
     emit('send')
     stopTyping()

--- a/frontend/apps/main/src/components/editor/mentionSuggestion.js
+++ b/frontend/apps/main/src/components/editor/mentionSuggestion.js
@@ -5,6 +5,11 @@ export default {
   char: '@',
   allowSpaces: true,
 
+  allow: ({ editor }) => {
+    const enableMentions = editor.options.editorProps?.enableMentions
+    return enableMentions ? enableMentions() : false
+  },
+
   items: async ({ query, editor }) => {
     // Get the suggestion handler from editor options
     const getSuggestions = editor.options.editorProps?.getSuggestions

--- a/frontend/apps/main/src/components/editor/useTextEditor.js
+++ b/frontend/apps/main/src/components/editor/useTextEditor.js
@@ -12,6 +12,7 @@ export function useTextEditor({
   isInlineEnabled = () => false,
   linkedModel = 'messages',
   getSuggestions = null,
+  enableMentions = () => false,
   onSend = () => {},
   onUpdate = () => {},
   onBlur = () => {},
@@ -50,6 +51,7 @@ export function useTextEditor({
     editorProps: {
       attributes: { class: 'outline-none' },
       getSuggestions,
+      enableMentions,
       handlePaste,
       handleDrop,
       handleKeyDown: (view, event) => {


### PR DESCRIPTION
Fix: disable mentions for replies in tiptap

Found an issue with mentions in the reply editor where suggestions always returned empty results by design. 
```
// ReplyBoxContent.vue

const getSuggestions = async (query) => {
  // Only show suggestions in private note mode
  if (messageType.value !== 'private_note') {
    return []
  }
  ...
```
However, the `mentionSuggestions` stills runs and shows empty results. With this fix, we no longer show the pop up at all.

Manually tested the behavior locally and no-longer seeing the mention pop-up.

Came across this issue when debugging a semi related issue #506. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable mention support for the conversation editor.
  - Mentions can now be enabled or disabled based on the editor’s configuration.
  - Mention suggestions are suppressed when mentions are disabled, preventing unintended mention interactions.
- **Bug Fixes**
  - Improved consistency between the conversation editor’s mention settings and the behavior shown while composing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->