### PR TITLE
api: accept source_id on conversation and message endpoints

### DIFF
--- a/cmd/conversation.go
+++ b/cmd/conversation.go
@@ -58,6 +58,7 @@ type createConversationRequest struct {
 	Content          string         `json:"content"`
 	Attachments      []int          `json:"attachments"`
 	Initiator        string         `json:"initiator"` // "contact" | "agent"
+	SourceID         string         `json:"source_id"` // RFC 5322 Message-ID of the inbound message; stored on the created contact message so replies thread on it. Contact-initiated only.
 	CustomAttributes map[string]any `json:"custom_attributes"`
 }
 
@@ -882,7 +883,7 @@ func handleCreateConversation(r *fastglue.Request) error {
 		}
 	case umodels.UserTypeContact:
 		// Create contact message.
-		if _, err := app.conversation.CreateContactMessage(media, contact.ID, conversationUUID, req.Content, cmodels.ContentTypeHTML, true); err != nil {
+		if _, err := app.conversation.CreateContactMessage(media, contact.ID, conversationUUID, req.Content, cmodels.ContentTypeHTML, true, req.SourceID); err != nil {
 			// Delete the conversation if message creation fails.
 			if err := app.conversation.DeleteConversation(conversationUUID); err != nil {
 				app.lo.Error("error deleting conversation", "error", err)

--- a/cmd/messages.go
+++ b/cmd/messages.go
@@ -22,6 +22,7 @@ type messageReq struct {
 	SenderType  string                 `json:"sender_type"`
 	Mentions    []cmodels.MentionInput `json:"mentions"`
 	EchoID      string                 `json:"echo_id"`
+	SourceID    string                 `json:"source_id"` // RFC 5322 Message-ID of the inbound message; stored on the created contact message so replies thread on it. Contact sender only.
 }
 
 // handleGetMessages returns messages for a conversation.
@@ -243,7 +244,7 @@ func handleSendMessage(r *fastglue.Request) error {
 
 	// Create contact message.
 	if req.SenderType == umodels.UserTypeContact {
-		message, err := app.conversation.CreateContactMessage(media, int(conv.ContactID), cuuid, req.Message, cmodels.ContentTypeHTML, false)
+		message, err := app.conversation.CreateContactMessage(media, int(conv.ContactID), cuuid, req.Message, cmodels.ContentTypeHTML, false, req.SourceID)
 		if err != nil {
 			return sendErrorEnvelope(r, err)
 		}

--- a/internal/conversation/message.go
+++ b/internal/conversation/message.go
@@ -476,7 +476,9 @@ func (m *Manager) SendPrivateNote(media []mmodels.Media, senderID int, conversat
 }
 
 // CreateContactMessage creates a contact message in a conversation.
-func (m *Manager) CreateContactMessage(media []mmodels.Media, contactID int, conversationUUID, content, contentType string, isNewConversation bool) (models.Message, error) {
+// sourceID is the bare RFC 5322 Message-ID of the inbound message; it is normalized and stored on the message so replies thread on it, mirroring the IMAP ingestion path. Empty leaves the column NULL.
+func (m *Manager) CreateContactMessage(media []mmodels.Media, contactID int, conversationUUID, content, contentType string, isNewConversation bool, sourceID string) (models.Message, error) {
+	sourceID = stringutil.NormalizeMessageID(sourceID)
 	message := models.Message{
 		ConversationUUID: conversationUUID,
 		SenderID:         contactID,
@@ -487,6 +489,7 @@ func (m *Manager) CreateContactMessage(media []mmodels.Media, contactID int, con
 		ContentType:      contentType,
 		Private:          false,
 		Media:            media,
+		SourceID:         null.NewString(sourceID, sourceID != ""),
 	}
 	if err := m.InsertMessage(&message); err != nil {
 		return models.Message{}, err

--- a/internal/stringutil/stringutil.go
+++ b/internal/stringutil/stringutil.go
@@ -138,9 +138,13 @@ func RemoveEmpty(s []string) []string {
 	return r
 }
 
-// NormalizeMessageID strips surrounding whitespace and the optional angle brackets from an RFC 5322 Message-ID. source_id is stored unbracketed; BuildEmailThreadingHeaders re-adds the brackets when composing In-Reply-To/References.
+// NormalizeMessageID strips surrounding whitespace and the optional angle brackets from an RFC 5322 Message-ID, and rejects values containing line breaks (which would produce malformed In-Reply-To/References headers). source_id is stored unbracketed; BuildEmailThreadingHeaders re-adds the brackets when composing them.
 func NormalizeMessageID(id string) string {
-	return strings.Trim(strings.TrimSpace(id), "<>")
+	id = strings.Trim(strings.TrimSpace(id), "<>")
+	if strings.ContainsAny(id, "\r\n") {
+		return ""
+	}
+	return id
 }
 
 // GenerateEmailMessageID generates an RFC-compliant Message-ID for an email without angle brackets.

--- a/internal/stringutil/stringutil.go
+++ b/internal/stringutil/stringutil.go
@@ -138,6 +138,11 @@ func RemoveEmpty(s []string) []string {
 	return r
 }
 
+// NormalizeMessageID strips surrounding whitespace and the optional angle brackets from an RFC 5322 Message-ID. source_id is stored unbracketed; BuildEmailThreadingHeaders re-adds the brackets when composing In-Reply-To/References.
+func NormalizeMessageID(id string) string {
+	return strings.Trim(strings.TrimSpace(id), "<>")
+}
+
 // GenerateEmailMessageID generates an RFC-compliant Message-ID for an email without angle brackets.
 func GenerateEmailMessageID(uuid string, fromAddress string) (string, error) {
 	if uuid == "" {

--- a/internal/stringutil/stringutil_test.go
+++ b/internal/stringutil/stringutil_test.go
@@ -483,6 +483,9 @@ func TestNormalizeMessageID(t *testing.T) {
 		{"surrounding whitespace", "  <abc@example.com>  ", "abc@example.com"},
 		{"empty stays empty", "", ""},
 		{"brackets only", "<>", ""},
+		{"line feed is rejected", "a\nb@example.com", ""},
+		{"carriage return is rejected", "a\rb@example.com", ""},
+		{"crlf inside brackets is rejected", "<a\r\nb@host>", ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := NormalizeMessageID(tc.in); got != tc.want {

--- a/internal/stringutil/stringutil_test.go
+++ b/internal/stringutil/stringutil_test.go
@@ -473,3 +473,21 @@ func TestHTML2TextMarkdownLinks(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeMessageID(t *testing.T) {
+	for _, tc := range []struct {
+		name, in, want string
+	}{
+		{"bracketed", "<abc@example.com>", "abc@example.com"},
+		{"already bare", "abc@example.com", "abc@example.com"},
+		{"surrounding whitespace", "  <abc@example.com>  ", "abc@example.com"},
+		{"empty stays empty", "", ""},
+		{"brackets only", "<>", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeMessageID(tc.in); got != tc.want {
+				t.Errorf("NormalizeMessageID(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #545.

## What

Add an optional `source_id` to `POST /api/v1/conversations` and `POST /api/v1/conversations/{cuuid}/messages`, stored on the created contact message. This mirrors the IMAP ingestion path, which is the only place `source_id` is otherwise populated.

## Why

Libredesk builds every outgoing reply's `References` and `In-Reply-To` headers from the `source_id` of prior messages (`BuildEmailThreadingHeaders`). `source_id` is only ever set on the IMAP ingestion path:

```go
// internal/inbox/channel/email/imap.go
SourceID: null.StringFrom(messageID),
```

Neither API endpoint accepts it. A desk fed over the API therefore references only its own previous sends, and the customer's mail client has nothing of theirs to thread on. Every reply arrives looking standalone.

This is an obviously correct addition that any API-fed inbox needs. Today the only way to set `source_id` from outside the IMAP path is a direct database write, which is fragile and invisible to upstream.

## What it does

- `createConversationRequest` and `messageReq` gain an optional `source_id`.
- The value is normalized (whitespace and angle brackets stripped) and stored on the created contact message, since `source_id` is stored unbracketed and the brackets are re-added by `BuildEmailThreadingHeaders`.
- Values containing line breaks are rejected (normalized to empty) so they cannot produce malformed `In-Reply-To`/`References` headers on outbound replies; an empty result leaves the column `NULL`.
- An empty value leaves the column `NULL` as before, so existing callers are unaffected.
- It is honored only for contact-originated messages (the `initiator: "contact"` case on create, and `sender_type: "contact"` on append). Agent replies generate their own `source_id` in `QueueReply` as today.

The normalization is a shared `stringutil.NormalizeMessageID` helper so it stays in step with what the IMAP path already does.

## Testing

- `go build ./...`
- `go test ./internal/stringutil/ ./internal/conversation/ ./cmd/`
- New `TestNormalizeMessageID` pins the bracket/whitespace stripping and the line-break rejection.

## Compatibility

Purely additive: a new optional field. No schema change (the column already exists). No behavior change for callers that do not send `source_id`.