### PR TITLE
fix(email): normalize sender colors in dark mode

### DIFF
--- a/frontend/apps/main/src/features/conversation/message/MessageBubble.vue
+++ b/frontend/apps/main/src/features/conversation/message/MessageBubble.vue
@@ -107,7 +107,8 @@
               </div>
               <div v-else ref="messageContentEl" @click="onMessageContentClick">
                 <Letter
-                  :html="sanitizedContent"
+                  :key="darkMode ? 'dark' : 'light'"
+                  :html="renderedHtmlContent"
                   :allowedSchemas="allowedSchemas"
                   :rewriteExternalLinks="rewriteMessageLink"
                   :allowed-css-properties="extendedCssProperties"
@@ -268,7 +269,7 @@
 </template>
 
 <script setup>
-import { computed, ref, onMounted, nextTick } from 'vue'
+import { computed, ref, onMounted, nextTick, watch } from 'vue'
 import { useConversationStore } from '@main/stores/conversation'
 import { useUserStore } from '@main/stores/user'
 import { useI18n } from 'vue-i18n'
@@ -302,6 +303,7 @@ import MessageEnvelope from './MessageEnvelope.vue'
 import CSATResponseDisplay from './CSATResponseDisplay.vue'
 import api from '@main/api'
 import { containsQuoteMarkers } from '@shared-ui/utils/quotedContent.js'
+import { normalizeEmailHtml } from '@/utils/emailHtmlNormalizer.js'
 
 const extendedCssProperties = [...allowedCssProperties, 'transform', 'transform-origin']
 
@@ -317,15 +319,21 @@ const measureExpandable = () => {
   isExpandable.value = el.scrollHeight > COLLAPSE_THRESHOLD_PX
 }
 
-onMounted(async () => {
-  await nextTick()
-  measureExpandable()
-
-  // Email HTML images change height after initial paint - re-measure on load.
+// Email HTML images change height after initial paint - re-measure on load. Also re-run
+// whenever the content DOM is (re)created, since a dark-mode toggle remounts the Letter
+// subtree (see the `props.darkMode` watcher below) and any images it inserts are fresh
+// elements with no listener attached yet.
+const attachImageLoadListeners = () => {
   const imgs = contentWrapperEl.value?.querySelectorAll?.('img') ?? []
   imgs.forEach((img) => {
     if (!img.complete) img.addEventListener('load', measureExpandable, { once: true })
   })
+}
+
+onMounted(async () => {
+  await nextTick()
+  measureExpandable()
+  attachImageLoadListeners()
 })
 
 const props = defineProps({
@@ -339,6 +347,10 @@ const props = defineProps({
     default: false
   },
   groupWithNext: {
+    type: Boolean,
+    default: false
+  },
+  darkMode: {
     type: Boolean,
     default: false
   }
@@ -400,6 +412,20 @@ const sanitizedContent = computed(() => {
   }
   return props.message.content || ''
 })
+const renderedHtmlContent = computed(() =>
+  normalizeEmailHtml(sanitizedContent.value, props.darkMode)
+)
+
+// Letter captures its sanitized HTML during setup and does not react to prop changes.
+// Remount it on theme changes, then reconnect image load measurement to the new DOM.
+watch(
+  () => props.darkMode,
+  async () => {
+    await nextTick()
+    measureExpandable()
+    attachImageLoadListeners()
+  }
+)
 
 const nonInlineAttachments = computed(() =>
   props.message.attachments.filter((attachment) => attachment.disposition !== 'inline')

--- a/frontend/apps/main/src/features/conversation/message/MessageList.vue
+++ b/frontend/apps/main/src/features/conversation/message/MessageList.vue
@@ -41,6 +41,7 @@
               <MessageBubble
                 :message="row.message"
                 :direction="row.message.type"
+                :dark-mode="colorMode === 'dark'"
                 :group-with-prev="row.groupWithPrev"
                 :group-with-next="row.groupWithNext"
               />
@@ -49,6 +50,7 @@
               <MessageBubble
                 :message="row.message"
                 direction="outgoing"
+                :dark-mode="colorMode === 'dark'"
                 :group-with-prev="row.groupWithPrev"
                 :group-with-next="row.groupWithNext"
               />
@@ -84,6 +86,7 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch, nextTick } from 'vue'
+import { useColorMode } from '@vueuse/core'
 import { useRoute } from 'vue-router'
 import MessageBubble from './MessageBubble.vue'
 import ActivityMessageBubble from './ActivityMessageBubble.vue'
@@ -108,6 +111,7 @@ const MENTION_MAX_ANCHOR_FRAMES = 90
 const HIGHLIGHT_MS = 2500
 
 const route = useRoute()
+const colorMode = useColorMode()
 
 const conversationStore = useConversationStore()
 const userStore = useUserStore()

--- a/frontend/apps/main/src/utils/__fixtures__/apple-mail.html
+++ b/frontend/apps/main/src/utils/__fixtures__/apple-mail.html
@@ -1,0 +1,4 @@
+<div bgcolor="#ffffff">
+  <font color="#000000" face="Helvetica Neue">Sent from Apple Mail</font>
+  <div style="background-color: #f2f2f7; color: #1c1c1e">Previous message</div>
+</div>

--- a/frontend/apps/main/src/utils/__fixtures__/gmail-reply.html
+++ b/frontend/apps/main/src/utils/__fixtures__/gmail-reply.html
@@ -1,0 +1,7 @@
+<style>
+  .gmail_quote { color: #5f6368; background-color: #ffffff; }
+</style>
+<div dir="ltr">Current reply</div>
+<blockquote class="gmail_quote">
+  <div style="color: rgb(95, 99, 104)">On Thursday, Support wrote:</div>
+</blockquote>

--- a/frontend/apps/main/src/utils/__fixtures__/marketing-banner.html
+++ b/frontend/apps/main/src/utils/__fixtures__/marketing-banner.html
@@ -1,0 +1,22 @@
+<style>
+  .hero { background-image: url("https://cdn.example.com/hero.jpg"); }
+  .hero-copy { color: #ffffff; }
+</style>
+<div style="background-image: linear-gradient(#ffffff, #dddddd); color: #ffffff">
+  <span style="color: #ffffff">Gradient banner copy</span>
+</div>
+<div style="background: url('https://cdn.example.com/texture.png') no-repeat; color: #ffffff">
+  <span style="color: #ffffff">Shorthand background copy</span>
+</div>
+<div class="hero">
+  <span class="hero-copy">Stylesheet background copy</span>
+</div>
+<table>
+  <tr>
+    <td background="https://cdn.example.com/banner.jpg" bgcolor="#ffffff">
+      <font color="#ffffff">Image banner copy</font>
+    </td>
+  </tr>
+</table>
+<div style="background-image: none; color: #000000">No image here</div>
+<p style="color: #000000">Footer copy outside the banners</p>

--- a/frontend/apps/main/src/utils/__fixtures__/outlook-desktop.html
+++ b/frontend/apps/main/src/utils/__fixtures__/outlook-desktop.html
@@ -1,0 +1,4 @@
+<div style="background-color: rgb(255, 255, 255); color: rgb(0, 0, 0)">
+  <p style="color: rgb(0, 0, 0)">The Outlook desktop client applies black to every paragraph.</p>
+  <p style="color: #c00000">This warning should remain red.</p>
+</div>

--- a/frontend/apps/main/src/utils/__fixtures__/plain-text-wrapped.html
+++ b/frontend/apps/main/src/utils/__fixtures__/plain-text-wrapped.html
@@ -1,0 +1,1 @@
+<div style="color: rgb(0, 0, 0)">Line one<br>Line two<br>Line three</div>

--- a/frontend/apps/main/src/utils/emailColorNormalizer.js
+++ b/frontend/apps/main/src/utils/emailColorNormalizer.js
@@ -1,0 +1,425 @@
+const DARK_MIN_LIGHTNESS = 0.08
+const DARK_MAX_LIGHTNESS = 0.92
+const MIN_CONTRAST_RATIO = 4.5
+const CONTRAST_ROUNDING_MARGIN = 0.05
+const MAX_CACHE_ENTRIES = 512
+const CSS_WIDE_KEYWORDS = new Set([
+  'currentcolor',
+  'inherit',
+  'initial',
+  'revert',
+  'revert-layer',
+  'unset'
+])
+const parsedColorCache = new Map()
+const remappedColorCache = new Map()
+const contrastColorCache = new Map()
+
+const clamp = (value, min = 0, max = 1) => Math.min(max, Math.max(min, value))
+
+const cacheValue = (cache, key, value) => {
+  if (cache.size >= MAX_CACHE_ENTRIES) {
+    cache.delete(cache.keys().next().value)
+  }
+  cache.set(key, value)
+  return value
+}
+
+const parseAlpha = (value) => {
+  const trimmed = value.trim()
+  if (trimmed.endsWith('%')) {
+    return clamp(Number.parseFloat(trimmed) / 100)
+  }
+  return clamp(Number.parseFloat(trimmed))
+}
+
+const parseRgbChannel = (value) => {
+  const trimmed = value.trim()
+  if (trimmed.endsWith('%')) {
+    return clamp(Number.parseFloat(trimmed) / 100)
+  }
+  return clamp(Number.parseFloat(trimmed) / 255)
+}
+
+const parseHue = (value) => {
+  const trimmed = value.trim().toLowerCase()
+  let degrees = Number.parseFloat(trimmed)
+  if (trimmed.endsWith('turn')) degrees *= 360
+  else if (trimmed.endsWith('grad')) degrees *= 0.9
+  else if (trimmed.endsWith('rad')) degrees = (degrees * 180) / Math.PI
+  return ((degrees % 360) + 360) % 360
+}
+
+const splitFunctionalColor = (body) => {
+  if (body.includes(',')) {
+    const parts = body.split(',').map((part) => part.trim())
+    if (parts.length !== 3 && parts.length !== 4) {
+      return { channels: [], alpha: undefined }
+    }
+    return {
+      channels: parts.slice(0, 3),
+      alpha: parts[3]
+    }
+  }
+
+  const [channels, alpha] = body.split('/').map((part) => part.trim())
+  return {
+    channels: channels.split(/\s+/),
+    alpha
+  }
+}
+
+const hslToRgb = ({ h, s, l, a = 1 }) => {
+  const chroma = (1 - Math.abs(2 * l - 1)) * s
+  const hue = h / 60
+  const x = chroma * (1 - Math.abs((hue % 2) - 1))
+  let red = 0
+  let green = 0
+  let blue = 0
+
+  if (hue < 1) [red, green] = [chroma, x]
+  else if (hue < 2) [red, green] = [x, chroma]
+  else if (hue < 3) [green, blue] = [chroma, x]
+  else if (hue < 4) [green, blue] = [x, chroma]
+  else if (hue < 5) [red, blue] = [x, chroma]
+  else [red, blue] = [chroma, x]
+
+  const match = l - chroma / 2
+  return { r: red + match, g: green + match, b: blue + match, a }
+}
+
+const rgbToHsl = ({ r, g, b, a = 1 }) => {
+  const max = Math.max(r, g, b)
+  const min = Math.min(r, g, b)
+  const delta = max - min
+  const l = (max + min) / 2
+  let h = 0
+
+  if (delta !== 0) {
+    if (max === r) h = 60 * (((g - b) / delta) % 6)
+    else if (max === g) h = 60 * ((b - r) / delta + 2)
+    else h = 60 * ((r - g) / delta + 4)
+  }
+
+  return {
+    h: (h + 360) % 360,
+    s: delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1)),
+    l,
+    a
+  }
+}
+
+const parseHexColor = (value) => {
+  const match = value.match(/^#([\da-f]{3,4}|[\da-f]{6}|[\da-f]{8})$/i)
+  if (!match) return null
+
+  let hex = match[1]
+  if (hex.length <= 4) {
+    hex = [...hex].map((character) => character.repeat(2)).join('')
+  }
+
+  const channels = [
+    Number.parseInt(hex.slice(0, 2), 16),
+    Number.parseInt(hex.slice(2, 4), 16),
+    Number.parseInt(hex.slice(4, 6), 16)
+  ]
+
+  return {
+    r: channels[0] / 255,
+    g: channels[1] / 255,
+    b: channels[2] / 255,
+    a: hex.length === 8 ? Number.parseInt(hex.slice(6, 8), 16) / 255 : 1
+  }
+}
+
+const parseRgbColor = (value) => {
+  const match = value.match(/^rgba?\((.*)\)$/i)
+  if (!match) return null
+
+  const { channels, alpha } = splitFunctionalColor(match[1])
+  if (channels.length !== 3) return null
+
+  const parsedChannels = channels.map(parseRgbChannel)
+  const parsedAlpha = alpha === undefined ? 1 : parseAlpha(alpha)
+  if ([...parsedChannels, parsedAlpha].some((channel) => Number.isNaN(channel))) return null
+
+  return {
+    r: parsedChannels[0],
+    g: parsedChannels[1],
+    b: parsedChannels[2],
+    a: parsedAlpha
+  }
+}
+
+const parseHslColor = (value) => {
+  const match = value.match(/^hsla?\((.*)\)$/i)
+  if (!match) return null
+
+  const { channels, alpha } = splitFunctionalColor(match[1])
+  if (
+    channels.length !== 3 ||
+    !channels[1].trim().endsWith('%') ||
+    !channels[2].trim().endsWith('%')
+  ) {
+    return null
+  }
+
+  const hsl = {
+    h: parseHue(channels[0]),
+    s: clamp(Number.parseFloat(channels[1]) / 100),
+    l: clamp(Number.parseFloat(channels[2]) / 100),
+    a: alpha === undefined ? 1 : parseAlpha(alpha)
+  }
+
+  if (Object.values(hsl).some((channel) => Number.isNaN(channel))) return null
+  return hslToRgb(hsl)
+}
+
+const parseNamedColor = (value) => {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return null
+
+  const probe = document.createElement('span')
+  try {
+    probe.style.color = value
+    if (!probe.style.color) return null
+
+    probe.hidden = true
+    document.documentElement.appendChild(probe)
+    const computed = window.getComputedStyle(probe).color
+    return parseRgbColor(computed)
+  } catch {
+    return null
+  } finally {
+    probe.remove()
+  }
+}
+
+/**
+ * Parses a CSS color into RGBA channels scaled from 0 to 1.
+ * @param {string} value
+ * @returns {{r: number, g: number, b: number, a: number} | null}
+ */
+export const parseCssColor = (value) => {
+  if (typeof value !== 'string') return null
+
+  const trimmed = value.trim()
+  const lower = trimmed.toLowerCase()
+  if (parsedColorCache.has(lower)) return parsedColorCache.get(lower)
+  if (!trimmed || CSS_WIDE_KEYWORDS.has(lower)) {
+    return cacheValue(parsedColorCache, lower, null)
+  }
+  if (lower === 'transparent') {
+    return cacheValue(parsedColorCache, lower, Object.freeze({ r: 0, g: 0, b: 0, a: 0 }))
+  }
+
+  const parsed =
+    parseHexColor(trimmed) ||
+    parseRgbColor(trimmed) ||
+    parseHslColor(trimmed) ||
+    parseNamedColor(trimmed)
+  return cacheValue(parsedColorCache, lower, parsed ? Object.freeze(parsed) : null)
+}
+
+const formatNumber = (value, precision = 2) => Number(value.toFixed(precision)).toString()
+
+const formatHslColor = ({ h, s, l, a = 1 }) => {
+  const channels = `${formatNumber(h)} ${formatNumber(s * 100)}% ${formatNumber(l * 100)}%`
+  if (a === 1) return `hsl(${channels})`
+  return `hsl(${channels} / ${formatNumber(a, 3)})`
+}
+
+const composite = (foreground, background) => {
+  const alpha = foreground.a + background.a * (1 - foreground.a)
+  if (alpha === 0) return { r: 0, g: 0, b: 0, a: 0 }
+
+  return {
+    r: (foreground.r * foreground.a + background.r * background.a * (1 - foreground.a)) / alpha,
+    g: (foreground.g * foreground.a + background.g * background.a * (1 - foreground.a)) / alpha,
+    b: (foreground.b * foreground.a + background.b * background.a * (1 - foreground.a)) / alpha,
+    a: alpha
+  }
+}
+
+/**
+ * Blends a foreground color over a background color.
+ * @param {string} foregroundValue
+ * @param {string} backgroundValue
+ * @returns {string | null}
+ */
+export const compositeCssColor = (foregroundValue, backgroundValue) => {
+  const foreground = parseCssColor(foregroundValue)
+  const background = parseCssColor(backgroundValue)
+  if (!foreground || !background) return null
+  if (foreground.a === 1) return foregroundValue
+  return formatHslColor(rgbToHsl(composite(foreground, background)))
+}
+
+const linearize = (channel) =>
+  channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+
+const relativeLuminance = ({ r, g, b }) =>
+  0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b)
+
+const contrastRatio = (foreground, background) => {
+  const opaqueBackground =
+    background.a === 1 ? background : composite(background, { r: 0, g: 0, b: 0, a: 1 })
+  const renderedForeground = composite(foreground, opaqueBackground)
+  const lighter = Math.max(
+    relativeLuminance(renderedForeground),
+    relativeLuminance(opaqueBackground)
+  )
+  const darker = Math.min(
+    relativeLuminance(renderedForeground),
+    relativeLuminance(opaqueBackground)
+  )
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+/**
+ * Returns the WCAG contrast ratio between two CSS colors.
+ * @param {string} foregroundValue
+ * @param {string} backgroundValue
+ * @returns {number | null}
+ */
+export const getContrastRatio = (foregroundValue, backgroundValue) => {
+  const foreground = parseCssColor(foregroundValue)
+  const background = parseCssColor(backgroundValue)
+  if (!foreground || !background) return null
+  return contrastRatio(foreground, background)
+}
+
+/**
+ * Remaps a CSS color for dark mode without changing its hue or saturation.
+ * @param {string} value
+ * @returns {string}
+ */
+export const remapColorForDarkMode = (value) => {
+  if (remappedColorCache.has(value)) return remappedColorCache.get(value)
+
+  const parsed = parseCssColor(value)
+  if (!parsed || parsed.a === 0) return cacheValue(remappedColorCache, value, value)
+
+  const hsl = rgbToHsl(parsed)
+  hsl.l = DARK_MIN_LIGHTNESS + (1 - hsl.l) * (DARK_MAX_LIGHTNESS - DARK_MIN_LIGHTNESS)
+  return cacheValue(remappedColorCache, value, formatHslColor(hsl))
+}
+
+const findPassingLightness = (hsl, background, direction, minimumRatio) => {
+  let failing = hsl.l
+  let passing = direction > 0 ? 1 : 0
+  if (contrastRatio(hslToRgb({ ...hsl, l: passing }), background) < minimumRatio) {
+    return null
+  }
+
+  for (let iteration = 0; iteration < 14; iteration += 1) {
+    const midpoint = (failing + passing) / 2
+    if (contrastRatio(hslToRgb({ ...hsl, l: midpoint }), background) >= minimumRatio) {
+      passing = midpoint
+    } else {
+      failing = midpoint
+    }
+  }
+  return clamp(passing + direction * 0.0001)
+}
+
+const findPassingLightnessCandidates = (hsl, background, targetRatio, preferLighter) =>
+  [
+    findPassingLightness(hsl, background, -1, targetRatio),
+    findPassingLightness(hsl, background, 1, targetRatio)
+  ]
+    .filter((lightness) => lightness !== null)
+    .sort((left, right) => {
+      const distance = Math.abs(left - hsl.l) - Math.abs(right - hsl.l)
+      if (distance !== 0 || preferLighter === undefined) return distance
+      return preferLighter ? right - left : left - right
+    })
+
+/**
+ * Adjusts a foreground color until it meets the requested contrast ratio.
+ * @param {string} foregroundValue
+ * @param {string} backgroundValue
+ * @param {number} [minimumRatio=4.5]
+ * @param {boolean} [preferLighter]
+ * @returns {string}
+ */
+export const ensureColorContrast = (
+  foregroundValue,
+  backgroundValue,
+  minimumRatio = MIN_CONTRAST_RATIO,
+  preferLighter
+) => {
+  const cacheKey = `${foregroundValue}\0${backgroundValue}\0${minimumRatio}\0${preferLighter}`
+  if (contrastColorCache.has(cacheKey)) return contrastColorCache.get(cacheKey)
+
+  const foreground = parseCssColor(foregroundValue)
+  const background = parseCssColor(backgroundValue)
+  if (!foreground || foreground.a === 0 || !background) {
+    return cacheValue(contrastColorCache, cacheKey, foregroundValue)
+  }
+  if (contrastRatio(foreground, background) >= minimumRatio) {
+    return cacheValue(contrastColorCache, cacheKey, foregroundValue)
+  }
+
+  const hsl = rgbToHsl(foreground)
+  const targetRatio = minimumRatio + CONTRAST_ROUNDING_MARGIN
+  let searchHsl = hsl
+  let candidates = findPassingLightnessCandidates(searchHsl, background, targetRatio, preferLighter)
+
+  if (candidates.length === 0 && hsl.a !== 1) {
+    // Alpha blending caps the contrast achievable by adjusting lightness alone (a near-fully
+    // transparent foreground is dominated by the background regardless of its own lightness).
+    // Fall back to a fully opaque foreground: black or white against any background reaches a
+    // ratio of up to ~21:1, so this recovers WCAG AA (4.5:1) requests that the lightness-only
+    // search above could not. It is not guaranteed to satisfy every possible `minimumRatio` -
+    // e.g. some backgrounds cap opaque contrast below AAA's 7:1 - in which case the final
+    // fallback below still applies.
+    searchHsl = { ...hsl, a: 1 }
+    candidates = findPassingLightnessCandidates(searchHsl, background, targetRatio, preferLighter)
+  }
+
+  if (candidates.length === 0) {
+    return cacheValue(contrastColorCache, cacheKey, foregroundValue)
+  }
+  return cacheValue(
+    contrastColorCache,
+    cacheKey,
+    formatHslColor({ ...searchHsl, l: candidates[0] })
+  )
+}
+
+/**
+ * Remaps a foreground and background together, keeping their contrast direction.
+ * @param {string} foregroundValue
+ * @param {string} backgroundValue
+ * @param {string} [backdropValue='rgb(0, 0, 0)']
+ * @returns {{color: string, backgroundColor: string}}
+ */
+export const remapColorPairForDarkMode = (
+  foregroundValue,
+  backgroundValue,
+  backdropValue = 'rgb(0, 0, 0)'
+) => {
+  const foreground = parseCssColor(foregroundValue)
+  const background = parseCssColor(backgroundValue)
+  const remappedForeground = remapColorForDarkMode(foregroundValue)
+  const remappedBackground = remapColorForDarkMode(backgroundValue)
+  const contrastBackground =
+    compositeCssColor(remappedBackground, backdropValue) || remappedBackground
+
+  if (!foreground || !background) {
+    return {
+      color: remappedForeground,
+      backgroundColor: remappedBackground
+    }
+  }
+
+  return {
+    color: ensureColorContrast(
+      remappedForeground,
+      contrastBackground,
+      MIN_CONTRAST_RATIO,
+      relativeLuminance(foreground) <= relativeLuminance(background)
+    ),
+    backgroundColor: remappedBackground
+  }
+}

--- a/frontend/apps/main/src/utils/emailColorNormalizer.test.js
+++ b/frontend/apps/main/src/utils/emailColorNormalizer.test.js
@@ -1,0 +1,96 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, test, vi } from 'vitest'
+import {
+  ensureColorContrast,
+  getContrastRatio,
+  parseCssColor,
+  remapColorForDarkMode,
+  remapColorPairForDarkMode
+} from './emailColorNormalizer.js'
+
+describe('remapColorForDarkMode', () => {
+  test('maps black to near-white', () => {
+    expect(remapColorForDarkMode('#000000')).toBe('hsl(0 0% 92%)')
+  })
+
+  test('maps white to near-black', () => {
+    expect(remapColorForDarkMode('#FFFFFF')).toBe('hsl(0 0% 8%)')
+  })
+
+  test('keeps a mid-grey near the middle of the range', () => {
+    const output = parseCssColor(remapColorForDarkMode('#808080'))
+    expect(output.r).toBeCloseTo(output.g, 5)
+    expect(output.g).toBeCloseTo(output.b, 5)
+    expect(output.r).toBeCloseTo(0.5, 1)
+  })
+
+  test('preserves the hue and saturation of saturated red', () => {
+    expect(remapColorForDarkMode('#ff0000')).toBe('hsl(0 100% 50%)')
+  })
+
+  test('parses grad hues without also applying the radian conversion', () => {
+    expect(parseCssColor('hsl(10grad 100% 50%)')).toEqual(parseCssColor('hsl(9deg 100% 50%)'))
+  })
+
+  test('leaves transparent unchanged', () => {
+    expect(remapColorForDarkMode('transparent')).toBe('transparent')
+  })
+
+  test('remaps a named colour', () => {
+    expect(remapColorForDarkMode('navy')).toBe('hsl(240 100% 70.92%)')
+  })
+
+  test('resolves each named colour against the live document once', () => {
+    const appendChild = vi.spyOn(document.documentElement, 'appendChild')
+
+    remapColorForDarkMode('papayawhip')
+    remapColorForDarkMode('papayawhip')
+
+    expect(appendChild).toHaveBeenCalledTimes(1)
+    appendChild.mockRestore()
+  })
+
+  test.each(['currentColor', 'inherit'])('leaves %s unchanged', (value) => {
+    expect(remapColorForDarkMode(value)).toBe(value)
+  })
+
+  test('preserves rgba alpha', () => {
+    const output = parseCssColor(remapColorForDarkMode('rgba(12, 34, 56, 0.4)'))
+    expect(output.a).toBeCloseTo(0.4, 3)
+  })
+
+  test('leaves malformed colours unchanged', () => {
+    expect(remapColorForDarkMode('rgb(not a colour)')).toBe('rgb(not a colour)')
+  })
+
+  test('leaves rgb() values with too many components unchanged', () => {
+    expect(remapColorForDarkMode('rgb(1,2,3,4,5)')).toBe('rgb(1,2,3,4,5)')
+  })
+
+  test('raises paired colour contrast to WCAG AA', () => {
+    const output = remapColorPairForDarkMode('#777777', '#888888')
+    expect(getContrastRatio(output.color, output.backgroundColor)).toBeGreaterThanOrEqual(4.5)
+  })
+
+  test('recovers if resolving a named colour throws', () => {
+    const appendChild = vi.spyOn(document.documentElement, 'appendChild').mockImplementation(() => {
+      throw new Error('boom')
+    })
+
+    try {
+      expect(() => remapColorForDarkMode('deeppink')).not.toThrow()
+      expect(appendChild).toHaveBeenCalled()
+      expect(remapColorForDarkMode('deeppink')).toBe('deeppink')
+    } finally {
+      appendChild.mockRestore()
+    }
+  })
+})
+
+describe('ensureColorContrast', () => {
+  test('boosts a near-transparent foreground to opaque to reach WCAG AA', () => {
+    const output = ensureColorContrast('rgba(128, 128, 128, 0.05)', 'rgb(128, 128, 128)')
+    expect(getContrastRatio(output, 'rgb(128, 128, 128)')).toBeGreaterThanOrEqual(4.5)
+  })
+})

--- a/frontend/apps/main/src/utils/emailHtmlNormalizer.js
+++ b/frontend/apps/main/src/utils/emailHtmlNormalizer.js
@@ -10,6 +10,13 @@ const DARK_MESSAGE_BACKGROUND = 'hsl(120 2.6% 7.6%)'
 const DARK_MESSAGE_FOREGROUND = 'hsl(150 6% 93%)'
 const COLOR_DECLARATION = /(^|;)(\s*)(color|background-color|background)(\s*:\s*)([^;}]+)/gi
 const CSS_RULE = /([^{}]+)\{([^{}]*)\}/g
+const BACKGROUND_IMAGE_DECLARATION = /(?:^|;)\s*background-image\s*:\s*([^;}]+)/gi
+const BACKGROUND_SHORTHAND_DECLARATION = /(?:^|;)\s*background\s*:\s*([^;}]+)/gi
+// Matches a top-level `@media (... prefers-color-scheme ...) { ... }` block (one level of rule
+// nesting). These blocks are already conditioned on a colour scheme, so their declarations must
+// be left byte-for-byte untouched: remapping a `dark` block would re-invert colours that are
+// already dark-mode-safe, and remapping a `light` block would corrupt colours that should only
+// ever apply when this normalizer's own dark mode is NOT active.
 const PREFERS_COLOR_SCHEME_BLOCK =
   /(@media[^{}]*prefers-color-scheme[^{}]*\{(?:[^{}]*\{[^{}]*\})*[^{}]*\})/gi
 const NON_CONTENT_TAGS = new Set(['style', 'script', 'title'])
@@ -91,18 +98,117 @@ const normalizeDeclarations = (cssText, inheritedBackground) => {
   }
 }
 
-const normalizeStyleRuleText = (cssText) =>
-  cssText.replace(/\{([^{}]*)\}/g, (rule, declarations) => {
-    return `{${normalizeDeclarations(declarations, DARK_MESSAGE_BACKGROUND).cssText}}`
+const normalizeStyleRuleText = (
+  cssText,
+  fragment,
+  imageBackedElements,
+  selectorMatches,
+  mixedStyleTargets
+) =>
+  cssText.replace(CSS_RULE, (rule, selector, declarations) => {
+    const targets = querySelectorAll(fragment, selector, selectorMatches)
+    if (hasImageBackground(declarations)) return rule
+
+    const protectedTargets = targets.filter((element) => imageBackedElements.has(element))
+    if (protectedTargets.length > 0) {
+      targets
+        .filter((element) => !imageBackedElements.has(element))
+        .forEach((element) => mixedStyleTargets.add(element))
+      return rule
+    }
+    return `${selector}{${normalizeDeclarations(declarations, DARK_MESSAGE_BACKGROUND).cssText}}`
   })
 
-const normalizeStyleBlocks = (fragment) => {
+const normalizeStyleBlocks = (
+  fragment,
+  imageBackedElements,
+  selectorMatches,
+  mixedStyleTargets
+) => {
   fragment.querySelectorAll('style').forEach((style) => {
     style.textContent = style.textContent
       .split(PREFERS_COLOR_SCHEME_BLOCK)
-      .map((segment, index) => (index % 2 === 1 ? segment : normalizeStyleRuleText(segment)))
+      .map((segment, index) =>
+        // Odd indices are the captured `prefers-color-scheme` blocks from the split above -
+        // leave them untouched. Even indices are the surrounding text, which normalizes as usual.
+        index % 2 === 1
+          ? segment
+          : normalizeStyleRuleText(
+              segment,
+              fragment,
+              imageBackedElements,
+              selectorMatches,
+              mixedStyleTargets
+            )
+      )
       .join('')
   })
+}
+
+const hasImageBackground = (cssText) => {
+  const probe = document.createElement('div')
+  probe.style.cssText = cssText
+  if (probe.style.backgroundImage && probe.style.backgroundImage !== 'none') return true
+
+  for (const match of cssText.matchAll(BACKGROUND_IMAGE_DECLARATION)) {
+    if (
+      match[1]
+        .replace(/\s*!important\s*$/i, '')
+        .trim()
+        .toLowerCase() !== 'none'
+    )
+      return true
+  }
+  for (const match of cssText.matchAll(BACKGROUND_SHORTHAND_DECLARATION)) {
+    if (/(?:url|gradient|image-set|cross-fade|var)\s*\(/i.test(match[1])) return true
+  }
+  return false
+}
+
+const collectImageBackedElements = (fragment, selectorMatches) => {
+  const roots = new WeakSet()
+
+  fragment.querySelectorAll('[style], td[background], th[background]').forEach((element) => {
+    const hasLegacyBackground =
+      ['td', 'th'].includes(element.tagName.toLowerCase()) &&
+      Boolean(element.getAttribute('background')?.trim())
+    const hasInlineBackground = hasImageBackground(element.getAttribute('style') || '')
+    if (hasLegacyBackground || hasInlineBackground) {
+      roots.add(element)
+    }
+  })
+
+  fragment.querySelectorAll('style').forEach((style) => {
+    for (const match of style.textContent.matchAll(CSS_RULE)) {
+      if (!hasImageBackground(match[2])) continue
+      querySelectorAll(fragment, match[1], selectorMatches).forEach((element) => roots.add(element))
+    }
+  })
+
+  const protectedElements = new WeakSet()
+  const stack = Array.from(fragment.children)
+    .reverse()
+    .map((element) => ({ element, protectedByAncestor: false }))
+  while (stack.length > 0) {
+    const { element, protectedByAncestor } = stack.pop()
+    const isProtected = protectedByAncestor || roots.has(element)
+    if (isProtected) protectedElements.add(element)
+    Array.from(element.children)
+      .reverse()
+      .forEach((child) => stack.push({ element: child, protectedByAncestor: isProtected }))
+  }
+  return protectedElements
+}
+
+const preserveLegacyBackgroundImage = (element) => {
+  const background = element.getAttribute('background')
+  if (!background?.trim() || element.style.backgroundImage) return
+
+  const escaped = background
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/[\n\r\f]/g, '')
+  element.style.setProperty('background-image', `url("${escaped}")`)
 }
 
 const splitSelectors = (selectorText) => {
@@ -264,9 +370,21 @@ const formatLegacyColor = (color) => {
   return `#${hex}`
 }
 
-const normalizeElement = (element, inheritedBackground, inheritedForeground, stylesheetColors) => {
+const stylesheetDeclarationWins = (declaration, inlineValue, inlinePriority) =>
+  Boolean(
+    declaration && (!inlineValue || (declaration.important && inlinePriority !== 'important'))
+  )
+
+const normalizeElement = (
+  element,
+  inheritedBackground,
+  inheritedForeground,
+  stylesheetColors,
+  rawStylesheetColors,
+  mixedStyleTargets
+) => {
   if (NON_CONTENT_TAGS.has(element.tagName.toLowerCase())) {
-    return
+    return { background: inheritedBackground, foreground: inheritedForeground }
   }
 
   let effectiveBackground = inheritedBackground
@@ -290,6 +408,10 @@ const normalizeElement = (element, inheritedBackground, inheritedForeground, sty
   }
 
   if (stylesheetBackground && parseCssColor(stylesheetBackground.value)?.a !== 0) {
+    // Composited against the ancestor background, not `effectiveBackground`: a stylesheet
+    // background-color always wins the cascade over a `bgcolor` attribute on the same element
+    // (bgcolor never stacks under it), so a translucent stylesheet colour must be resolved
+    // against what's truly behind the element, not against the bgcolor value it overrides.
     effectiveBackground = resolvedBackground(stylesheetBackground.value, inheritedBackground)
   }
   if (parseCssColor(stylesheet?.color?.value)) {
@@ -307,6 +429,9 @@ const normalizeElement = (element, inheritedBackground, inheritedForeground, sty
       normalized.backgroundColor &&
       parseCssColor(normalized.backgroundColor)?.a !== 0
     ) {
+      // Same reasoning as above: an inline background-color that wins the cascade replaces
+      // any bgcolor/stylesheet background on this element rather than stacking on top of it,
+      // so it must be composited against the ancestor background, not the overridden value.
       effectiveBackground = resolvedBackground(normalized.backgroundColor, inheritedBackground)
     }
     const inlineColorWins =
@@ -328,6 +453,52 @@ const normalizeElement = (element, inheritedBackground, inheritedForeground, sty
     }
   }
 
+  if (mixedStyleTargets.has(element)) {
+    const rawStylesheet = rawStylesheetColors.get(element)
+    const rawBackground = rawStylesheet?.['background-color']
+    const rawForeground = rawStylesheet?.color
+    const backgroundWins = stylesheetDeclarationWins(
+      rawBackground,
+      element.style.getPropertyValue('background-color'),
+      element.style.getPropertyPriority('background-color')
+    )
+    const foregroundWins = stylesheetDeclarationWins(
+      rawForeground,
+      element.style.getPropertyValue('color'),
+      element.style.getPropertyPriority('color')
+    )
+    const pair =
+      backgroundWins && foregroundWins
+        ? remapColorPairForDarkMode(rawForeground.value, rawBackground.value, inheritedBackground)
+        : null
+
+    if (backgroundWins) {
+      const normalizedBackground =
+        pair?.backgroundColor || remapColorForDarkMode(rawBackground.value)
+      element.style.setProperty(
+        'background-color',
+        normalizedBackground,
+        rawBackground.important ? 'important' : ''
+      )
+      effectiveBackground =
+        parseCssColor(normalizedBackground)?.a === 0
+          ? inheritedBackground
+          : resolvedBackground(normalizedBackground, inheritedBackground)
+    }
+
+    if (foregroundWins) {
+      const normalizedForeground =
+        pair?.color ||
+        ensureColorContrast(remapColorForDarkMode(rawForeground.value), effectiveBackground)
+      element.style.setProperty(
+        'color',
+        normalizedForeground,
+        rawForeground.important ? 'important' : ''
+      )
+      effectiveForeground = normalizedForeground
+    }
+  }
+
   const adjustedForeground = ensureColorContrast(effectiveForeground, effectiveBackground)
   if (adjustedForeground !== effectiveForeground) {
     element.style.setProperty(
@@ -338,9 +509,59 @@ const normalizeElement = (element, inheritedBackground, inheritedForeground, sty
     effectiveForeground = adjustedForeground
   }
 
-  Array.from(element.children).forEach((child) =>
-    normalizeElement(child, effectiveBackground, effectiveForeground, stylesheetColors)
-  )
+  return { background: effectiveBackground, foreground: effectiveForeground }
+}
+
+const normalizeElements = (
+  fragment,
+  imageBackedElements,
+  stylesheetColors,
+  rawStylesheetColors,
+  mixedStyleTargets
+) => {
+  const stack = Array.from(fragment.children)
+    .reverse()
+    .map((element) => ({
+      element,
+      inheritedBackground: DARK_MESSAGE_BACKGROUND,
+      inheritedForeground: DARK_MESSAGE_FOREGROUND
+    }))
+
+  while (stack.length > 0) {
+    const { element, inheritedBackground, inheritedForeground } = stack.pop()
+    if (imageBackedElements.has(element)) {
+      preserveLegacyBackgroundImage(element)
+      // Descend without normalizing: a protected element can itself contain a nested
+      // legacy `background`-attribute element (e.g. a per-cell table banner inside an
+      // outer image-backed wrapper) that also needs its raw attribute converted to an
+      // inline style before sanitization, since `collectImageBackedElements` already
+      // marked the whole subtree as protected.
+      Array.from(element.children)
+        .reverse()
+        .forEach((child) =>
+          stack.push({ element: child, inheritedBackground, inheritedForeground })
+        )
+      continue
+    }
+
+    const effective = normalizeElement(
+      element,
+      inheritedBackground,
+      inheritedForeground,
+      stylesheetColors,
+      rawStylesheetColors,
+      mixedStyleTargets
+    )
+    Array.from(element.children)
+      .reverse()
+      .forEach((child) =>
+        stack.push({
+          element: child,
+          inheritedBackground: effective.background,
+          inheritedForeground: effective.foreground
+        })
+      )
+  }
 }
 
 /**
@@ -355,10 +576,18 @@ export const normalizeEmailHtml = (html, darkMode) => {
   try {
     const template = document.createElement('template')
     template.innerHTML = html
-    normalizeStyleBlocks(template.content)
-    const stylesheetColors = collectStylesheetColors(template.content, new Map())
-    Array.from(template.content.children).forEach((element) =>
-      normalizeElement(element, DARK_MESSAGE_BACKGROUND, DARK_MESSAGE_FOREGROUND, stylesheetColors)
+    const selectorMatches = new Map()
+    const imageBackedElements = collectImageBackedElements(template.content, selectorMatches)
+    const rawStylesheetColors = collectStylesheetColors(template.content, selectorMatches)
+    const mixedStyleTargets = new WeakSet()
+    normalizeStyleBlocks(template.content, imageBackedElements, selectorMatches, mixedStyleTargets)
+    const stylesheetColors = collectStylesheetColors(template.content, selectorMatches)
+    normalizeElements(
+      template.content,
+      imageBackedElements,
+      stylesheetColors,
+      rawStylesheetColors,
+      mixedStyleTargets
     )
     return template.innerHTML
   } catch (error) {

--- a/frontend/apps/main/src/utils/emailHtmlNormalizer.js
+++ b/frontend/apps/main/src/utils/emailHtmlNormalizer.js
@@ -1,0 +1,368 @@
+import {
+  compositeCssColor,
+  ensureColorContrast,
+  parseCssColor,
+  remapColorForDarkMode,
+  remapColorPairForDarkMode
+} from './emailColorNormalizer.js'
+
+const DARK_MESSAGE_BACKGROUND = 'hsl(120 2.6% 7.6%)'
+const DARK_MESSAGE_FOREGROUND = 'hsl(150 6% 93%)'
+const COLOR_DECLARATION = /(^|;)(\s*)(color|background-color|background)(\s*:\s*)([^;}]+)/gi
+const CSS_RULE = /([^{}]+)\{([^{}]*)\}/g
+const PREFERS_COLOR_SCHEME_BLOCK =
+  /(@media[^{}]*prefers-color-scheme[^{}]*\{(?:[^{}]*\{[^{}]*\})*[^{}]*\})/gi
+const NON_CONTENT_TAGS = new Set(['style', 'script', 'title'])
+
+const parseDeclarationValue = (value) => {
+  const important = value.match(/\s*!important\s*$/i)?.[0] || ''
+  return {
+    color: value.slice(0, value.length - important.length).trim(),
+    important
+  }
+}
+
+const collectColorDeclarations = (cssText) => {
+  const declarations = []
+  for (const match of cssText.matchAll(COLOR_DECLARATION)) {
+    const parsed = parseDeclarationValue(match[5])
+    const property = match[3].toLowerCase()
+    if (property === 'background' && !parseCssColor(parsed.color)) continue
+
+    declarations.push({
+      important: Boolean(parsed.important),
+      index: match.index,
+      property: property === 'background' ? 'background-color' : property,
+      value: parsed.color
+    })
+  }
+  return declarations
+}
+
+const findWinningDeclaration = (declarations, property) =>
+  declarations.reduce((winner, declaration) => {
+    if (declaration.property !== property) return winner
+    if (!winner || Number(declaration.important) > Number(winner.important)) return declaration
+    if (declaration.important === winner.important && declaration.index > winner.index) {
+      return declaration
+    }
+    return winner
+  }, null)
+
+const normalizeDeclarations = (cssText, inheritedBackground) => {
+  const declarations = collectColorDeclarations(cssText)
+  const foreground = findWinningDeclaration(declarations, 'color')
+  const background = findWinningDeclaration(declarations, 'background-color')
+  const replacements = new Map()
+
+  if (foreground && background) {
+    const pair = remapColorPairForDarkMode(foreground.value, background.value, inheritedBackground)
+    replacements.set(foreground.index, pair.color)
+    replacements.set(background.index, pair.backgroundColor)
+  }
+
+  declarations.forEach((declaration) => {
+    if (replacements.has(declaration.index)) return
+    const remapped = remapColorForDarkMode(declaration.value)
+    replacements.set(
+      declaration.index,
+      declaration.property === 'color'
+        ? ensureColorContrast(remapped, inheritedBackground)
+        : remapped
+    )
+  })
+
+  const normalizedCss = cssText.replace(
+    COLOR_DECLARATION,
+    (match, separator, whitespace, property, colon, value, offset) => {
+      const parsed = parseDeclarationValue(value)
+      const replacement = replacements.get(offset)
+      if (!replacement || replacement === parsed.color) return match
+      const normalizedProperty =
+        property.toLowerCase() === 'background' ? 'background-color' : property
+      return `${separator}${whitespace}${normalizedProperty}${colon}${replacement}${parsed.important}`
+    }
+  )
+
+  return {
+    cssText: normalizedCss,
+    backgroundColor: background ? replacements.get(background.index) : null,
+    color: foreground ? replacements.get(foreground.index) : null
+  }
+}
+
+const normalizeStyleRuleText = (cssText) =>
+  cssText.replace(/\{([^{}]*)\}/g, (rule, declarations) => {
+    return `{${normalizeDeclarations(declarations, DARK_MESSAGE_BACKGROUND).cssText}}`
+  })
+
+const normalizeStyleBlocks = (fragment) => {
+  fragment.querySelectorAll('style').forEach((style) => {
+    style.textContent = style.textContent
+      .split(PREFERS_COLOR_SCHEME_BLOCK)
+      .map((segment, index) => (index % 2 === 1 ? segment : normalizeStyleRuleText(segment)))
+      .join('')
+  })
+}
+
+const splitSelectors = (selectorText) => {
+  const selectors = []
+  let start = 0
+  let depth = 0
+
+  for (let index = 0; index < selectorText.length; index += 1) {
+    const character = selectorText[index]
+    if (character === '(' || character === '[') depth += 1
+    else if (character === ')' || character === ']') depth -= 1
+    else if (character === ',' && depth === 0) {
+      selectors.push(selectorText.slice(start, index).trim())
+      start = index + 1
+    }
+  }
+  selectors.push(selectorText.slice(start).trim())
+  return selectors.filter(Boolean)
+}
+
+const selectorSpecificity = (selector) => {
+  const withoutStrings = selector.replace(/(["'])(?:\\.|(?!\1).)*\1/g, '')
+  return [
+    (withoutStrings.match(/#[\w-]+/g) || []).length,
+    (withoutStrings.match(/\.[\w-]+|\[[^\]]+\]|:(?!:)[\w-]+(?:\([^)]*\))?/g) || []).length,
+    (withoutStrings.match(/(^|[\s>+~])(?:[a-z][\w-]*|\*)/gi) || []).length +
+      (withoutStrings.match(/::[\w-]+/g) || []).length
+  ]
+}
+
+const compareSpecificity = (left, right) => {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index]
+  }
+  return 0
+}
+
+const collectCssRules = (cssText) => {
+  if (typeof CSSStyleSheet !== 'undefined' && CSSStyleSheet.prototype.replaceSync) {
+    try {
+      const sheet = new CSSStyleSheet()
+      sheet.replaceSync(cssText)
+      const rules = []
+      const walk = (cssRules) => {
+        Array.from(cssRules).forEach((rule) => {
+          if (rule.selectorText && rule.style) {
+            rules.push({ selector: rule.selectorText, style: rule.style })
+          } else if (rule.cssRules) {
+            const matches =
+              !rule.conditionText ||
+              typeof window.matchMedia !== 'function' ||
+              window.matchMedia(rule.conditionText).matches
+            if (matches) walk(rule.cssRules)
+          }
+        })
+      }
+      walk(sheet.cssRules)
+      return rules
+    } catch {
+      // Fall through to the fragment parser used by jsdom and older browsers.
+    }
+  }
+
+  const rules = []
+  for (const match of cssText.matchAll(CSS_RULE)) {
+    const probe = document.createElement('div')
+    probe.style.cssText = match[2]
+    rules.push({ selector: match[1].trim(), style: probe.style })
+  }
+  return rules
+}
+
+const querySelectorAll = (fragment, selector, cache) => {
+  const normalizedSelector = selector.trim()
+  if (cache.has(normalizedSelector)) return cache.get(normalizedSelector)
+
+  let matches
+  try {
+    matches = Array.from(fragment.querySelectorAll(normalizedSelector))
+  } catch {
+    matches = []
+  }
+  cache.set(normalizedSelector, matches)
+  return matches
+}
+
+const collectStylesheetColors = (fragment, selectorMatches) => {
+  const elementStyles = new WeakMap()
+  const selectorStyles = new Map()
+  let order = 0
+
+  fragment.querySelectorAll('style').forEach((style) => {
+    collectCssRules(style.textContent).forEach((rule) => {
+      const properties = ['color', 'background-color'].filter((property) =>
+        rule.style.getPropertyValue(property)
+      )
+      if (properties.length === 0) return
+
+      splitSelectors(rule.selector).forEach((selector) => {
+        const specificity = selectorSpecificity(selector)
+        const styles = selectorStyles.get(selector) || {}
+        for (const property of properties) {
+          const candidate = {
+            value: rule.style.getPropertyValue(property),
+            important: rule.style.getPropertyPriority(property) === 'important',
+            specificity,
+            order
+          }
+          const current = styles[property]
+          if (
+            !current ||
+            Number(candidate.important) > Number(current.important) ||
+            (candidate.important === current.important && candidate.order > current.order)
+          ) {
+            styles[property] = candidate
+          }
+        }
+        selectorStyles.set(selector, styles)
+      })
+      order += 1
+    })
+  })
+
+  selectorStyles.forEach((declarations, selector) => {
+    querySelectorAll(fragment, selector, selectorMatches).forEach((element) => {
+      const styles = elementStyles.get(element) || {}
+      Object.entries(declarations).forEach(([property, candidate]) => {
+        const current = styles[property]
+        const wins =
+          !current ||
+          Number(candidate.important) > Number(current.important) ||
+          (candidate.important === current.important &&
+            (compareSpecificity(candidate.specificity, current.specificity) > 0 ||
+              (compareSpecificity(candidate.specificity, current.specificity) === 0 &&
+                candidate.order > current.order)))
+        if (wins) styles[property] = candidate
+      })
+      elementStyles.set(element, styles)
+    })
+  })
+
+  return elementStyles
+}
+
+const resolvedBackground = (background, inheritedBackground) =>
+  compositeCssColor(background, inheritedBackground) || inheritedBackground
+
+const formatLegacyColor = (color) => {
+  const parsed = parseCssColor(color)
+  if (!parsed) return color
+
+  const hex = [parsed.r, parsed.g, parsed.b]
+    .map((channel) =>
+      Math.round(channel * 255)
+        .toString(16)
+        .padStart(2, '0')
+    )
+    .join('')
+  return `#${hex}`
+}
+
+const normalizeElement = (element, inheritedBackground, inheritedForeground, stylesheetColors) => {
+  if (NON_CONTENT_TAGS.has(element.tagName.toLowerCase())) {
+    return
+  }
+
+  let effectiveBackground = inheritedBackground
+  let effectiveForeground = inheritedForeground
+  const style = element.getAttribute('style')
+  const legacyBackground = element.getAttribute('bgcolor')
+  const legacyForeground =
+    element.tagName.toLowerCase() === 'font' ? element.getAttribute('color') : null
+  const stylesheet = stylesheetColors.get(element)
+  const stylesheetBackground = stylesheet?.['background-color']
+  const inlineBackground = element.style.getPropertyValue('background-color')
+
+  if (legacyBackground && !stylesheetBackground && !inlineBackground) {
+    const normalizedBackground = remapColorForDarkMode(legacyBackground)
+    if (parseCssColor(normalizedBackground)) {
+      const renderedBackground = resolvedBackground(normalizedBackground, inheritedBackground)
+      const legacyColor = formatLegacyColor(renderedBackground)
+      element.setAttribute('bgcolor', legacyColor)
+      effectiveBackground = legacyColor
+    }
+  }
+
+  if (stylesheetBackground && parseCssColor(stylesheetBackground.value)?.a !== 0) {
+    effectiveBackground = resolvedBackground(stylesheetBackground.value, inheritedBackground)
+  }
+  if (parseCssColor(stylesheet?.color?.value)) {
+    effectiveForeground = stylesheet.color.value
+  }
+
+  if (style !== null) {
+    const normalized = normalizeDeclarations(style, effectiveBackground)
+    if (normalized.cssText !== style) element.setAttribute('style', normalized.cssText)
+    const inlineBackgroundWins =
+      !stylesheetBackground?.important ||
+      element.style.getPropertyPriority('background-color') === 'important'
+    if (
+      inlineBackgroundWins &&
+      normalized.backgroundColor &&
+      parseCssColor(normalized.backgroundColor)?.a !== 0
+    ) {
+      effectiveBackground = resolvedBackground(normalized.backgroundColor, inheritedBackground)
+    }
+    const inlineColorWins =
+      !stylesheet?.color?.important || element.style.getPropertyPriority('color') === 'important'
+    if (inlineColorWins && normalized.color) effectiveForeground = normalized.color
+  }
+
+  if (legacyForeground && !stylesheet?.color && !element.style.color) {
+    const normalizedForeground = ensureColorContrast(
+      remapColorForDarkMode(legacyForeground),
+      effectiveBackground
+    )
+    if (parseCssColor(normalizedForeground)) {
+      const renderedForeground =
+        compositeCssColor(normalizedForeground, effectiveBackground) || normalizedForeground
+      const legacyColor = formatLegacyColor(renderedForeground)
+      element.setAttribute('color', legacyColor)
+      effectiveForeground = legacyColor
+    }
+  }
+
+  const adjustedForeground = ensureColorContrast(effectiveForeground, effectiveBackground)
+  if (adjustedForeground !== effectiveForeground) {
+    element.style.setProperty(
+      'color',
+      adjustedForeground,
+      stylesheet?.color?.important ? 'important' : ''
+    )
+    effectiveForeground = adjustedForeground
+  }
+
+  Array.from(element.children).forEach((child) =>
+    normalizeElement(child, effectiveBackground, effectiveForeground, stylesheetColors)
+  )
+}
+
+/**
+ * Remaps email colors for dark mode, or returns the original HTML unchanged.
+ * @param {string} html
+ * @param {boolean} darkMode
+ * @returns {string}
+ */
+export const normalizeEmailHtml = (html, darkMode) => {
+  if (!darkMode || typeof html !== 'string' || html.length === 0) return html
+
+  try {
+    const template = document.createElement('template')
+    template.innerHTML = html
+    normalizeStyleBlocks(template.content)
+    const stylesheetColors = collectStylesheetColors(template.content, new Map())
+    Array.from(template.content.children).forEach((element) =>
+      normalizeElement(element, DARK_MESSAGE_BACKGROUND, DARK_MESSAGE_FOREGROUND, stylesheetColors)
+    )
+    return template.innerHTML
+  } catch (error) {
+    console.warn('Could not normalize email colours for dark mode.', error)
+    return html
+  }
+}

--- a/frontend/apps/main/src/utils/emailHtmlNormalizer.test.js
+++ b/frontend/apps/main/src/utils/emailHtmlNormalizer.test.js
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { cwd } from 'node:process'
 import { describe, expect, test, vi } from 'vitest'
+import { allowedCssProperties, sanitize } from 'lettersanitizer'
 import { compositeCssColor, getContrastRatio, parseCssColor } from './emailColorNormalizer.js'
 import { normalizeEmailHtml } from './emailHtmlNormalizer.js'
 
@@ -17,13 +18,16 @@ const parseFragment = (html) => {
 }
 
 describe('normalizeEmailHtml', () => {
-  test.each(['outlook-desktop', 'gmail-reply', 'apple-mail', 'plain-text-wrapped'])(
-    'returns the %s fixture byte-for-byte in light mode',
-    (fixture) => {
-      const input = loadFixture(fixture)
-      expect(normalizeEmailHtml(input, false)).toBe(input)
-    }
-  )
+  test.each([
+    'outlook-desktop',
+    'gmail-reply',
+    'apple-mail',
+    'marketing-banner',
+    'plain-text-wrapped'
+  ])('returns the %s fixture byte-for-byte in light mode', (fixture) => {
+    const input = loadFixture(fixture)
+    expect(normalizeEmailHtml(input, false)).toBe(input)
+  })
 
   test('normalizes Outlook desktop inline colours', () => {
     const output = parseFragment(normalizeEmailHtml(loadFixture('outlook-desktop'), true))
@@ -193,6 +197,103 @@ describe('normalizeEmailHtml', () => {
     }
   })
 
+  test('preserves colours inside image-backed marketing banners', () => {
+    const output = parseFragment(normalizeEmailHtml(loadFixture('marketing-banner'), true))
+    const gradientBanner = output.querySelector('[style*="background-image"]')
+    const shorthandBanner = output.querySelector('[style*="texture.png"]')
+    const stylesheetBanner = output.querySelector('.hero')
+    const tableCell = output.querySelector('td[background]')
+    const noImage = output.querySelector('[style*="background-image: none"]')
+    const footer = output.querySelector('p')
+
+    expect(gradientBanner.style.color).toBe('rgb(255, 255, 255)')
+    expect(gradientBanner.querySelector('span').style.color).toBe('rgb(255, 255, 255)')
+    expect(shorthandBanner.getAttribute('style')).toContain('color: #ffffff')
+    expect(shorthandBanner.querySelector('span').getAttribute('style')).toContain('color: #ffffff')
+    expect(stylesheetBanner.querySelector('span').className).toBe('hero-copy')
+    expect(output.querySelector('style').textContent).toContain('.hero-copy { color: #ffffff; }')
+    expect(tableCell.getAttribute('bgcolor')).toBe('#ffffff')
+    expect(tableCell.querySelector('font').getAttribute('color')).toBe('#ffffff')
+    expect(tableCell.style.backgroundImage).toContain('banner.jpg')
+    expect(noImage.style.color).not.toBe('rgb(0, 0, 0)')
+    expect(footer.style.color).not.toBe('rgb(0, 0, 0)')
+  })
+
+  test('normalizes ordinary targets of a rule shared with an image-backed banner', () => {
+    const output = parseFragment(
+      normalizeEmailHtml(
+        '<style>.card { color: #000000; background-color: #ffffff; }</style>' +
+          '<div style="background-image: url(https://cdn.example.com/hero.jpg)">' +
+          '<div id="banner-card" class="card">Banner</div></div>' +
+          '<div id="regular-card" class="card">Regular</div>',
+        true
+      )
+    )
+    const stylesheet = output.querySelector('style').textContent
+    const banner = output.querySelector('#banner-card')
+    const regular = output.querySelector('#regular-card')
+
+    expect(stylesheet).toContain('color: #000000')
+    expect(stylesheet).toContain('background-color: #ffffff')
+    expect(banner.getAttribute('style')).toBeNull()
+    expect(regular.style.backgroundColor).not.toBe('rgb(255, 255, 255)')
+    expect(
+      getContrastRatio(regular.style.color, regular.style.backgroundColor)
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  test('keeps legacy table background images through sanitization', () => {
+    const normalized = normalizeEmailHtml(
+      '<table><tr><td background="https://cdn.example.com/banner.jpg"><font color="#ffffff">Copy</font></td></tr></table>',
+      true
+    )
+    const sanitized = sanitize(normalized, null, {
+      noWrapper: true,
+      allowedSchemas: ['cid', 'https', 'http', 'mailto'],
+      allowedCssProperties
+    })
+    const output = parseFragment(sanitized)
+
+    expect(output.querySelector('td').style.backgroundImage).toContain('banner.jpg')
+  })
+
+  test('handles deeply nested reply chains without recursive traversal', () => {
+    let input = '<span style="color: #000000">Latest reply</span>'
+    for (let depth = 0; depth < 1500; depth += 1) {
+      input = `<blockquote style="color: #111111; background-color: #ffffff">${input}</blockquote>`
+    }
+
+    expect(() => normalizeEmailHtml(input, true)).not.toThrow()
+  })
+
+  test('keeps a nested table-cell background image through sanitization', () => {
+    const normalized = normalizeEmailHtml(
+      '<div style="background-image: url(https://cdn.example.com/hero.jpg)">' +
+        '<table><tr><td background="https://cdn.example.com/cell.jpg">' +
+        '<font color="#ffffff">Copy</font></td></tr></table></div>',
+      true
+    )
+    const sanitized = sanitize(normalized, null, {
+      noWrapper: true,
+      allowedSchemas: ['cid', 'https', 'http', 'mailto'],
+      allowedCssProperties
+    })
+    const output = parseFragment(sanitized)
+
+    expect(output.querySelector('td').style.backgroundImage).toContain('cell.jpg')
+  })
+
+  test('does not protect a table cell with a blank legacy background attribute', () => {
+    const output = parseFragment(
+      normalizeEmailHtml(
+        '<table><tr><td background="  " style="color: #000000">Copy</td></tr></table>',
+        true
+      )
+    )
+
+    expect(output.querySelector('td').style.color).not.toBe('rgb(0, 0, 0)')
+  })
+
   test('leaves prefers-color-scheme media blocks untouched', () => {
     const input =
       '<style>@media (prefers-color-scheme: dark) { .a { color: #eeeeee; background-color: #111111; } } .b { color: #222222; }</style><div class="a">Dark</div><div class="b">Light</div>'
@@ -223,7 +324,8 @@ describe('normalizeEmailHtml', () => {
     const output = parseFragment(
       normalizeEmailHtml('<style>.a { color: #222222; }</style><div class="a">Text</div>', true)
     )
+    const styleEl = output.querySelector('style')
 
-    expect(output.querySelector('style').getAttribute('style')).toBeNull()
+    expect(styleEl.getAttribute('style')).toBeNull()
   })
 })

--- a/frontend/apps/main/src/utils/emailHtmlNormalizer.test.js
+++ b/frontend/apps/main/src/utils/emailHtmlNormalizer.test.js
@@ -1,0 +1,229 @@
+/** @vitest-environment jsdom */
+
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { cwd } from 'node:process'
+import { describe, expect, test, vi } from 'vitest'
+import { compositeCssColor, getContrastRatio, parseCssColor } from './emailColorNormalizer.js'
+import { normalizeEmailHtml } from './emailHtmlNormalizer.js'
+
+const loadFixture = (name) =>
+  readFileSync(resolve(cwd(), `apps/main/src/utils/__fixtures__/${name}.html`), 'utf8')
+
+const parseFragment = (html) => {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  return template.content
+}
+
+describe('normalizeEmailHtml', () => {
+  test.each(['outlook-desktop', 'gmail-reply', 'apple-mail', 'plain-text-wrapped'])(
+    'returns the %s fixture byte-for-byte in light mode',
+    (fixture) => {
+      const input = loadFixture(fixture)
+      expect(normalizeEmailHtml(input, false)).toBe(input)
+    }
+  )
+
+  test('normalizes Outlook desktop inline colours', () => {
+    const output = parseFragment(normalizeEmailHtml(loadFixture('outlook-desktop'), true))
+    const container = output.querySelector('div')
+    const paragraphs = output.querySelectorAll('p')
+
+    expect(
+      getContrastRatio(container.style.color, container.style.backgroundColor)
+    ).toBeGreaterThanOrEqual(4.5)
+    expect(
+      getContrastRatio(paragraphs[0].style.color, container.style.backgroundColor)
+    ).toBeGreaterThanOrEqual(4.5)
+    const warning = parseCssColor(paragraphs[1].style.color)
+    expect(warning.r).toBeGreaterThan(0.9)
+    expect(warning.g).toBeLessThan(0.25)
+    expect(warning.b).toBeLessThan(0.25)
+  })
+
+  test('normalizes Gmail style blocks and quoted content', () => {
+    const output = parseFragment(normalizeEmailHtml(loadFixture('gmail-reply'), true))
+    const stylesheet = output.querySelector('style').textContent
+    const quotedColor = output.querySelector('.gmail_quote div').style.color
+
+    expect(stylesheet).toContain('color: hsl(')
+    expect(stylesheet).toContain('background-color: hsl(')
+    expect(getContrastRatio(quotedColor, 'hsl(120 2.6% 7.6%)')).toBeGreaterThanOrEqual(4.5)
+  })
+
+  test('enforces contrast across separate stylesheet rules', () => {
+    const output = parseFragment(
+      normalizeEmailHtml(
+        '<style>.surface { background-color: #777777; } .copy { color: #888888; }</style><div class="surface"><span class="copy">Copy</span></div>',
+        true
+      )
+    )
+    const background = output
+      .querySelector('style')
+      .textContent.match(/background-color:\s*([^;}]+)/)[1]
+    const foreground = output.querySelector('.copy').style.color
+
+    expect(getContrastRatio(foreground, background)).toBeGreaterThanOrEqual(4.5)
+  })
+
+  test('normalizes Apple Mail presentational attributes', () => {
+    const output = parseFragment(normalizeEmailHtml(loadFixture('apple-mail'), true))
+    const container = output.querySelector('[bgcolor]')
+    const font = output.querySelector('font')
+    const previousMessage = output.querySelector('div div')
+
+    expect(container.getAttribute('bgcolor')).toMatch(/^#[\da-f]{6}$/)
+    expect(font.getAttribute('color')).toMatch(/^#[\da-f]{6}$/)
+    expect(
+      getContrastRatio(font.getAttribute('color'), container.getAttribute('bgcolor'))
+    ).toBeGreaterThanOrEqual(4.5)
+    expect(
+      getContrastRatio(previousMessage.style.color, previousMessage.style.backgroundColor)
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  test('checks inline text against an element bgcolor', () => {
+    const output = parseFragment(
+      normalizeEmailHtml('<td bgcolor="#000000" style="color: #ffffff">Copy</td>', true)
+    )
+    const cell = output.querySelector('td')
+
+    expect(getContrastRatio(cell.style.color, cell.getAttribute('bgcolor'))).toBeGreaterThanOrEqual(
+      4.5
+    )
+  })
+
+  test('checks nested text against the composited background', () => {
+    const output = parseFragment(
+      normalizeEmailHtml(
+        '<div style="background-color: rgba(255, 255, 255, 0.5)"><span style="color: #777777">Copy</span></div>',
+        true
+      )
+    )
+    const container = output.querySelector('div')
+    const text = output.querySelector('span')
+    const background = compositeCssColor(container.style.backgroundColor, 'hsl(120 2.6% 7.6%)')
+
+    expect(getContrastRatio(text.style.color, background)).toBeGreaterThanOrEqual(4.5)
+  })
+
+  test('normalizes a color-only background shorthand with its text color', () => {
+    const output = parseFragment(
+      normalizeEmailHtml(
+        '<div style="background: #ffffff; color: #000000"><span style="color: #000000">Copy</span></div>',
+        true
+      )
+    )
+    const container = output.querySelector('div')
+    const text = output.querySelector('span')
+
+    expect(
+      getContrastRatio(container.style.color, container.style.backgroundColor)
+    ).toBeGreaterThanOrEqual(4.5)
+    expect(
+      getContrastRatio(text.style.color, container.style.backgroundColor)
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  test('normalizes a color-only background shorthand in a style block', () => {
+    const output = parseFragment(
+      normalizeEmailHtml(
+        '<style>.surface { background: #ffffff; color: #000000; }</style><div class="surface">Copy</div>',
+        true
+      )
+    )
+    const stylesheet = output.querySelector('style').textContent
+    const background = stylesheet.match(/background-color:\s*([^;}]+)/)[1]
+    const foreground = stylesheet.match(/(?:^|;)\s*color:\s*([^;}]+)/)[1]
+
+    expect(getContrastRatio(foreground, background)).toBeGreaterThanOrEqual(4.5)
+  })
+
+  test('uses the important inline background when checking descendant contrast', () => {
+    const output = parseFragment(
+      normalizeEmailHtml(
+        '<div style="background-color: #ffffff !important; background-color: #000000"><span style="color: #000000">Copy</span></div>',
+        true
+      )
+    )
+    const container = output.querySelector('div')
+    const text = output.querySelector('span')
+
+    expect(
+      getContrastRatio(text.style.color, container.style.backgroundColor)
+    ).toBeGreaterThanOrEqual(4.5)
+  })
+
+  test('leaves legacy attributes untouched when CSS overrides them', () => {
+    const output = parseFragment(
+      normalizeEmailHtml(
+        '<div bgcolor="#ffffff" style="background-color: #000000"><font color="#000000" style="color: #ffffff">Copy</font></div>',
+        true
+      )
+    )
+
+    expect(output.querySelector('div').getAttribute('bgcolor')).toBe('#ffffff')
+    expect(output.querySelector('font').getAttribute('color')).toBe('#000000')
+  })
+
+  test('normalizes auto-wrapped plain-text HTML without adding a wrapper', () => {
+    const input = loadFixture('plain-text-wrapped')
+    const output = normalizeEmailHtml(input, true)
+
+    expect(output.trimStart().startsWith('<div')).toBe(true)
+    expect(output).toContain('Line one<br>Line two<br>Line three')
+    expect(output).not.toContain('<html')
+    expect(output).not.toContain('<body')
+  })
+
+  test('falls back to the original HTML when normalization fails', () => {
+    const input = '<p style="color: #000000">Original copy</p>'
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const createElement = vi.spyOn(document, 'createElement').mockImplementationOnce(() => {
+      throw new Error('DOM parser unavailable')
+    })
+
+    try {
+      expect(normalizeEmailHtml(input, true)).toBe(input)
+      expect(warning).toHaveBeenCalledOnce()
+    } finally {
+      createElement.mockRestore()
+      warning.mockRestore()
+    }
+  })
+
+  test('leaves prefers-color-scheme media blocks untouched', () => {
+    const input =
+      '<style>@media (prefers-color-scheme: dark) { .a { color: #eeeeee; background-color: #111111; } } .b { color: #222222; }</style><div class="a">Dark</div><div class="b">Light</div>'
+    const output = parseFragment(normalizeEmailHtml(input, true))
+    const stylesheet = output.querySelector('style').textContent
+
+    expect(stylesheet).toContain('color: #eeeeee')
+    expect(stylesheet).toContain('background-color: #111111')
+    expect(stylesheet).toMatch(/\.b\s*\{\s*color:\s*hsl\(/)
+  })
+
+  test('ignores an overridden bgcolor attribute when resolving a translucent inline background', () => {
+    const spanColor = (html) => parseFragment(html).querySelector('span').style.color
+
+    const withBgcolorAttr = normalizeEmailHtml(
+      '<div bgcolor="rgba(0, 0, 0, 0.5)" style="background-color: rgba(255, 255, 255, 0.3)"><span style="color: #777777">Copy</span></div>',
+      true
+    )
+    const withoutBgcolorAttr = normalizeEmailHtml(
+      '<div style="background-color: rgba(255, 255, 255, 0.3)"><span style="color: #777777">Copy</span></div>',
+      true
+    )
+
+    expect(spanColor(withBgcolorAttr)).toBe(spanColor(withoutBgcolorAttr))
+  })
+
+  test('does not add a style attribute to non-content elements while walking the tree', () => {
+    const output = parseFragment(
+      normalizeEmailHtml('<style>.a { color: #222222; }</style><div class="a">Text</div>', true)
+    )
+
+    expect(output.querySelector('style').getAttribute('style')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Closes abhinavxd/libredesk#449.

I took a look at abhinavxd/libredesk#452 and wanted to take a stab at an approach that keeps the email itself in dark mode rather than placing it on a light canvas.

It remaps the incoming text and background colors at render time, preserving the hue and saturation but just inverting the lightness for the dark theme. I had used this approach in a different project elsewhere and it worked pretty nicely for us!

It handles inline styles, embedded `<style>` rules, `bgcolor`, and `<font color>`, then adjusts text where needed to maintain a WCAG AA contrast ratio of at least 4.5:1.

The original message HTML is never modified. Light mode still receives the original HTML exactly as received. I didn't touch image-backed banners since they can be pretty flaky to try to handle cleanly.

![Incoming email rendered in dark mode](https://github.com/user-attachments/assets/b6dfa352-35fc-4d22-973b-97ba6d6ad9e0)

We have been running this version in our production deployment for about two weeks, and it has worked pretty well across the tickets we have received so far.

## Testing

- Added unit coverage for color parsing, remapping, alpha handling, malformed values, and contrast correction.
- Added fixtures for Outlook, Gmail replies, Apple Mail, plain-text mail, and image-backed marketing banners.
- Covered long reply chains, stylesheet rules, legacy attributes, theme switching, and failure fallback.
- Ran the full frontend test suite and production frontend build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Email content in conversation message bubbles now adapts automatically to dark mode.
  - Dark-mode rendering preserves email backgrounds, images, legacy styling, and readable text contrast across common email formats.

- **Bug Fixes**
  - Improved readability for translucent, inherited, and inline colors in dark mode.
  - Preserved special color schemes and background images during email rendering.

- **Tests**
  - Added coverage for Gmail, Outlook, Apple Mail, marketing banners, and plain-text messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->