### PR TITLE
Conversation list: show a priority marker on each row

### DIFF
--- a/frontend/apps/main/src/features/conversation/PriorityDot.vue
+++ b/frontend/apps/main/src/features/conversation/PriorityDot.vue
@@ -1,0 +1,44 @@
+<template>
+  <Tooltip v-if="priorityName">
+    <TooltipTrigger asChild>
+      <span
+        class="h-2 w-2 rounded-full flex-shrink-0"
+        :class="dotClass"
+        role="img"
+        :aria-label="priorityLabel"
+      />
+    </TooltipTrigger>
+    <TooltipContent>{{ priorityLabel }}</TooltipContent>
+  </Tooltip>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@shared-ui/components/ui/tooltip'
+import { useI18n } from 'vue-i18n'
+
+// Priorities are seeded rows (Low, Medium, High) and are not translated, so match on the
+// name and keep anything unrecognised neutral rather than inventing a colour for it.
+const PRIORITY_DOT_CLASSES = {
+  low: 'bg-muted-foreground',
+  medium: 'bg-warning-600',
+  high: 'bg-destructive'
+}
+
+const props = defineProps({
+  priority: {
+    type: String,
+    default: ''
+  }
+})
+
+const { t } = useI18n()
+
+const priorityName = computed(() => (props.priority || '').trim())
+
+const dotClass = computed(
+  () => PRIORITY_DOT_CLASSES[priorityName.value.toLowerCase()] || 'bg-muted-foreground'
+)
+
+const priorityLabel = computed(() => `${t('globals.terms.priority', 1)}: ${priorityName.value}`)
+</script>

--- a/frontend/apps/main/src/features/conversation/list/ConversationListItem.vue
+++ b/frontend/apps/main/src/features/conversation/list/ConversationListItem.vue
@@ -60,6 +60,7 @@
                   <TooltipContent>{{ contactFullName }}</TooltipContent>
                 </Tooltip>
                 <div class="flex items-center gap-1 flex-shrink-0">
+                  <PriorityDot :priority="conversation.priority" />
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <component
@@ -176,6 +177,7 @@ import {
   ContextMenuTrigger
 } from '@shared-ui/components/ui/context-menu'
 import SlaBadge from '@main/features/sla/SlaBadge.vue'
+import PriorityDot from '@main/features/conversation/PriorityDot.vue'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@shared-ui/components/ui/tooltip'
 import { Checkbox } from '@shared-ui/components/ui/checkbox'
 import { useConversationStore } from '@main/stores/conversation'


### PR DESCRIPTION
The conversation list shows no priority today, so an agent cannot see at a glance which rows are High priority (in our desk an automation sets High for paying customers, and the list is where triage happens).

- New `PriorityDot.vue`: an 8 px dot in the row's metadata cluster, left of the channel icon and the time, with a tooltip and `aria-label` "Priority: <name>". Colours use the design-system tokens already used by `SlaBadge.vue` (`bg-destructive` for High, `bg-warning-600` for Medium, `bg-muted-foreground` for Low or an unknown name); nothing renders when the conversation has no priority.
- `ConversationListItem.vue` mounts it. No backend change: the list query already selects the priority name and priority updates already reach list rows over the websocket.

Small and single-scope; tested with `pnpm build:main`, `pnpm test:run` (782 tests) and eslint on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added priority indicators next to conversation contact names.
  - Added tooltips showing localized priority labels.
  - Added visual priority icons with levels from unassigned to high priority.
  - Unrecognized priority values display an unknown marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->