### PR TITLE
settings: reload auth on general settings update (narrow fix)

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -860,7 +860,8 @@ func reloadAuth(app *App) error {
 	app.lo.Info("reloading auth manager")
 	providers, err := buildProviders(app.oidc)
 	if err != nil {
-		log.Fatalf("error reloading auth: %v", err)
+		app.lo.Error("error reloading auth", "error", err)
+		return err
 	}
 	if err := app.auth.Reload(auth_.Config{Providers: providers}); err != nil {
 		app.lo.Error("error reloading auth", "error", err)

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -86,6 +86,14 @@ func handleUpdateGeneralSettings(r *fastglue.Request) error {
 		app.lo.Error("error reloading templates", "error", err)
 		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
 	}
+
+	// Rebuild auth providers, which snapshot settings such as app.root_url into
+	// their RedirectURL at construction time. Without this, a Root URL change
+	// leaves OIDC redirect URIs stale until the process restarts.
+	if err := reloadAuth(app); err != nil {
+		app.lo.Error("error reloading auth", "error", err)
+		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
+	}
 	return r.SendEnvelope(true)
 }
 


### PR DESCRIPTION
Closes #546 (narrow option).

This is the narrow fix for #546. A second PR with the preferred option (live lookup instead of a snapshot) is at #548, so the maintainer can choose the approach. See the comment on this PR.

## What

Add `reloadAuth(app)` to `handleUpdateGeneralSettings`, after the existing `reloadSettings`, i18n re-init and `reloadTemplates`. Also make `reloadAuth` return the `buildProviders` error instead of calling `log.Fatalf`, so a settings save whose only fault is a provider that cannot be built at runtime returns a 500 envelope rather than crashing the process.

## Why

The general settings handler reloads settings, i18n and templates, but not auth. OIDC providers snapshot `app.root_url` into their `RedirectURL` at construction time (`buildProviders`, `cmd/init.go:872`), so changing Root URL in Admin -> Workspace -> General leaves the redirect URI stale until the process restarts. SSO then keeps sending the old `redirect_uri` and the identity provider rejects it:

```
{"error":"invalid_request","error_description":"The requested redirect_uri is missing in the client configuration."}
```

`reloadAuth` already exists and is called correctly on OIDC create/update (`cmd/oidc.go:62`, `:99`); it just has no path from the settings handler.

## Scope

This closes the reported bug (OIDC redirect URI going stale on Root URL change) but does not address the wider class: any other subsystem that snapshots a setting reintroduces it silently. #546 proposes two alternatives -- a single `reloadAll(app)` so the dependency list is written in one place, and live lookup over snapshots, which removes the reload requirement entirely. This PR is the narrow one-liner (plus the fatal-to-error fix the reload path needed); the preferred option is in #548.

## Testing

- `go build ./...`
- `go test ./cmd/`

There is no existing test harness for the settings handler (it requires a full `*App` and a database), so this change is verified structurally: the handler now calls `reloadAuth`, which rebuilds providers from the current `app.root_url`. The `reloadAuth` fatal-to-error change is covered by its three existing callers already handling the returned error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication providers now immediately use updated Root URL settings, including correctly rebuilt OIDC redirect URIs.
  * Improved error handling when authentication settings cannot be reloaded, with failures reported without terminating the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->