### PR TITLE
Widget: accept an optional subject on conversation init and return it on the widget list and thread

### DIFF
--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/abhinavxd/libredesk/internal/attachment"
 	bhmodels "github.com/abhinavxd/libredesk/internal/business_hours/models"
@@ -204,10 +205,11 @@ func handleChatInit(r *fastglue.Request) error {
 	}
 	// Optional subject: a single line, whitespace-collapsed, so an app or a pre-chat form can file a titled
 	// conversation the way an email does. Never required — the embedded widget does not send one.
-	req.Subject = strings.Join(strings.Fields(req.Subject), " ")
-	if len(req.Subject) > maxChatSubjectLength {
+	subject, ok := normalizeChatSubject(req.Subject)
+	if !ok {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxChatSubjectLength)), nil, envelope.InputError)
 	}
+	req.Subject = subject
 
 	inbox, err := getWidgetInbox(r)
 	if err != nil {
@@ -956,6 +958,17 @@ func verifyStandardJWT(jwtToken string, inboxSecret string) (Claims, error) {
 	}
 
 	return *claims, nil
+}
+
+// normalizeChatSubject collapses all whitespace in a widget-supplied subject to single spaces and trims it,
+// then enforces maxChatSubjectLength as a count of characters (Unicode code points), not UTF-8 bytes, so a
+// non-ASCII subject is not cut short of the documented limit. Returns false when the subject is too long.
+func normalizeChatSubject(subject string) (string, bool) {
+	subject = strings.Join(strings.Fields(subject), " ")
+	if utf8.RuneCountInString(subject) > maxChatSubjectLength {
+		return "", false
+	}
+	return subject, true
 }
 
 // generateSessionToken creates a random session token and stores it in Redis.

--- a/cmd/chat.go
+++ b/cmd/chat.go
@@ -38,6 +38,7 @@ const (
 	defaultSessionTTL               = 180 * 24 * time.Hour
 	minSessionTTL                   = 1 * time.Hour
 	maxChatMessageLength            = 10000
+	maxChatSubjectLength            = 255
 	maxEmailLength                  = 254
 	maxNameLength                   = 128
 	maxExternalUserIDLength         = 128
@@ -83,6 +84,7 @@ type customAttributeWidget struct {
 
 type chatInitReq struct {
 	Message  string         `json:"message"`
+	Subject  string         `json:"subject"`
 	FormData map[string]any `json:"form_data"`
 }
 
@@ -200,6 +202,12 @@ func handleChatInit(r *fastglue.Request) error {
 	if len(req.Message) > maxChatMessageLength {
 		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxChatMessageLength)), nil, envelope.InputError)
 	}
+	// Optional subject: a single line, whitespace-collapsed, so an app or a pre-chat form can file a titled
+	// conversation the way an email does. Never required — the embedded widget does not send one.
+	req.Subject = strings.Join(strings.Fields(req.Subject), " ")
+	if len(req.Subject) > maxChatSubjectLength {
+		return r.SendErrorEnvelope(fasthttp.StatusBadRequest, app.i18n.Ts("globals.messages.maxLength", "max", strconv.Itoa(maxChatSubjectLength)), nil, envelope.InputError)
+	}
 
 	inbox, err := getWidgetInbox(r)
 	if err != nil {
@@ -247,7 +255,7 @@ func handleChatInit(r *fastglue.Request) error {
 		inbox.ID,
 		"",
 		time.Now(),
-		"",
+		req.Subject,
 		false,
 		meta,
 		conversationAttrs,

--- a/cmd/chat_subject_test.go
+++ b/cmd/chat_subject_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeChatSubject(t *testing.T) {
+	ascii := strings.Repeat("a", maxChatSubjectLength)
+	cyrillic := strings.Repeat("ж", maxChatSubjectLength) // 2 bytes per character: byte-counting would reject it
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{"empty stays empty", "", "", true},
+		{"whitespace collapsed and trimmed", "  Login \t fails\n after  update  ", "Login fails after update", true},
+		{"ascii at the limit", ascii, ascii, true},
+		{"ascii one over the limit", ascii + "a", "", false},
+		{"non-ascii at the limit counts characters, not bytes", cyrillic, cyrillic, true},
+		{"non-ascii one over the limit", cyrillic + "ж", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := normalizeChatSubject(tt.in)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("normalizeChatSubject(%q) = (%q, %v), want (%q, %v)", tt.in, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/internal/conversation/models/models.go
+++ b/internal/conversation/models/models.go
@@ -93,6 +93,7 @@ type LastChatMessage struct {
 type ChatConversation struct {
 	CreatedAt          time.Time         `db:"created_at" json:"created_at"`
 	UUID               string            `db:"uuid" json:"uuid"`
+	Subject            string            `db:"subject" json:"subject"`
 	Status             string            `db:"status" json:"status"`
 	LastChatMessage    LastChatMessage   `db:"last_message" json:"last_message"`
 	UnreadMessageCount int               `db:"unread_message_count" json:"unread_message_count"`

--- a/internal/conversation/queries.sql
+++ b/internal/conversation/queries.sql
@@ -355,6 +355,7 @@ LIMIT 50;
 SELECT
     c.created_at,
     c.uuid,
+    COALESCE(c.subject, '') AS subject,
     cs.name as status,
     COALESCE(c.last_interaction, '') as "last_message.content",
     c.last_interaction_at as "last_message.created_at",
@@ -392,6 +393,7 @@ WHERE c.uuid = $1
 SELECT
     c.created_at,
     c.uuid,
+    COALESCE(c.subject, '') AS subject,
     cs.name as status,
     COALESCE(c.last_interaction, '') as "last_message.content",
     c.last_interaction_at as "last_message.created_at",


### PR DESCRIPTION
Part 1 of #574.

Live-chat conversations are always created with an empty `subject`: the widget init request has no field for it, although `CreateConversation` already takes one and the conversation list already shows a subject whenever it is set. Clients that file titled requests through the widget API (an in-app support screen, in our case) therefore cannot give agents a subject to triage by, and cannot read one back either.

- `POST /api/v1/widget/chat/conversations/init` accepts an optional `subject`: whitespace-collapsed to a single line, max 255 characters (400 above). It is passed to `CreateConversation` as is, with no reference-number suffix, matching live chat today. The embedded widget keeps sending no subject, so its behaviour is unchanged.
- `GET /api/v1/widget/chat/conversations` and `GET …/conversations/{uuid}` now include `subject` (`""` when unset) via `COALESCE(c.subject, '')` in both widget queries and a `Subject` field on `ChatConversation`.

Tested with `go build ./...` and `go vet`, and against our own client: requests filed with a subject show it in the conversation list next to email tickets, and the widget list returns it. Part 2 (agents editing a subject, behind a new permission) follows as a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live chat conversations can include an optional subject.
  * Conversation subjects are normalized for consistent spacing and included in conversation data.
  * Subjects up to 255 characters are accepted.

* **Bug Fixes**
  * Subject length validation now counts characters correctly, including non-ASCII text.
  * Subjects exceeding 255 characters continue to be rejected with a bad-request response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->