### PR TITLE
notification: apply email settings live instead of asking for a restart

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -46,6 +46,7 @@ import (
 	"github.com/abhinavxd/libredesk/internal/role"
 	"github.com/abhinavxd/libredesk/internal/search"
 	"github.com/abhinavxd/libredesk/internal/setting"
+	smodels "github.com/abhinavxd/libredesk/internal/setting/models"
 	"github.com/abhinavxd/libredesk/internal/sla"
 	"github.com/abhinavxd/libredesk/internal/ssrf"
 	"github.com/abhinavxd/libredesk/internal/tag"
@@ -671,28 +672,57 @@ func initAutoAssigner(teamManager *team.Manager, userManager *user.Manager, conv
 	return e
 }
 
-// buildEmailNotifier builds the email notification provider from the
-// `notification.email.*` settings currently loaded in koanf. It is used at boot
-// and again by reloadNotifier whenever those settings are saved.
-func buildEmailNotifier() (*emailnotifier.Email, error) {
-	smtpCfg := imodels.SMTPConfig{}
-	if err := ko.UnmarshalWithConf("notification.email", &smtpCfg, koanf.UnmarshalConf{Tag: "json"}); err != nil {
-		return nil, fmt.Errorf("unmarshalling email notification provider config: %w", err)
+// loadEmailNotificationSettings reads the `notification.email.*` settings
+// from the database. The notifier is built from this struct, both at boot and
+// when the settings are saved, so it never reads koanf on the live path (koanf
+// is reloaded under the App lock and is not safe to read concurrently).
+func loadEmailNotificationSettings(settings *setting.Manager) (smodels.EmailNotification, error) {
+	var cfg smodels.EmailNotification
+	out, err := settings.GetByPrefix("notification.email")
+	if err != nil {
+		return cfg, err
 	}
-	// The setting is stored as `wait_timeout` but the pool option's JSON tag is
-	// `pool_wait_timeout`, so the unmarshal above never fills it and the pool
-	// silently ran on its default. Map it by hand.
-	smtpCfg.PoolWaitTimeout = ko.String("notification.email.wait_timeout")
+	if err := json.Unmarshal(out, &cfg); err != nil {
+		return cfg, fmt.Errorf("unmarshalling email notification settings: %w", err)
+	}
+	return cfg, nil
+}
 
+// buildEmailNotifier builds the email notification provider from the given
+// settings. Building does not connect, so a config the pool rejects (an
+// unknown auth protocol, say) fails here and nothing is left half-applied.
+func buildEmailNotifier(cfg smodels.EmailNotification) (*emailnotifier.Email, error) {
+	smtpCfg := imodels.SMTPConfig{
+		Username:          cfg.Username,
+		Password:          cfg.Password,
+		AuthProtocol:      cfg.AuthProtocol,
+		TLSType:           cfg.TLSType,
+		TLSSkipVerify:     cfg.TLSSkipVerify,
+		Host:              cfg.Host,
+		Port:              cfg.Port,
+		HelloHostname:     cfg.HelloHostname,
+		MaxConns:          cfg.MaxConns,
+		MaxMessageRetries: cfg.MaxMsgRetries,
+		IdleTimeout:       cfg.IdleTimeout,
+		// Mapped by name on purpose: the setting is `wait_timeout` while the
+		// pool option's JSON tag is `pool_wait_timeout`, so the koanf
+		// unmarshal this replaced never filled it and the pool always ran on
+		// the library default.
+		PoolWaitTimeout: cfg.WaitTimeout,
+	}
 	return emailnotifier.New([]imodels.SMTPConfig{smtpCfg}, emailnotifier.Opts{
 		Lo:        initLogger("email-notifier"),
-		FromEmail: ko.String("notification.email.email_address"),
+		FromEmail: cfg.EmailAddress,
 	})
 }
 
 // initNotifier initializes the notifier service with available providers.
-func initNotifier() *notifier.Service {
-	emailNotifier, err := buildEmailNotifier()
+func initNotifier(settings *setting.Manager) *notifier.Service {
+	cfg, err := loadEmailNotificationSettings(settings)
+	if err != nil {
+		log.Fatalf("error loading email notification settings: %v", err)
+	}
+	emailNotifier, err := buildEmailNotifier(cfg)
 	if err != nil {
 		log.Fatalf("error initializing email notifier: %v", err)
 	}
@@ -702,21 +732,6 @@ func initNotifier() *notifier.Service {
 	}
 
 	return notifier.NewService(notifierProviders, ko.MustInt("notification.concurrency"), ko.MustInt("notification.queue_size"), initLogger("notifier"))
-}
-
-// reloadNotifier rebuilds the email provider from the current settings and
-// swaps it into the running notifier service, so SMTP changes apply to the
-// next notification instead of waiting for a restart. The previous provider's
-// idle connections are dropped by its own sweeper.
-func reloadNotifier(app *App) error {
-	app.lo.Info("reloading email notifier")
-	emailNotifier, err := buildEmailNotifier()
-	if err != nil {
-		app.lo.Error("error reloading email notifier", "error", err)
-		return err
-	}
-	app.notifier.SetProvider(emailNotifier)
-	return nil
 }
 
 // initEmailInbox loads inbox config from DB and initializes the email inbox.
@@ -1198,14 +1213,12 @@ func initImporter(i18n *i18n.I18n) *importer.Importer {
 }
 
 // initNotifDispatcher initializes the notification dispatcher.
-func initNotifDispatcher(userNotification *notifier.UserNotificationManager, outbound *notifier.Service, wsHub *ws.Hub) *notifier.Dispatcher {
+func initNotifDispatcher(userNotification *notifier.UserNotificationManager, outbound *notifier.Service, wsHub *ws.Hub, emailEnabled bool) *notifier.Dispatcher {
 	return notifier.NewDispatcher(notifier.DispatcherOpts{
-		InApp:    userNotification,
-		Outbound: outbound,
-		WSHub:    wsHub,
-		// Read live, like the media store's root URL, so the toggle in
-		// settings applies without a restart.
-		EmailEnabled: func() bool { return ko.Bool("notification.email.enabled") },
+		InApp:        userNotification,
+		Outbound:     outbound,
+		WSHub:        wsHub,
+		EmailEnabled: emailEnabled,
 		Lo:           initLogger("notification-dispatcher"),
 	})
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -671,17 +671,28 @@ func initAutoAssigner(teamManager *team.Manager, userManager *user.Manager, conv
 	return e
 }
 
-// initNotifier initializes the notifier service with available providers.
-func initNotifier() *notifier.Service {
+// buildEmailNotifier builds the email notification provider from the
+// `notification.email.*` settings currently loaded in koanf. It is used at boot
+// and again by reloadNotifier whenever those settings are saved.
+func buildEmailNotifier() (*emailnotifier.Email, error) {
 	smtpCfg := imodels.SMTPConfig{}
 	if err := ko.UnmarshalWithConf("notification.email", &smtpCfg, koanf.UnmarshalConf{Tag: "json"}); err != nil {
-		log.Fatalf("error unmarshalling email notification provider config: %v", err)
+		return nil, fmt.Errorf("unmarshalling email notification provider config: %w", err)
 	}
+	// The setting is stored as `wait_timeout` but the pool option's JSON tag is
+	// `pool_wait_timeout`, so the unmarshal above never fills it and the pool
+	// silently ran on its default. Map it by hand.
+	smtpCfg.PoolWaitTimeout = ko.String("notification.email.wait_timeout")
 
-	emailNotifier, err := emailnotifier.New([]imodels.SMTPConfig{smtpCfg}, emailnotifier.Opts{
+	return emailnotifier.New([]imodels.SMTPConfig{smtpCfg}, emailnotifier.Opts{
 		Lo:        initLogger("email-notifier"),
 		FromEmail: ko.String("notification.email.email_address"),
 	})
+}
+
+// initNotifier initializes the notifier service with available providers.
+func initNotifier() *notifier.Service {
+	emailNotifier, err := buildEmailNotifier()
 	if err != nil {
 		log.Fatalf("error initializing email notifier: %v", err)
 	}
@@ -691,6 +702,21 @@ func initNotifier() *notifier.Service {
 	}
 
 	return notifier.NewService(notifierProviders, ko.MustInt("notification.concurrency"), ko.MustInt("notification.queue_size"), initLogger("notifier"))
+}
+
+// reloadNotifier rebuilds the email provider from the current settings and
+// swaps it into the running notifier service, so SMTP changes apply to the
+// next notification instead of waiting for a restart. The previous provider's
+// idle connections are dropped by its own sweeper.
+func reloadNotifier(app *App) error {
+	app.lo.Info("reloading email notifier")
+	emailNotifier, err := buildEmailNotifier()
+	if err != nil {
+		app.lo.Error("error reloading email notifier", "error", err)
+		return err
+	}
+	app.notifier.SetProvider(emailNotifier)
+	return nil
 }
 
 // initEmailInbox loads inbox config from DB and initializes the email inbox.
@@ -1172,12 +1198,14 @@ func initImporter(i18n *i18n.I18n) *importer.Importer {
 }
 
 // initNotifDispatcher initializes the notification dispatcher.
-func initNotifDispatcher(userNotification *notifier.UserNotificationManager, outbound *notifier.Service, wsHub *ws.Hub, emailEnabled bool) *notifier.Dispatcher {
+func initNotifDispatcher(userNotification *notifier.UserNotificationManager, outbound *notifier.Service, wsHub *ws.Hub) *notifier.Dispatcher {
 	return notifier.NewDispatcher(notifier.DispatcherOpts{
-		InApp:        userNotification,
-		Outbound:     outbound,
-		WSHub:        wsHub,
-		EmailEnabled: emailEnabled,
+		InApp:    userNotification,
+		Outbound: outbound,
+		WSHub:    wsHub,
+		// Read live, like the media store's root URL, so the toggle in
+		// settings applies without a restart.
+		EmailEnabled: func() bool { return ko.Bool("notification.email.enabled") },
 		Lo:           initLogger("notification-dispatcher"),
 	})
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -138,8 +138,6 @@ type App struct {
 
 	// Global state that stores data on an available app update.
 	update *AppUpdate
-	// Flag to indicate if app restart is required for settings to take effect.
-	restartRequired bool
 	sync.Mutex
 }
 
@@ -249,7 +247,7 @@ func main() {
 		wsHub                       = initWS(user)
 		notifier                    = initNotifier()
 		userNotification            = initUserNotification(db, i18n)
-		notifDispatcher             = initNotifDispatcher(userNotification, notifier, wsHub, ko.Bool("notification.email.enabled"))
+		notifDispatcher             = initNotifDispatcher(userNotification, notifier, wsHub)
 		automation                  = initAutomationEngine(db, i18n)
 		ai                          = initAI(ctx, db, i18n, ssrfControl)
 		sla                         = initSLA(db, team, settings, businessHours, template, user, i18n, notifDispatcher)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -94,38 +94,42 @@ const (
 
 // App is the global app context which is passed and injected in the http handlers.
 type App struct {
-	ctx              context.Context
-	fs               stuffbin.FileSystem
-	consts           atomic.Value
-	auth             *auth_.Auth
-	authz            *authz.Enforcer
-	i18n             *i18n.I18n
-	lo               *logf.Logger
-	oidc             *oidc.Manager
-	media            *media.Manager
-	setting          *setting.Manager
-	role             *role.Manager
-	user             *user.Manager
-	team             *team.Manager
-	status           *status.Manager
-	priority         *priority.Manager
-	tag              *tag.Manager
-	inbox            *inbox.Manager
-	tmpl             *template.Manager
-	macro            *macro.Manager
-	conversation     *conversation.Manager
-	automation       *automation.Engine
-	businessHours    *businesshours.Manager
-	sla              *sla.Manager
-	csat             *csat.Manager
-	view             *view.Manager
-	ai               *ai.Manager
-	aiAgent          *aiagent.Manager
-	helpcenter       *helpcenter.Manager
-	search           *search.Manager
-	activityLog      *activitylog.Manager
-	notifier         *notifier.Service
-	notifDispatcher  *notifier.Dispatcher
+	ctx             context.Context
+	fs              stuffbin.FileSystem
+	consts          atomic.Value
+	auth            *auth_.Auth
+	authz           *authz.Enforcer
+	i18n            *i18n.I18n
+	lo              *logf.Logger
+	oidc            *oidc.Manager
+	media           *media.Manager
+	setting         *setting.Manager
+	role            *role.Manager
+	user            *user.Manager
+	team            *team.Manager
+	status          *status.Manager
+	priority        *priority.Manager
+	tag             *tag.Manager
+	inbox           *inbox.Manager
+	tmpl            *template.Manager
+	macro           *macro.Manager
+	conversation    *conversation.Manager
+	automation      *automation.Engine
+	businessHours   *businesshours.Manager
+	sla             *sla.Manager
+	csat            *csat.Manager
+	view            *view.Manager
+	ai              *ai.Manager
+	aiAgent         *aiagent.Manager
+	helpcenter      *helpcenter.Manager
+	search          *search.Manager
+	activityLog     *activitylog.Manager
+	notifier        *notifier.Service
+	notifDispatcher *notifier.Dispatcher
+	// Serializes email notification settings updates end to end (read current,
+	// build, persist, publish), so two concurrent saves cannot leave the
+	// database holding one config while the running notifier uses the other.
+	emailSettingsMu  sync.Mutex
 	userNotification *notifier.UserNotificationManager
 	customAttribute  *customAttribute.Manager
 	report           *report.Manager

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -125,6 +125,7 @@ type App struct {
 	search           *search.Manager
 	activityLog      *activitylog.Manager
 	notifier         *notifier.Service
+	notifDispatcher  *notifier.Dispatcher
 	userNotification *notifier.UserNotificationManager
 	customAttribute  *customAttribute.Manager
 	report           *report.Manager
@@ -245,9 +246,9 @@ func main() {
 		webhook                     = initWebhook(db, i18n, ssrfControl)
 		user                        = initUser(i18n, db)
 		wsHub                       = initWS(user)
-		notifier                    = initNotifier()
+		notifier                    = initNotifier(settings)
 		userNotification            = initUserNotification(db, i18n)
-		notifDispatcher             = initNotifDispatcher(userNotification, notifier, wsHub)
+		notifDispatcher             = initNotifDispatcher(userNotification, notifier, wsHub, ko.Bool("notification.email.enabled"))
 		automation                  = initAutomationEngine(db, i18n)
 		ai                          = initAI(ctx, db, i18n, ssrfControl)
 		sla                         = initSLA(db, team, settings, businessHours, template, user, i18n, notifDispatcher)
@@ -304,6 +305,7 @@ func main() {
 		priority:         priority,
 		tmpl:             template,
 		notifier:         notifier,
+		notifDispatcher:  notifDispatcher,
 		consts:           atomic.Value{},
 		conversation:     conversation,
 		automation:       automation,

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -148,18 +148,24 @@ func handleUpdateEmailNotificationSettings(r *fastglue.Request) error {
 		req.Password = cur.Password
 	}
 
+	// Build the provider from the request BEFORE anything is persisted, so a
+	// config the SMTP pool rejects is refused with nothing changed, rather
+	// than saved and then failing to apply.
+	provider, err := buildEmailNotifier(req)
+	if err != nil {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, err.Error(), nil, envelope.InputError)
+	}
+
 	if err := app.setting.Update(req); err != nil {
+		provider.Close()
 		return sendErrorEnvelope(r, err)
 	}
 
-	// Load the saved values into koanf (the dispatcher reads the enabled flag
-	// from there on every send) and rebuild the SMTP provider from them.
-	if err := reloadSettings(app); err != nil {
-		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
-	}
-	if err := reloadNotifier(app); err != nil {
-		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
-	}
+	// Publish the complete state to the running process: the provider first,
+	// then the flag that lets sends reach it. Neither reads koanf, which is
+	// why no reloadSettings is needed here; boot reads the database too.
+	app.notifier.SetProvider(provider)
+	app.notifDispatcher.SetEmailEnabled(req.Enabled)
 
 	return r.SendEnvelope(true)
 }

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -129,6 +129,12 @@ func handleUpdateEmailNotificationSettings(r *fastglue.Request) error {
 	req.IdleTimeout = strings.TrimSpace(req.IdleTimeout)
 	req.WaitTimeout = strings.TrimSpace(req.WaitTimeout)
 
+	// One save at a time from here on: the current-password read, the
+	// persist and the publish below must not interleave with another save,
+	// or the database and the running notifier end up on different configs.
+	app.emailSettingsMu.Lock()
+	defer app.emailSettingsMu.Unlock()
+
 	out, err := app.setting.GetByPrefix("notification.email")
 	if err != nil {
 		return sendErrorEnvelope(r, err)

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -31,8 +31,6 @@ func handleGetGeneralSettings(r *fastglue.Request) error {
 	settings["app.update"] = app.update
 	// Set app version.
 	settings["app.version"] = versionString
-	// Set restart required flag.
-	settings["app.restart_required"] = app.restartRequired
 	return r.SendEnvelope(settings)
 }
 
@@ -154,10 +152,14 @@ func handleUpdateEmailNotificationSettings(r *fastglue.Request) error {
 		return sendErrorEnvelope(r, err)
 	}
 
-	// Email notification settings require app restart to take effect.
-	app.Lock()
-	app.restartRequired = true
-	app.Unlock()
+	// Load the saved values into koanf (the dispatcher reads the enabled flag
+	// from there on every send) and rebuild the SMTP provider from them.
+	if err := reloadSettings(app); err != nil {
+		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
+	}
+	if err := reloadNotifier(app); err != nil {
+		return sendErrorEnvelope(r, envelope.NewError(envelope.GeneralError, app.i18n.T("globals.messages.somethingWentWrong"), nil))
+	}
 
 	return r.SendEnvelope(true)
 }

--- a/frontend/apps/main/src/components/banner/AdminBanner.vue
+++ b/frontend/apps/main/src/components/banner/AdminBanner.vue
@@ -36,28 +36,11 @@
         </div>
       </div>
     </div>
-
-    <!-- Restart required notification -->
-    <div
-      v-if="appSettingsStore.settings['app.restart_required']"
-      class="px-4 py-2.5 border-b border-border/50 last:border-b-0"
-    >
-      <div class="flex items-center gap-3">
-        <div class="flex-shrink-0">
-          <Info class="w-5 h-5 text-primary" />
-        </div>
-        <div class="min-w-0 flex-1">
-          <div class="text-sm text-foreground">
-            {{ $t('admin.banner.restartMessage') }}
-          </div>
-        </div>
-      </div>
-    </div>
   </div>
 </template>
 
 <script setup>
-import { Download, Info } from 'lucide-vue-next'
+import { Download } from 'lucide-vue-next'
 import { useAppSettingsStore } from '@/stores/appSettings'
 const appSettingsStore = useAppSettingsStore()
 </script>

--- a/frontend/apps/main/src/features/admin/notification/NotificationSetting.vue
+++ b/frontend/apps/main/src/features/admin/notification/NotificationSetting.vue
@@ -68,7 +68,7 @@ const submitForm = async (values) => {
     )
     await api.updateEmailNotificationSettings(updatedValues)
     emitter.emit(EMITTER_EVENTS.SHOW_TOAST, {
-      description: t('admin.notification.restartApp')
+      description: t('globals.messages.savedSuccessfully')
     })
     await getNotificationSettings()
     appSettingsStore.fetchSettings()

--- a/internal/notification/dispatcher.go
+++ b/internal/notification/dispatcher.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"encoding/json"
+	"sync/atomic"
 
 	"github.com/abhinavxd/libredesk/internal/notification/models"
 	wsmodels "github.com/abhinavxd/libredesk/internal/ws/models"
@@ -47,7 +48,7 @@ type Dispatcher struct {
 	inApp        *UserNotificationManager
 	outbound     *Service
 	wsHub        WSHub
-	emailEnabled func() bool
+	emailEnabled atomic.Bool
 	lo           *logf.Logger
 }
 
@@ -56,26 +57,28 @@ type DispatcherOpts struct {
 	InApp    *UserNotificationManager
 	Outbound *Service
 	WSHub    WSHub
-	// EmailEnabled is consulted on every send rather than captured once, so
-	// toggling email notifications in settings takes effect without a restart.
-	// nil means email is never sent.
-	EmailEnabled func() bool
+	// EmailEnabled is the initial value; SetEmailEnabled changes it on a
+	// running dispatcher when the setting is saved.
+	EmailEnabled bool
 	Lo           *logf.Logger
 }
 
 // NewDispatcher creates a new notification Dispatcher.
 func NewDispatcher(opts DispatcherOpts) *Dispatcher {
-	enabled := opts.EmailEnabled
-	if enabled == nil {
-		enabled = func() bool { return false }
+	d := &Dispatcher{
+		inApp:    opts.InApp,
+		outbound: opts.Outbound,
+		wsHub:    opts.WSHub,
+		lo:       opts.Lo,
 	}
-	return &Dispatcher{
-		inApp:        opts.InApp,
-		outbound:     opts.Outbound,
-		wsHub:        opts.WSHub,
-		emailEnabled: enabled,
-		lo:           opts.Lo,
-	}
+	d.emailEnabled.Store(opts.EmailEnabled)
+	return d
+}
+
+// SetEmailEnabled turns the email channel on or off for every send after this call, so the
+// setting takes effect without a restart.
+func (d *Dispatcher) SetEmailEnabled(enabled bool) {
+	d.emailEnabled.Store(enabled)
 }
 
 // Send sends a notification through all configured channels.
@@ -85,7 +88,7 @@ func (d *Dispatcher) Send(n Notification) {
 	for i, recipientID := range n.RecipientIDs {
 		d.sendToRecipient(recipientID, n)
 
-		if d.outbound != nil && n.Email != nil && d.emailEnabled() {
+		if d.outbound != nil && n.Email != nil && d.emailEnabled.Load() {
 			var email string
 			if i < len(n.Email.Recipients) {
 				email = n.Email.Recipients[i]
@@ -105,7 +108,7 @@ func (d *Dispatcher) SendWithEmails(n Notification, emails []EmailNotification) 
 	for i, recipientID := range n.RecipientIDs {
 		d.sendToRecipient(recipientID, n)
 
-		if d.outbound != nil && i < len(emails) && len(emails[i].Recipients) > 0 && d.emailEnabled() {
+		if d.outbound != nil && i < len(emails) && len(emails[i].Recipients) > 0 && d.emailEnabled.Load() {
 			e := emails[i]
 			d.sendEmail(recipientID, e.Recipients[0], e.Subject, e.Content, n.Type)
 		}

--- a/internal/notification/dispatcher.go
+++ b/internal/notification/dispatcher.go
@@ -47,26 +47,33 @@ type Dispatcher struct {
 	inApp        *UserNotificationManager
 	outbound     *Service
 	wsHub        WSHub
-	emailEnabled bool
+	emailEnabled func() bool
 	lo           *logf.Logger
 }
 
 // DispatcherOpts contains options for creating a new Dispatcher.
 type DispatcherOpts struct {
-	InApp        *UserNotificationManager
-	Outbound     *Service
-	WSHub        WSHub
-	EmailEnabled bool
+	InApp    *UserNotificationManager
+	Outbound *Service
+	WSHub    WSHub
+	// EmailEnabled is consulted on every send rather than captured once, so
+	// toggling email notifications in settings takes effect without a restart.
+	// nil means email is never sent.
+	EmailEnabled func() bool
 	Lo           *logf.Logger
 }
 
 // NewDispatcher creates a new notification Dispatcher.
 func NewDispatcher(opts DispatcherOpts) *Dispatcher {
+	enabled := opts.EmailEnabled
+	if enabled == nil {
+		enabled = func() bool { return false }
+	}
 	return &Dispatcher{
 		inApp:        opts.InApp,
 		outbound:     opts.Outbound,
 		wsHub:        opts.WSHub,
-		emailEnabled: opts.EmailEnabled,
+		emailEnabled: enabled,
 		lo:           opts.Lo,
 	}
 }
@@ -78,7 +85,7 @@ func (d *Dispatcher) Send(n Notification) {
 	for i, recipientID := range n.RecipientIDs {
 		d.sendToRecipient(recipientID, n)
 
-		if d.outbound != nil && n.Email != nil && d.emailEnabled {
+		if d.outbound != nil && n.Email != nil && d.emailEnabled() {
 			var email string
 			if i < len(n.Email.Recipients) {
 				email = n.Email.Recipients[i]
@@ -98,7 +105,7 @@ func (d *Dispatcher) SendWithEmails(n Notification, emails []EmailNotification) 
 	for i, recipientID := range n.RecipientIDs {
 		d.sendToRecipient(recipientID, n)
 
-		if d.outbound != nil && i < len(emails) && len(emails[i].Recipients) > 0 && d.emailEnabled {
+		if d.outbound != nil && i < len(emails) && len(emails[i].Recipients) > 0 && d.emailEnabled() {
 			e := emails[i]
 			d.sendEmail(recipientID, e.Recipients[0], e.Subject, e.Content, n.Type)
 		}

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -43,9 +43,11 @@ type Notifier interface {
 
 // Service manages message providers and a worker pool.
 type Service struct {
-	// providersMu guards providers on its own: Close holds mu while waiting for
-	// the workers, and a worker mid-SendSync must still be able to look its
-	// provider up, so the two must never share a lock.
+	// providersMu is held for reading across an entire SendSync and for
+	// writing by SetProvider, so a swap waits for in-flight sends to finish
+	// and can then close the retired provider safely. It is separate from mu
+	// on purpose: Close holds mu while waiting for the workers, and a worker
+	// mid-send must not need it.
 	providers      map[string]Notifier
 	providersMu    sync.RWMutex
 	messageChannel chan Message
@@ -83,28 +85,38 @@ func (s *Service) Send(message Message) error {
 	}
 }
 
-// SendSync sends on the caller's goroutine so delivery failures reach the caller; the provider
-// lookup is the only locked section, so a slow relay cannot stall Send, Close or SetProvider.
+// SendSync sends on the caller's goroutine so delivery failures reach the caller. It holds
+// the providers read lock for the duration of the send, which never blocks Send or Close (they
+// use mu); it only makes SetProvider wait for sends already in flight.
 func (s *Service) SendSync(message Message) error {
 	s.providersMu.RLock()
+	defer s.providersMu.RUnlock()
 	provider, exists := s.providers[message.Provider]
-	s.providersMu.RUnlock()
 	if !exists {
 		return fmt.Errorf("unsupported provider: %s", message.Provider)
 	}
 	return provider.Send(message)
 }
 
-// SetProvider replaces the provider registered under p.Name(), or adds it. Messages already
-// in flight finish on the provider they resolved; everything after the swap uses the new one.
-// This is how a settings change reaches a running service without a restart.
+// SetProvider replaces the provider registered under p.Name(), or adds it. It waits for sends
+// in flight on the old provider to finish, then closes the old one if it has a Close method,
+// so a swapped-out SMTP pool does not keep its connections or sweeper goroutine alive. This is
+// how a settings change reaches a running service without a restart.
 func (s *Service) SetProvider(p Notifier) {
 	s.providersMu.Lock()
-	defer s.providersMu.Unlock()
 	if s.providers == nil {
 		s.providers = map[string]Notifier{}
 	}
+	old := s.providers[p.Name()]
 	s.providers[p.Name()] = p
+	s.providersMu.Unlock()
+
+	if old == nil || old == p {
+		return
+	}
+	if c, ok := old.(interface{ Close() }); ok {
+		c.Close()
+	}
 }
 
 // Run starts the worker pool to process messages.

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -43,7 +43,11 @@ type Notifier interface {
 
 // Service manages message providers and a worker pool.
 type Service struct {
+	// providersMu guards providers on its own: Close holds mu while waiting for
+	// the workers, and a worker mid-SendSync must still be able to look its
+	// provider up, so the two must never share a lock.
 	providers      map[string]Notifier
+	providersMu    sync.RWMutex
 	messageChannel chan Message
 	concurrency    int
 	lo             *logf.Logger
@@ -79,13 +83,28 @@ func (s *Service) Send(message Message) error {
 	}
 }
 
-// SendSync sends on the caller's goroutine so delivery failures reach the caller; it holds no lock, so a slow relay cannot stall Send or Close.
+// SendSync sends on the caller's goroutine so delivery failures reach the caller; the provider
+// lookup is the only locked section, so a slow relay cannot stall Send, Close or SetProvider.
 func (s *Service) SendSync(message Message) error {
+	s.providersMu.RLock()
 	provider, exists := s.providers[message.Provider]
+	s.providersMu.RUnlock()
 	if !exists {
 		return fmt.Errorf("unsupported provider: %s", message.Provider)
 	}
 	return provider.Send(message)
+}
+
+// SetProvider replaces the provider registered under p.Name(), or adds it. Messages already
+// in flight finish on the provider they resolved; everything after the swap uses the new one.
+// This is how a settings change reaches a running service without a restart.
+func (s *Service) SetProvider(p Notifier) {
+	s.providersMu.Lock()
+	defer s.providersMu.Unlock()
+	if s.providers == nil {
+		s.providers = map[string]Notifier{}
+	}
+	s.providers[p.Name()] = p
 }
 
 // Run starts the worker pool to process messages.

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -1,0 +1,54 @@
+package notifier
+
+import (
+	"testing"
+)
+
+type fakeProvider struct {
+	name string
+	got  []Message
+}
+
+func (f *fakeProvider) Send(m Message) error { f.got = append(f.got, m); return nil }
+func (f *fakeProvider) Name() string         { return f.name }
+
+// A settings save swaps the provider on the running service; the next message
+// must reach the new one and the old one must see nothing more.
+func TestSetProviderRoutesSubsequentSends(t *testing.T) {
+	old := &fakeProvider{name: ProviderEmail}
+	s := NewService(map[string]Notifier{ProviderEmail: old}, 1, 1, nil)
+
+	if err := s.SendSync(Message{Provider: ProviderEmail, Subject: "before"}); err != nil {
+		t.Fatal(err)
+	}
+
+	next := &fakeProvider{name: ProviderEmail}
+	s.SetProvider(next)
+
+	if err := s.SendSync(Message{Provider: ProviderEmail, Subject: "after"}); err != nil {
+		t.Fatal(err)
+	}
+	if len(old.got) != 1 || old.got[0].Subject != "before" {
+		t.Fatalf("old provider got %+v, want only the message sent before the swap", old.got)
+	}
+	if len(next.got) != 1 || next.got[0].Subject != "after" {
+		t.Fatalf("new provider got %+v, want only the message sent after the swap", next.got)
+	}
+}
+
+// The enabled flag is a closure, so flipping it between sends changes the
+// outcome without rebuilding the dispatcher. A nil closure means never.
+func TestDispatcherEmailEnabledIsResolvedPerSend(t *testing.T) {
+	enabled := false
+	d := NewDispatcher(DispatcherOpts{EmailEnabled: func() bool { return enabled }})
+	if d.emailEnabled() {
+		t.Fatal("expected email disabled")
+	}
+	enabled = true
+	if !d.emailEnabled() {
+		t.Fatal("expected email enabled after the flag flipped")
+	}
+	if NewDispatcher(DispatcherOpts{}).emailEnabled() {
+		t.Fatal("nil EmailEnabled must mean disabled, not a nil-func panic")
+	}
+}

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -2,53 +2,103 @@ package notifier
 
 import (
 	"testing"
+	"time"
 )
 
 type fakeProvider struct {
-	name string
-	got  []Message
+	name    string
+	got     []Message
+	closed  bool
+	release chan struct{} // when set, Send blocks until it is closed
 }
 
-func (f *fakeProvider) Send(m Message) error { f.got = append(f.got, m); return nil }
-func (f *fakeProvider) Name() string         { return f.name }
+func (f *fakeProvider) Send(m Message) error {
+	if f.release != nil {
+		<-f.release
+	}
+	f.got = append(f.got, m)
+	return nil
+}
+func (f *fakeProvider) Name() string { return f.name }
+func (f *fakeProvider) Close()       { f.closed = true }
 
-// A settings save swaps the provider on the running service; the next message
-// must reach the new one and the old one must see nothing more.
-func TestSetProviderRoutesSubsequentSends(t *testing.T) {
+// A settings save swaps the provider on the running service: the next message
+// reaches the new one, the old one sees nothing more and is closed.
+func TestSetProviderRoutesSubsequentSendsAndClosesOld(t *testing.T) {
 	old := &fakeProvider{name: ProviderEmail}
 	s := NewService(map[string]Notifier{ProviderEmail: old}, 1, 1, nil)
 
 	if err := s.SendSync(Message{Provider: ProviderEmail, Subject: "before"}); err != nil {
 		t.Fatal(err)
 	}
-
 	next := &fakeProvider{name: ProviderEmail}
 	s.SetProvider(next)
-
 	if err := s.SendSync(Message{Provider: ProviderEmail, Subject: "after"}); err != nil {
 		t.Fatal(err)
 	}
+
 	if len(old.got) != 1 || old.got[0].Subject != "before" {
 		t.Fatalf("old provider got %+v, want only the message sent before the swap", old.got)
+	}
+	if !old.closed {
+		t.Fatal("old provider was not closed after the swap")
 	}
 	if len(next.got) != 1 || next.got[0].Subject != "after" {
 		t.Fatalf("new provider got %+v, want only the message sent after the swap", next.got)
 	}
+	if next.closed {
+		t.Fatal("new provider must not be closed")
+	}
 }
 
-// The enabled flag is a closure, so flipping it between sends changes the
-// outcome without rebuilding the dispatcher. A nil closure means never.
-func TestDispatcherEmailEnabledIsResolvedPerSend(t *testing.T) {
-	enabled := false
-	d := NewDispatcher(DispatcherOpts{EmailEnabled: func() bool { return enabled }})
-	if d.emailEnabled() {
+// A swap must not close a provider while one of its sends is still running.
+func TestSetProviderWaitsForInFlightSend(t *testing.T) {
+	old := &fakeProvider{name: ProviderEmail, release: make(chan struct{})}
+	s := NewService(map[string]Notifier{ProviderEmail: old}, 1, 1, nil)
+
+	sendDone := make(chan struct{})
+	go func() {
+		_ = s.SendSync(Message{Provider: ProviderEmail})
+		close(sendDone)
+	}()
+	// Let the send reach the provider and block there.
+	time.Sleep(20 * time.Millisecond)
+
+	swapDone := make(chan struct{})
+	go func() {
+		s.SetProvider(&fakeProvider{name: ProviderEmail})
+		close(swapDone)
+	}()
+
+	select {
+	case <-swapDone:
+		t.Fatal("SetProvider returned while a send was still in flight on the old provider")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if old.closed {
+		t.Fatal("old provider closed under an in-flight send")
+	}
+
+	close(old.release)
+	<-sendDone
+	select {
+	case <-swapDone:
+	case <-time.After(time.Second):
+		t.Fatal("SetProvider did not complete once the in-flight send finished")
+	}
+	if !old.closed {
+		t.Fatal("old provider not closed after its send drained")
+	}
+}
+
+// The email channel flag can be flipped on a running dispatcher.
+func TestDispatcherSetEmailEnabled(t *testing.T) {
+	d := NewDispatcher(DispatcherOpts{EmailEnabled: false})
+	if d.emailEnabled.Load() {
 		t.Fatal("expected email disabled")
 	}
-	enabled = true
-	if !d.emailEnabled() {
-		t.Fatal("expected email enabled after the flag flipped")
-	}
-	if NewDispatcher(DispatcherOpts{}).emailEnabled() {
-		t.Fatal("nil EmailEnabled must mean disabled, not a nil-func panic")
+	d.SetEmailEnabled(true)
+	if !d.emailEnabled.Load() {
+		t.Fatal("expected email enabled after SetEmailEnabled(true)")
 	}
 }

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -9,10 +9,14 @@ type fakeProvider struct {
 	name    string
 	got     []Message
 	closed  bool
+	started chan struct{} // when set, closed once Send has been entered
 	release chan struct{} // when set, Send blocks until it is closed
 }
 
 func (f *fakeProvider) Send(m Message) error {
+	if f.started != nil {
+		close(f.started)
+	}
 	if f.release != nil {
 		<-f.release
 	}
@@ -53,7 +57,7 @@ func TestSetProviderRoutesSubsequentSendsAndClosesOld(t *testing.T) {
 
 // A swap must not close a provider while one of its sends is still running.
 func TestSetProviderWaitsForInFlightSend(t *testing.T) {
-	old := &fakeProvider{name: ProviderEmail, release: make(chan struct{})}
+	old := &fakeProvider{name: ProviderEmail, started: make(chan struct{}), release: make(chan struct{})}
 	s := NewService(map[string]Notifier{ProviderEmail: old}, 1, 1, nil)
 
 	sendDone := make(chan struct{})
@@ -61,8 +65,8 @@ func TestSetProviderWaitsForInFlightSend(t *testing.T) {
 		_ = s.SendSync(Message{Provider: ProviderEmail})
 		close(sendDone)
 	}()
-	// Let the send reach the provider and block there.
-	time.Sleep(20 * time.Millisecond)
+	// Wait until the send is inside the provider and blocked there.
+	<-old.started
 
 	swapDone := make(chan struct{})
 	go func() {

--- a/internal/notification/providers/email/email.go
+++ b/internal/notification/providers/email/email.go
@@ -49,6 +49,14 @@ func (e *Email) Name() string {
 	return notifier.ProviderEmail
 }
 
+// Close releases every SMTP pool, stopping their idle-connection sweepers. Called by the
+// notifier service once this provider has been swapped out and its in-flight sends are done.
+func (e *Email) Close() {
+	for _, p := range e.smtpPools {
+		p.Close()
+	}
+}
+
 // send sends an email message.
 func (e *Email) send(em smtppool.Email) error {
 	srv := e.selectSmtpPool()


### PR DESCRIPTION
Closes #566.

Another instance of the settings-snapshot class described in #546 (the OIDC one was fixed in #548). This one is the email notification settings, and it fails more quietly; #566 has the full trace.

## What

Make **Admin -> Notifications** take effect on save. The dispatcher reads `notification.email.enabled` live on every send, the SMTP provider is rebuilt from the saved settings and swapped into the running notifier service, and the "restart required" flag, banner and toast go away because nothing needs them any more.

## Why

Two values were captured at boot and never refreshed:

- `notification.email.enabled` was passed to `initNotifDispatcher` as a **bool** (`cmd/main.go:252`), so the dispatcher kept the boot-time answer forever.
- The email provider was built once in `initNotifier` from the config loaded at startup, so host, port, credentials and the From address were all snapshots.

The update handler knew this and set `app.restartRequired = true`, which surfaced as a banner. But the SLA sender does not wait for the restart: on an instance that enabled notifications while running, each scheduled SLA notification was picked up on time, handed to a dispatcher that believed email was off, and marked `processed_at` with nothing sent. Those rows are not retried after the restart. So the visible outcome was "settings saved, banner shown, SLA warnings silently lost until someone restarts", which took us a while to trace.

Verified on v2.8.0: `scheduled_sla_notifications` row processed at 19:54:27, no SMTP traffic from the pod, `notification.email.enabled = true` in the DB since 19:06, pod started four days earlier.

## What it does

- `notifier.DispatcherOpts.EmailEnabled` stays a bool for the initial value; the dispatcher keeps it in an `atomic.Bool` and gains `SetEmailEnabled`, so the update handler flips it on the running dispatcher. Nothing on the send path reads koanf.
- The provider is built from the `models.EmailNotification` settings struct by one `buildEmailNotifier`: at boot `loadEmailNotificationSettings` reads it from the database, on save the handler passes the request. Building does not connect.
- The handler builds the candidate provider **before** persisting. A config the pool rejects (unknown auth protocol) is refused with 400 and nothing changes; if the database update fails the built provider is closed. Only then is the complete state published: `SetProvider`, then `SetEmailEnabled`.
- `notifier.Service` gains `SetProvider(p Notifier)`. `SendSync` holds a providers read lock across the send, on a mutex **separate** from the one `Close` holds while waiting for workers, so `SetProvider` waits for sends in flight on the old provider and then closes it. `email.Email` gains `Close`, which closes every SMTP pool and stops its sweeper goroutine. `Send` and `Close` never wait on a slow relay.
- `App.restartRequired`, the `app.restart_required` field in the general settings response, the banner block in `AdminBanner.vue` and the "restart the app" toast on the notification page are removed. The toast now says "Changes saved" like General settings. The two i18n keys (`admin.banner.restartMessage`, `admin.notification.restartApp`) are left in every locale file rather than touching twenty translations; happy to drop them if you prefer.

While here: `notification.email.wait_timeout` never reached the SMTP pool. The setting key is `wait_timeout` but `inbox/models.SMTPConfig` tags the field `pool_wait_timeout`, so `ko.UnmarshalWithConf` left it empty and the pool always ran on the library default. `buildEmailNotifier` maps it by name.

## Scope

Fixes the notification settings instance of #546 and removes the restart mechanism that only this handler used. The password-reset and agent-welcome mails in `cmd/users.go` go through the same `Service`, so they pick up new SMTP settings too. Not touched: the email inbox channels, which have their own lifecycle.

## Testing

- `go build ./...`, `go vet ./cmd/... ./internal/notification/...`, `go test ./cmd/... ./internal/notification/...`
- New `internal/notification/notification_test.go`, run with `-race`: a swapped provider receives the next message, the old one receives nothing more and is closed; `SetProvider` waits for an in-flight send before closing; the flag flips on a running dispatcher.
- Not yet exercised end to end on a running instance; the failure mode above was verified on an unpatched v2.8.0, the fix is verified by build, vet and the unit tests. I will report back once our fork image carries it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email notification settings now take effect immediately without requiring an application restart.
  * Email notifications now honor the current enabled or disabled setting.
  * Changes to email notification providers are applied safely while the application is running, including during active deliveries.

* **Bug Fixes**
  * Removed outdated restart-required messaging from the admin interface.
  * Updated the save confirmation to indicate settings were saved successfully.

* **Tests**
  * Added coverage for runtime provider updates and email notification setting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->