### PR TITLE
livechat: add pattern validation for pre-chat form fields

### DIFF
--- a/frontend/apps/widget/src/components/preChatFormSchema.js
+++ b/frontend/apps/widget/src/components/preChatFormSchema.js
@@ -87,7 +87,17 @@ export const createPreChatFormSchema = (t, fields = []) => {
           })
         }
       }
-      
+
+      if (field.pattern) {
+        try {
+          fieldSchema = fieldSchema.regex(new RegExp(field.pattern), {
+            message: field.pattern_message || t('validation.invalid')
+          })
+        } catch {
+          // Ignore an invalid regex from the inbox config, field keeps its existing validation.
+        }
+      }
+
       if (field.required && field.type !== 'checkbox') {
         fieldSchema = fieldSchema.min(1, {
           message: t('globals.messages.required')

--- a/frontend/apps/widget/src/components/preChatFormSchema.test.js
+++ b/frontend/apps/widget/src/components/preChatFormSchema.test.js
@@ -76,6 +76,24 @@ describe('Pre Chat Text Fields', () => {
         expect(() => schema.parse({ thing: '' })).toThrow()
         expect(() => schema.parse({ thing: 'ok' })).not.toThrow()
     })
+
+    test('pattern rejects a value that does not match', () => {
+        const schema = build(field({ key: 'order', type: 'text', required: true, pattern: '^\\d{8}$', pattern_message: 'must be 8 digits' }))
+        expect(() => schema.parse({ order: '12345' })).toThrow('must be 8 digits')
+        expect(() => schema.parse({ order: '12345678' })).not.toThrow()
+    })
+
+    test('pattern is skipped for an optional empty value', () => {
+        const schema = build(field({ key: 'order', type: 'text', pattern: '^\\d{8}$' }))
+        expect(() => schema.parse({ order: '' })).not.toThrow()
+        expect(() => schema.parse({})).not.toThrow()
+        expect(() => schema.parse({ order: '123' })).toThrow()
+    })
+
+    test('an invalid pattern from config is ignored rather than crashing', () => {
+        const schema = build(field({ key: 'order', type: 'text', required: true, pattern: '(' }))
+        expect(() => schema.parse({ order: 'anything' })).not.toThrow()
+    })
 })
 
 describe('Pre Chat Email Field', () => {

--- a/internal/inbox/channel/livechat/livechat.go
+++ b/internal/inbox/channel/livechat/livechat.go
@@ -37,6 +37,8 @@ type PreChatFormField struct {
 	Order             int    `json:"order"`
 	IsDefault         bool   `json:"is_default"`
 	CustomAttributeID int    `json:"custom_attribute_id"`
+	Pattern           string `json:"pattern"`
+	PatternMessage    string `json:"pattern_message"`
 }
 
 // ContinuityConfig holds per-inbox conversation continuity settings.


### PR DESCRIPTION
Motivation:
Pre-chat form fields today only validate by type (email format, URL
format, etc). Deployments that key a conversation to a free-text
identifier such as an account number or order reference have no way
to shape-check it, so a typo becomes a submission nobody can match to
an account.

Approach:
Add optional `Pattern` (a regex) and `PatternMessage` (its error text)
to `PreChatFormField` in internal/inbox/channel/livechat/livechat.go.
Both are empty by default, so existing configs are unaffected. In the
widget's preChatFormSchema.js, when a field carries a pattern, chain a
`.regex()` check onto its zod schema using the same fall-through path
already used for email/date/text/list fields; an invalid regex string
is caught and ignored rather than breaking form validation for every
visitor. Optional empty fields keep bypassing the pattern check, same
as they already bypass other format checks. Matches the existing
codebase convention that field-shape validation is enforced
client-side in the widget, not duplicated server-side.

There is no admin UI to set these two fields yet; for this first PR
they're set directly on the inbox's stored config (e.g. via the API),
matching how the issue describes this half of the change.

Validation:
- go build ./... and go vet ./... pass.
- go test -count=1 ./... passes, aside from a pre-existing failure in
  internal/stringutil (TestNormalizeTimezoneFallsBackToUTC) that
  reproduces identically on the unmodified tree (verified via git
  stash) and is unrelated to this change.
- cd frontend && pnpm exec vitest run: 778 tests pass, including 3 new
  cases added to preChatFormSchema.test.js covering a rejected
  pattern, an optional empty value skipping the pattern, and an
  invalid pattern string being ignored instead of throwing.
- cd frontend && pnpm exec eslint on the two changed frontend files:
  clean.

Report: https://github.com/abhinavxd/libredesk/issues/564
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #564

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable pattern validation for pre-chat fields.
  * Custom validation messages can now be displayed when values do not match the configured pattern.
  * Optional fields skip pattern validation when left empty.

* **Bug Fixes**
  * Invalid pattern configurations are safely ignored instead of causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->