### PR TITLE
oidc: resolve redirect URL live so Root URL changes without a restart (preferred option)

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -119,9 +119,19 @@ func handleOIDCCallback(r *fastglue.Request) error {
 	}
 
 	// Reuse the redirect URI stored at login so the token exchange sends the
-	// same one the provider saw (RFC 6749 4.1.3).
-	storedRedirectURI, _ := app.auth.GetSessionValue(r, oidcRedirectURISessKey)
-	redirectURI, _ := storedRedirectURI.(string)
+	// same one the provider saw (RFC 6749 4.1.3). A missing or unreadable value
+	// means the session is stale or login never completed, so fail the same
+	// way as a state mismatch rather than sending an empty redirect_uri.
+	storedRedirectURI, err := app.auth.GetSessionValue(r, oidcRedirectURISessKey)
+	if err != nil {
+		app.lo.Error("error getting oidc redirect uri from session", "provider_id", providerID, "error", err)
+		return redirectLoginError(r, oidcErrSessionExpired, nextStr)
+	}
+	redirectURI, ok := storedRedirectURI.(string)
+	if !ok || redirectURI == "" {
+		app.lo.Error("oidc redirect uri missing from session", "provider_id", providerID)
+		return redirectLoginError(r, oidcErrSessionExpired, nextStr)
+	}
 
 	_, claims, err := app.auth.ExchangeOIDCToken(r.RequestCtx, providerID, code, redirectURI)
 	if err != nil {

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -25,9 +25,8 @@ const (
 )
 
 var (
-	oidcStateSessKey       = "oidc_state"
-	oidcNextSessKey        = "oidc_next"
-	oidcRedirectURISessKey = "oidc_redirect_uri"
+	oidcStateSessKey = "oidc_state"
+	oidcNextSessKey  = "oidc_next"
 )
 
 // handleOIDCLogin redirects to the OIDC provider for login.
@@ -60,17 +59,9 @@ func handleOIDCLogin(r *fastglue.Request) error {
 		return redirectLoginError(r, oidcErrLoginFailed, next)
 	}
 
-	authURL, redirectURI, err := app.auth.LoginURL(providerID, state)
+	authURL, err := app.auth.LoginURL(providerID, state)
 	if err != nil {
 		app.lo.Error("error getting oidc login url", "provider_id", providerID, "error", err)
-		return redirectLoginError(r, oidcErrLoginFailed, next)
-	}
-	// Persist the redirect URI used at login so the callback's token exchange
-	// sends the same one (RFC 6749 4.1.3). It is resolved live from the current
-	// root URL, so a Root URL change between login and callback would otherwise
-	// produce a mismatch the IdP rejects.
-	if err = app.auth.SetSessionValues(r, map[string]any{oidcRedirectURISessKey: redirectURI}); err != nil {
-		app.lo.Error("error saving redirect uri in session", "error", err)
 		return redirectLoginError(r, oidcErrLoginFailed, next)
 	}
 	app.lo.Debug("redirecting to oidc provider for login", "provider_id", providerID)
@@ -118,22 +109,7 @@ func handleOIDCCallback(r *fastglue.Request) error {
 		return redirectLoginError(r, oidcErrSessionExpired, nextStr)
 	}
 
-	// Reuse the redirect URI stored at login so the token exchange sends the
-	// same one the provider saw (RFC 6749 4.1.3). A missing or unreadable value
-	// means the session is stale or login never completed, so fail the same
-	// way as a state mismatch rather than sending an empty redirect_uri.
-	storedRedirectURI, err := app.auth.GetSessionValue(r, oidcRedirectURISessKey)
-	if err != nil {
-		app.lo.Error("error getting oidc redirect uri from session", "provider_id", providerID, "error", err)
-		return redirectLoginError(r, oidcErrSessionExpired, nextStr)
-	}
-	redirectURI, ok := storedRedirectURI.(string)
-	if !ok || redirectURI == "" {
-		app.lo.Error("oidc redirect uri missing from session", "provider_id", providerID)
-		return redirectLoginError(r, oidcErrSessionExpired, nextStr)
-	}
-
-	_, claims, err := app.auth.ExchangeOIDCToken(r.RequestCtx, providerID, code, redirectURI)
+	_, claims, err := app.auth.ExchangeOIDCToken(r.RequestCtx, providerID, code)
 	if err != nil {
 		if errors.Is(err, auth_.ErrOIDCInvalidClient) {
 			return redirectLoginError(r, oidcErrInvalidClient, nextStr)

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -25,8 +25,9 @@ const (
 )
 
 var (
-	oidcStateSessKey = "oidc_state"
-	oidcNextSessKey  = "oidc_next"
+	oidcStateSessKey       = "oidc_state"
+	oidcNextSessKey        = "oidc_next"
+	oidcRedirectURISessKey = "oidc_redirect_uri"
 )
 
 // handleOIDCLogin redirects to the OIDC provider for login.
@@ -59,9 +60,17 @@ func handleOIDCLogin(r *fastglue.Request) error {
 		return redirectLoginError(r, oidcErrLoginFailed, next)
 	}
 
-	authURL, err := app.auth.LoginURL(providerID, state)
+	authURL, redirectURI, err := app.auth.LoginURL(providerID, state)
 	if err != nil {
 		app.lo.Error("error getting oidc login url", "provider_id", providerID, "error", err)
+		return redirectLoginError(r, oidcErrLoginFailed, next)
+	}
+	// Persist the redirect URI used at login so the callback's token exchange
+	// sends the same one (RFC 6749 4.1.3). It is resolved live from the current
+	// root URL, so a Root URL change between login and callback would otherwise
+	// produce a mismatch the IdP rejects.
+	if err = app.auth.SetSessionValues(r, map[string]any{oidcRedirectURISessKey: redirectURI}); err != nil {
+		app.lo.Error("error saving redirect uri in session", "error", err)
 		return redirectLoginError(r, oidcErrLoginFailed, next)
 	}
 	app.lo.Debug("redirecting to oidc provider for login", "provider_id", providerID)
@@ -109,7 +118,12 @@ func handleOIDCCallback(r *fastglue.Request) error {
 		return redirectLoginError(r, oidcErrSessionExpired, nextStr)
 	}
 
-	_, claims, err := app.auth.ExchangeOIDCToken(r.RequestCtx, providerID, code)
+	// Reuse the redirect URI stored at login so the token exchange sends the
+	// same one the provider saw (RFC 6749 4.1.3).
+	storedRedirectURI, _ := app.auth.GetSessionValue(r, oidcRedirectURISessKey)
+	redirectURI, _ := storedRedirectURI.(string)
+
+	_, claims, err := app.auth.ExchangeOIDCToken(r.RequestCtx, providerID, code, redirectURI)
 	if err != nil {
 		if errors.Is(err, auth_.ErrOIDCInvalidClient) {
 			return redirectLoginError(r, oidcErrInvalidClient, nextStr)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -860,7 +860,8 @@ func reloadAuth(app *App) error {
 	app.lo.Info("reloading auth manager")
 	providers, err := buildProviders(app.oidc)
 	if err != nil {
-		log.Fatalf("error reloading auth: %v", err)
+		app.lo.Error("error reloading auth", "error", err)
+		return err
 	}
 	if err := app.auth.Reload(auth_.Config{Providers: providers}); err != nil {
 		app.lo.Error("error reloading auth", "error", err)
@@ -881,16 +882,11 @@ func buildProviders(o *oidc.Manager) ([]auth_.Provider, error) {
 		if !config.Enabled {
 			continue
 		}
-		// Capture the redirect URL as a closure over the live root URL rather
-		// than the value at build time, so a Root URL change takes effect
-		// without an explicit reload. Other fields (client ID, provider URL)
-		// are still snapshotted and refreshed by reloadAuth on OIDC changes.
-		providerID := config.ID
 		providers = append(providers, auth_.Provider{
 			ID:           config.ID,
 			Provider:     config.Provider,
 			ProviderURL:  config.ProviderURL,
-			RedirectURL:  func() (string, error) { return o.RedirectURL(providerID) },
+			RedirectURL:  func() (string, error) { return o.RedirectURL(config.ID) },
 			ClientID:     config.ClientID,
 			ClientSecret: config.ClientSecret,
 		})

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -881,11 +881,16 @@ func buildProviders(o *oidc.Manager) ([]auth_.Provider, error) {
 		if !config.Enabled {
 			continue
 		}
+		// Capture the redirect URL as a closure over the live root URL rather
+		// than the value at build time, so a Root URL change takes effect
+		// without an explicit reload. Other fields (client ID, provider URL)
+		// are still snapshotted and refreshed by reloadAuth on OIDC changes.
+		providerID := config.ID
 		providers = append(providers, auth_.Provider{
 			ID:           config.ID,
 			Provider:     config.Provider,
 			ProviderURL:  config.ProviderURL,
-			RedirectURL:  config.RedirectURI,
+			RedirectURL:  func() string { u, _ := o.RedirectURL(providerID); return u },
 			ClientID:     config.ClientID,
 			ClientSecret: config.ClientSecret,
 		})

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -890,7 +890,7 @@ func buildProviders(o *oidc.Manager) ([]auth_.Provider, error) {
 			ID:           config.ID,
 			Provider:     config.Provider,
 			ProviderURL:  config.ProviderURL,
-			RedirectURL:  func() string { u, _ := o.RedirectURL(providerID); return u },
+			RedirectURL:  func() (string, error) { return o.RedirectURL(providerID) },
 			ClientID:     config.ClientID,
 			ClientSecret: config.ClientSecret,
 		})

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -44,7 +44,7 @@ type Provider struct {
 	ID           int
 	Provider     string
 	ProviderURL  string
-	RedirectURL  func() string
+	RedirectURL  func() (string, error)
 	ClientID     string
 	ClientSecret string
 }
@@ -66,7 +66,7 @@ type Auth struct {
 	i18n         *i18n.I18n
 	oauthCfgs    map[int]oauth2.Config
 	verifiers    map[int]*oidc.IDTokenVerifier
-	redirectURLs map[int]func() string
+	redirectURLs map[int]func() (string, error)
 	sess         *simplesessions.Manager
 	logger       *logf.Logger
 	rd           *redis.Client
@@ -77,7 +77,7 @@ type Auth struct {
 func New(cfg Config, i18n *i18n.I18n, rd *redis.Client, logger *logf.Logger, dialControl ssrf.Control) (*Auth, error) {
 	oauthCfgs := make(map[int]oauth2.Config)
 	verifiers := make(map[int]*oidc.IDTokenVerifier)
-	redirectURLs := make(map[int]func() string)
+	redirectURLs := make(map[int]func() (string, error))
 
 	oidcClient := newOIDCClient(dialControl)
 
@@ -165,7 +165,7 @@ func (a *Auth) Reload(cfg Config) error {
 
 	oauthCfgs := make(map[int]oauth2.Config)
 	verifiers := make(map[int]*oidc.IDTokenVerifier)
-	redirectURLs := make(map[int]func() string)
+	redirectURLs := make(map[int]func() (string, error))
 
 	for _, provider := range cfg.Providers {
 		oidcProv, err := oidc.NewProvider(oidc.ClientContext(context.Background(), a.oidcClient), provider.ProviderURL)
@@ -196,24 +196,34 @@ func (a *Auth) Reload(cfg Config) error {
 	return nil
 }
 
-// LoginURL returns the login URL for the given provider.
-func (a *Auth) LoginURL(providerID int, state string) (string, error) {
+// LoginURL returns the login URL for the given provider, along with the
+// redirect URI it was built with. The caller must persist that URI and pass it
+// to ExchangeOIDCToken so the token exchange sends the same redirect_uri the
+// provider saw at login (RFC 6749 4.1.3) -- resolving it twice would let a Root
+// URL change between the two requests produce a mismatch the IdP rejects.
+func (a *Auth) LoginURL(providerID int, state string) (string, string, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	oauthCfg, ok := a.oauthCfgs[providerID]
 	if !ok {
-		return "", envelope.NewError(envelope.InputError, a.i18n.T("validation.notFoundProvider"), nil)
+		return "", "", envelope.NewError(envelope.InputError, a.i18n.T("validation.notFoundProvider"), nil)
 	}
-	// Resolve redirect URL on use so a Root URL change takes effect without a
-	// reload: providers capture the closure, not the value, at build time.
+	// Resolve the redirect URL live from the current root URL so a change takes
+	// effect without a reload. The closure reads the setting, not a snapshot.
 	if fn, ok := a.redirectURLs[providerID]; ok && fn != nil {
-		oauthCfg.RedirectURL = fn()
+		redirectURL, err := fn()
+		if err != nil {
+			return "", "", envelope.NewError(envelope.GeneralError, a.i18n.T("globals.messages.somethingWentWrong"), nil)
+		}
+		oauthCfg.RedirectURL = redirectURL
 	}
-	return oauthCfg.AuthCodeURL(state), nil
+	return oauthCfg.AuthCodeURL(state), oauthCfg.RedirectURL, nil
 }
 
 // ExchangeOIDCToken takes an OIDC authorization code, validates it, and returns an OIDC token for subsequent auth.
-func (a *Auth) ExchangeOIDCToken(ctx context.Context, providerID int, code string) (string, OIDCclaim, error) {
+// redirectURI must be the URI LoginURL returned at the start of this login, so
+// the token exchange sends the same redirect_uri the provider saw then.
+func (a *Auth) ExchangeOIDCToken(ctx context.Context, providerID int, code, redirectURI string) (string, OIDCclaim, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
@@ -222,11 +232,9 @@ func (a *Auth) ExchangeOIDCToken(ctx context.Context, providerID int, code strin
 		a.logger.Error("oidc provider not configured, it may have failed to initialize at startup", "provider_id", providerID)
 		return "", OIDCclaim{}, fmt.Errorf("invalid provider ID: %d", providerID)
 	}
-	// Resolve redirect URL on use so a Root URL change takes effect without a
-	// reload (see LoginURL).
-	if fn, ok := a.redirectURLs[providerID]; ok && fn != nil {
-		oauthCfg.RedirectURL = fn()
-	}
+	// Reuse the redirect URI captured at login, not a fresh resolution: the
+	// exchange redirect_uri must match the one in the auth request.
+	oauthCfg.RedirectURL = redirectURI
 
 	verifier, ok := a.verifiers[providerID]
 	if !ok {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -44,7 +44,7 @@ type Provider struct {
 	ID           int
 	Provider     string
 	ProviderURL  string
-	RedirectURL  string
+	RedirectURL  func() string
 	ClientID     string
 	ClientSecret string
 }
@@ -61,21 +61,23 @@ const defaultSessionLifetime = 9 * time.Hour
 
 // Auth is the auth service it manages OIDC authentication and sessions
 type Auth struct {
-	mu         sync.RWMutex
-	cfg        Config
-	i18n       *i18n.I18n
-	oauthCfgs  map[int]oauth2.Config
-	verifiers  map[int]*oidc.IDTokenVerifier
-	sess       *simplesessions.Manager
-	logger     *logf.Logger
-	rd         *redis.Client
-	oidcClient *http.Client
+	mu           sync.RWMutex
+	cfg          Config
+	i18n         *i18n.I18n
+	oauthCfgs    map[int]oauth2.Config
+	verifiers    map[int]*oidc.IDTokenVerifier
+	redirectURLs map[int]func() string
+	sess         *simplesessions.Manager
+	logger       *logf.Logger
+	rd           *redis.Client
+	oidcClient   *http.Client
 }
 
 // New creates an Auth service with configured OIDC providers.
 func New(cfg Config, i18n *i18n.I18n, rd *redis.Client, logger *logf.Logger, dialControl ssrf.Control) (*Auth, error) {
 	oauthCfgs := make(map[int]oauth2.Config)
 	verifiers := make(map[int]*oidc.IDTokenVerifier)
+	redirectURLs := make(map[int]func() string)
 
 	oidcClient := newOIDCClient(dialControl)
 
@@ -90,7 +92,6 @@ func New(cfg Config, i18n *i18n.I18n, rd *redis.Client, logger *logf.Logger, dia
 			ClientID:     provider.ClientID,
 			ClientSecret: provider.ClientSecret,
 			Endpoint:     oidcProv.Endpoint(),
-			RedirectURL:  provider.RedirectURL,
 			Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
 		}
 
@@ -98,6 +99,7 @@ func New(cfg Config, i18n *i18n.I18n, rd *redis.Client, logger *logf.Logger, dia
 
 		oauthCfgs[provider.ID] = oauthCfg
 		verifiers[provider.ID] = verifier
+		redirectURLs[provider.ID] = provider.RedirectURL
 	}
 
 	lifetime := cfg.SessionLifetime
@@ -123,14 +125,15 @@ func New(cfg Config, i18n *i18n.I18n, rd *redis.Client, logger *logf.Logger, dia
 	sess.SetCookieHooks(simpleSessGetCookieCB, simpleSessSetCookieCB)
 
 	return &Auth{
-		cfg:        cfg,
-		i18n:       i18n,
-		oauthCfgs:  oauthCfgs,
-		verifiers:  verifiers,
-		sess:       sess,
-		logger:     logger,
-		rd:         rd,
-		oidcClient: oidcClient,
+		cfg:          cfg,
+		i18n:         i18n,
+		oauthCfgs:    oauthCfgs,
+		verifiers:    verifiers,
+		redirectURLs: redirectURLs,
+		sess:         sess,
+		logger:       logger,
+		rd:           rd,
+		oidcClient:   oidcClient,
 	}, nil
 }
 
@@ -162,6 +165,7 @@ func (a *Auth) Reload(cfg Config) error {
 
 	oauthCfgs := make(map[int]oauth2.Config)
 	verifiers := make(map[int]*oidc.IDTokenVerifier)
+	redirectURLs := make(map[int]func() string)
 
 	for _, provider := range cfg.Providers {
 		oidcProv, err := oidc.NewProvider(oidc.ClientContext(context.Background(), a.oidcClient), provider.ProviderURL)
@@ -174,7 +178,6 @@ func (a *Auth) Reload(cfg Config) error {
 			ClientID:     provider.ClientID,
 			ClientSecret: provider.ClientSecret,
 			Endpoint:     oidcProv.Endpoint(),
-			RedirectURL:  provider.RedirectURL,
 			Scopes:       []string{oidc.ScopeOpenID, "profile", "email"},
 		}
 
@@ -182,11 +185,13 @@ func (a *Auth) Reload(cfg Config) error {
 
 		oauthCfgs[provider.ID] = oauthCfg
 		verifiers[provider.ID] = verifier
+		redirectURLs[provider.ID] = provider.RedirectURL
 	}
 
 	a.cfg = cfg
 	a.oauthCfgs = oauthCfgs
 	a.verifiers = verifiers
+	a.redirectURLs = redirectURLs
 
 	return nil
 }
@@ -198,6 +203,11 @@ func (a *Auth) LoginURL(providerID int, state string) (string, error) {
 	oauthCfg, ok := a.oauthCfgs[providerID]
 	if !ok {
 		return "", envelope.NewError(envelope.InputError, a.i18n.T("validation.notFoundProvider"), nil)
+	}
+	// Resolve redirect URL on use so a Root URL change takes effect without a
+	// reload: providers capture the closure, not the value, at build time.
+	if fn, ok := a.redirectURLs[providerID]; ok && fn != nil {
+		oauthCfg.RedirectURL = fn()
 	}
 	return oauthCfg.AuthCodeURL(state), nil
 }
@@ -211,6 +221,11 @@ func (a *Auth) ExchangeOIDCToken(ctx context.Context, providerID int, code strin
 	if !ok {
 		a.logger.Error("oidc provider not configured, it may have failed to initialize at startup", "provider_id", providerID)
 		return "", OIDCclaim{}, fmt.Errorf("invalid provider ID: %d", providerID)
+	}
+	// Resolve redirect URL on use so a Root URL change takes effect without a
+	// reload (see LoginURL).
+	if fn, ok := a.redirectURLs[providerID]; ok && fn != nil {
+		oauthCfg.RedirectURL = fn()
 	}
 
 	verifier, ok := a.verifiers[providerID]

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -212,17 +212,6 @@ func (a *Auth) LoginURL(providerID int, state string) (string, error) {
 	oauthCfg.RedirectURL = redirectURL
 	return oauthCfg.AuthCodeURL(state), nil
 }
-
-// resolveRedirectURL reads the provider's redirect URL from the current root URL setting.
-func (a *Auth) resolveRedirectURL(providerID int) (string, error) {
-	fn, ok := a.redirectURLs[providerID]
-	if !ok || fn == nil {
-		return "", fmt.Errorf("no redirect URL resolver for provider: %d", providerID)
-	}
-	return fn()
-}
-
-// ExchangeOIDCToken takes an OIDC authorization code, validates it, and returns an OIDC token for subsequent auth.
 func (a *Auth) ExchangeOIDCToken(ctx context.Context, providerID int, code string) (string, OIDCclaim, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
@@ -413,6 +402,15 @@ func (a *Auth) DestroySession(r *fastglue.Request) error {
 		return err
 	}
 	return nil
+}
+
+// resolveRedirectURL reads the provider's redirect URL from the current root URL setting.
+func (a *Auth) resolveRedirectURL(providerID int) (string, error) {
+	fn, ok := a.redirectURLs[providerID]
+	if !ok || fn == nil {
+		return "", fmt.Errorf("no redirect URL resolver for provider: %d", providerID)
+	}
+	return fn()
 }
 
 // generateCSRFToken creates a random base64 encoded str.

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -196,34 +196,34 @@ func (a *Auth) Reload(cfg Config) error {
 	return nil
 }
 
-// LoginURL returns the login URL for the given provider, along with the
-// redirect URI it was built with. The caller must persist that URI and pass it
-// to ExchangeOIDCToken so the token exchange sends the same redirect_uri the
-// provider saw at login (RFC 6749 4.1.3) -- resolving it twice would let a Root
-// URL change between the two requests produce a mismatch the IdP rejects.
-func (a *Auth) LoginURL(providerID int, state string) (string, string, error) {
+// LoginURL returns the login URL for the given provider.
+func (a *Auth) LoginURL(providerID int, state string) (string, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	oauthCfg, ok := a.oauthCfgs[providerID]
 	if !ok {
-		return "", "", envelope.NewError(envelope.InputError, a.i18n.T("validation.notFoundProvider"), nil)
+		return "", envelope.NewError(envelope.InputError, a.i18n.T("validation.notFoundProvider"), nil)
 	}
-	// Resolve the redirect URL live from the current root URL so a change takes
-	// effect without a reload. The closure reads the setting, not a snapshot.
-	if fn, ok := a.redirectURLs[providerID]; ok && fn != nil {
-		redirectURL, err := fn()
-		if err != nil {
-			return "", "", envelope.NewError(envelope.GeneralError, a.i18n.T("globals.messages.somethingWentWrong"), nil)
-		}
-		oauthCfg.RedirectURL = redirectURL
+	redirectURL, err := a.resolveRedirectURL(providerID)
+	if err != nil {
+		a.logger.Error("error resolving oidc redirect url", "provider_id", providerID, "error", err)
+		return "", envelope.NewError(envelope.GeneralError, a.i18n.T("globals.messages.somethingWentWrong"), nil)
 	}
-	return oauthCfg.AuthCodeURL(state), oauthCfg.RedirectURL, nil
+	oauthCfg.RedirectURL = redirectURL
+	return oauthCfg.AuthCodeURL(state), nil
+}
+
+// resolveRedirectURL reads the provider's redirect URL from the current root URL setting.
+func (a *Auth) resolveRedirectURL(providerID int) (string, error) {
+	fn, ok := a.redirectURLs[providerID]
+	if !ok || fn == nil {
+		return "", fmt.Errorf("no redirect URL resolver for provider: %d", providerID)
+	}
+	return fn()
 }
 
 // ExchangeOIDCToken takes an OIDC authorization code, validates it, and returns an OIDC token for subsequent auth.
-// redirectURI must be the URI LoginURL returned at the start of this login, so
-// the token exchange sends the same redirect_uri the provider saw then.
-func (a *Auth) ExchangeOIDCToken(ctx context.Context, providerID int, code, redirectURI string) (string, OIDCclaim, error) {
+func (a *Auth) ExchangeOIDCToken(ctx context.Context, providerID int, code string) (string, OIDCclaim, error) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 
@@ -232,9 +232,12 @@ func (a *Auth) ExchangeOIDCToken(ctx context.Context, providerID int, code, redi
 		a.logger.Error("oidc provider not configured, it may have failed to initialize at startup", "provider_id", providerID)
 		return "", OIDCclaim{}, fmt.Errorf("invalid provider ID: %d", providerID)
 	}
-	// Reuse the redirect URI captured at login, not a fresh resolution: the
-	// exchange redirect_uri must match the one in the auth request.
-	oauthCfg.RedirectURL = redirectURI
+	redirectURL, err := a.resolveRedirectURL(providerID)
+	if err != nil {
+		a.logger.Error("error resolving oidc redirect url", "provider_id", providerID, "error", err)
+		return "", OIDCclaim{}, err
+	}
+	oauthCfg.RedirectURL = redirectURL
 
 	verifier, ok := a.verifiers[providerID]
 	if !ok {

--- a/internal/oidc/oidc.go
+++ b/internal/oidc/oidc.go
@@ -90,13 +90,7 @@ func (o *Manager) Get(id int) (models.OIDC, error) {
 	return oidc, nil
 }
 
-// RedirectURL returns the OIDC redirect URI for the given provider, computed
-// from the current app root URL. It is intended for live lookup so callers
-// that capture the redirect URL (e.g. auth providers) do not go stale when
-// the root URL changes; it does not read the OIDC row, only the setting.
-// rootURL is passed as a formatting argument, not concatenated into the
-// format string, so a root URL containing a %-sequence (e.g. %2F) is not
-// interpreted as a verb.
+// RedirectURL returns the OIDC redirect URI for the given provider, computed from the current app root URL.
 func (o *Manager) RedirectURL(id int) (string, error) {
 	rootURL, err := o.setting.GetAppRootURL()
 	if err != nil {

--- a/internal/oidc/oidc.go
+++ b/internal/oidc/oidc.go
@@ -94,12 +94,15 @@ func (o *Manager) Get(id int) (models.OIDC, error) {
 // from the current app root URL. It is intended for live lookup so callers
 // that capture the redirect URL (e.g. auth providers) do not go stale when
 // the root URL changes; it does not read the OIDC row, only the setting.
+// rootURL is passed as a formatting argument, not concatenated into the
+// format string, so a root URL containing a %-sequence (e.g. %2F) is not
+// interpreted as a verb.
 func (o *Manager) RedirectURL(id int) (string, error) {
 	rootURL, err := o.setting.GetAppRootURL()
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf(rootURL+redirectURL, id), nil
+	return fmt.Sprintf("%s"+redirectURL, rootURL, id), nil
 }
 
 // GetAll retrieves all oidc.

--- a/internal/oidc/oidc.go
+++ b/internal/oidc/oidc.go
@@ -90,6 +90,18 @@ func (o *Manager) Get(id int) (models.OIDC, error) {
 	return oidc, nil
 }
 
+// RedirectURL returns the OIDC redirect URI for the given provider, computed
+// from the current app root URL. It is intended for live lookup so callers
+// that capture the redirect URL (e.g. auth providers) do not go stale when
+// the root URL changes; it does not read the OIDC row, only the setting.
+func (o *Manager) RedirectURL(id int) (string, error) {
+	rootURL, err := o.setting.GetAppRootURL()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(rootURL+redirectURL, id), nil
+}
+
 // GetAll retrieves all oidc.
 func (o *Manager) GetAll() ([]models.OIDC, error) {
 	var oidc = make([]models.OIDC, 0)


### PR DESCRIPTION
Closes #546 (preferred option).

This is the preferred fix for #546. A companion PR with the narrow one-liner is at #547; the maintainer can choose the approach. See the comment on this PR.

## What

Change `auth.Provider.RedirectURL` from a `string` captured at build time to a `func() (string, error)` closure, resolve it live once per login, and carry it through the token exchange. Add `oidc.Manager.RedirectURL(id)` to compute the URI from the current `app.root_url`.

## Why

OIDC providers snapshot `app.root_url` into their `RedirectURL` at construction time (`buildProviders`, `cmd/init.go:873`), so changing Root URL in Admin -> Workspace -> General leaves the redirect URI stale until the process restarts. SSO then keeps sending the old `redirect_uri` and the identity provider rejects it:

```
{"error":"invalid_request","error_description":"The requested redirect_uri is missing in the client configuration."}
```

`reloadAuth` rebuilds providers and is called on OIDC create/update, but nothing calls it from the settings handler, so Root URL -- the one input to the redirect URI -- has no reload path at all.

This PR removes the reload requirement for Root URL entirely: the redirect URL is read live from the setting on login, so it cannot go stale. This is the pattern the media store already uses two hundred lines earlier in the same file (`cmd/init.go:579`, `rootURL := func() string { ... }`).

## What it does

- `auth.Provider.RedirectURL` becomes `func() (string, error)`. `buildProviders` passes a closure calling `o.RedirectURL(providerID)`.
- `auth.New` and `auth.Reload` store the closures in a `redirectURLs` map and no longer bake `RedirectURL` into the stored `oauth2.Config`.
- `LoginURL` resolves the redirect URI live, returns it alongside the auth URL, and propagates a resolution error instead of discarding it (an empty `redirect_uri` would be rejected by the IdP).
- The login handler persists the resolved URI in the session (`oidc_redirect_uri`); the callback handler passes it to `ExchangeOIDCToken`, which reuses it verbatim. The token exchange `redirect_uri` must equal the one in the auth request (RFC 6749 4.1.3), so resolving it twice would let a Root URL change between login and callback produce a mismatch.
- `oidc.Manager.RedirectURL(id)` computes `rootURL + "/api/v1/oidc/%d/finish"` from the live setting, passing `rootURL` as a formatting argument so a root URL containing a `%`-sequence (e.g. `%2F`) is not interpreted as a verb. The path format stays owned by the `oidc` package.
- Other provider fields (client ID, provider URL) remain snapshotted and are refreshed by `reloadAuth` on OIDC create/update, as before.

## Scope

This closes the reported bug and removes the reload dependency for Root URL specifically. It does not add a generic `reloadAll`, so a future subsystem that snapshots a *different* setting could still reintroduce the class. #546 describes that wider concern; this PR is the targeted fix that makes the reported case impossible to go stale.

## Testing

- `go build ./...`
- `go test ./...`
- `go vet ./internal/auth/ ./internal/oidc/ ./cmd/`

There is no existing test harness for the auth/oidc layer (both packages have no test files today; `New`/`Reload` require an OIDC discovery endpoint and Redis). The change is verified structurally: the stored `oauth2.Config.RedirectURL` is no longer set at build time; `LoginURL` resolves it live and returns it; `ExchangeOIDCToken` reuses the caller-supplied value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication provider error handling so failures are reported without abruptly terminating the application.
  - Redirect URLs are now resolved using the current application URL at runtime.
  - Fixed redirect handling for URLs containing special formatting characters.
  - Authentication and OIDC token exchanges now surface redirect URL resolution errors correctly.
  - Improved reliability when application URL configuration is unavailable or changes during authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->